### PR TITLE
schema/attribute: introduce explicit IsOptional field

### DIFF
--- a/decoder/body_candidates.go
+++ b/decoder/body_candidates.go
@@ -94,7 +94,7 @@ func sortedBlockTypes(blocks map[string]*schema.BlockSchema) []string {
 }
 
 func isAttributeDeclarable(body *hclsyntax.Body, name string, attr *schema.AttributeSchema) bool {
-	if attr.IsReadOnly {
+	if attr.IsComputed && !attr.IsOptional {
 		return false
 	}
 

--- a/decoder/body_decoder_test.go
+++ b/decoder/body_decoder_test.go
@@ -84,6 +84,77 @@ func TestDecoder_CandidateAtPos_incompleteAttributes(t *testing.T) {
 	}
 }
 
+func TestDecoder_CandidateAtPos_computedAttributes(t *testing.T) {
+	bodySchema := &schema.BodySchema{
+		Blocks: map[string]*schema.BlockSchema{
+			"customblock": {
+				Labels: []*schema.LabelSchema{
+					{Name: "type"},
+				},
+				Body: &schema.BodySchema{
+					Attributes: map[string]*schema.AttributeSchema{
+						"attr1":           {ValueType: cty.Number, IsComputed: true},
+						"attr2":           {ValueType: cty.Number, IsComputed: true, IsOptional: true},
+						"some_other_attr": {ValueType: cty.Number},
+						"another_attr":    {ValueType: cty.Number},
+					},
+				},
+			},
+		},
+	}
+
+	d := NewDecoder()
+	d.SetSchema(bodySchema)
+
+	f, _ := hclsyntax.ParseConfig([]byte(`customblock "label1" {
+  attr
+}
+`), "test.tf", hcl.InitialPos)
+	err := d.LoadFile("test.tf", f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	candidates, err := d.CandidatesAtPos("test.tf", hcl.Pos{
+		Line:   2,
+		Column: 7,
+		Byte:   29,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedCandidates := lang.Candidates{
+		List: []lang.Candidate{
+			{
+				Label:  "attr2",
+				Detail: "Optional, number",
+				TextEdit: lang.TextEdit{
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   2,
+							Column: 3,
+							Byte:   25,
+						},
+						End: hcl.Pos{
+							Line:   2,
+							Column: 7,
+							Byte:   29,
+						},
+					},
+					NewText: "attr2",
+					Snippet: "attr2 = ${1:1}",
+				},
+				Kind: lang.AttributeCandidateKind,
+			},
+		},
+		IsComplete: true,
+	}
+	if diff := cmp.Diff(expectedCandidates, candidates); diff != "" {
+		t.Fatalf("unexpected candidates: %s", diff)
+	}
+}
+
 func TestDecoder_CandidateAtPos_incompleteBlocks(t *testing.T) {
 	bodySchema := &schema.BodySchema{
 		Blocks: map[string]*schema.BlockSchema{

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/google/go-cmp v0.3.1
+	github.com/hashicorp/go-multierror v1.1.0
 	github.com/hashicorp/hcl/v2 v2.6.0
 	github.com/mitchellh/copystructure v1.0.0
 	github.com/zclconf/go-cty v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,10 @@ github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.4/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-multierror v1.1.0 h1:B9UzwGQJehnUY1yNrnwREHc3fGbC2xefo8g4TbElacI=
+github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
 github.com/hashicorp/hcl/v2 v2.6.0 h1:3krZOfGY6SziUXa6H9PJU6TyohHn7I+ARYnhbeNBz+o=
 github.com/hashicorp/hcl/v2 v2.6.0/go.mod h1:bQTN5mpo+jewjJgh8jr0JUguIi7qPHUF6yIfAEN3jqY=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=

--- a/schema/attribute_schema.go
+++ b/schema/attribute_schema.go
@@ -1,6 +1,8 @@
 package schema
 
 import (
+	"errors"
+
 	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -9,8 +11,9 @@ import (
 type AttributeSchema struct {
 	Description  lang.MarkupContent
 	IsRequired   bool
+	IsOptional   bool
 	IsDeprecated bool
-	IsReadOnly   bool
+	IsComputed   bool
 
 	ValueType  cty.Type
 	ValueTypes ValueTypes
@@ -32,4 +35,27 @@ func (vt ValueTypes) FriendlyNames() []string {
 
 func (*AttributeSchema) isSchemaImpl() schemaImplSigil {
 	return schemaImplSigil{}
+}
+
+func (as *AttributeSchema) Validate() error {
+	if len(as.ValueTypes) == 0 && as.ValueType == cty.NilType {
+		return errors.New("one of ValueType or ValueTypes must be specified")
+	}
+	if len(as.ValueTypes) > 0 && as.ValueType != cty.NilType {
+		return errors.New("ValueType or ValueTypes must be specified, not both")
+	}
+
+	if as.IsOptional && as.IsRequired {
+		return errors.New("IsOptional or IsRequired must be set, not both")
+	}
+
+	if as.IsRequired && as.IsComputed {
+		return errors.New("cannot be both IsRequired and IsComputed")
+	}
+
+	if !as.IsRequired && !as.IsOptional && !as.IsComputed {
+		return errors.New("one of IsRequired, IsOptional, or IsComputed must be set")
+	}
+
+	return nil
 }

--- a/schema/attribute_schema_test.go
+++ b/schema/attribute_schema_test.go
@@ -1,0 +1,81 @@
+package schema
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestAttributeSchema_Validate(t *testing.T) {
+	testCases := []struct {
+		schema      *AttributeSchema
+		expectedErr error
+	}{
+		{
+			&AttributeSchema{},
+			errors.New("one of ValueType or ValueTypes must be specified"),
+		},
+		{
+			&AttributeSchema{
+				ValueType: cty.String,
+			},
+			errors.New("one of IsRequired, IsOptional, or IsComputed must be set"),
+		},
+		{
+			&AttributeSchema{
+				ValueTypes: []cty.Type{cty.String, cty.Number},
+				IsComputed: true,
+			},
+			nil,
+		},
+		{
+			&AttributeSchema{
+				ValueType:  cty.String,
+				ValueTypes: []cty.Type{cty.String, cty.Number},
+				IsComputed: true,
+			},
+			errors.New("ValueType or ValueTypes must be specified, not both"),
+		},
+		{
+			&AttributeSchema{
+				ValueType:  cty.String,
+				IsRequired: true,
+				IsOptional: true,
+			},
+			errors.New("IsOptional or IsRequired must be set, not both"),
+		},
+		{
+			&AttributeSchema{
+				ValueType:  cty.String,
+				IsRequired: true,
+				IsComputed: true,
+			},
+			errors.New("cannot be both IsRequired and IsComputed"),
+		},
+		{
+			&AttributeSchema{
+				ValueType:  cty.String,
+				IsOptional: true,
+				IsComputed: true,
+			},
+			nil,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			err := tc.schema.Validate()
+			if tc.expectedErr == nil && err != nil {
+				t.Fatal(err)
+			}
+			if tc.expectedErr != nil && err == nil {
+				t.Fatalf("expected error: %q, none given", tc.expectedErr.Error())
+			}
+			if tc.expectedErr != nil && tc.expectedErr.Error() != err.Error() {
+				t.Fatalf("error mismatch,\nexpected: %q\ngiven: %q", tc.expectedErr.Error(), err.Error())
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is to differentiate between fields which are
computed-only (IsComputed: true, IsOptional: false)
and computed + optional (IsComputed: true, IsOptional: true).

Technically we could assume IsOptional: true when IsComputed: false,
but that would likely make a future serialization story more complex
and introduce potential confusion for callers where they may just read
raw struct field, instead of going through some functions
which set the defaults.