### PR TITLE
lang/Candidate: Add TriggerSuggest field

### DIFF
--- a/decoder/block_candidates.go
+++ b/decoder/block_candidates.go
@@ -10,6 +10,19 @@ import (
 )
 
 func blockSchemaToCandidate(blockType string, block *schema.BlockSchema, rng hcl.Range) lang.Candidate {
+	triggerSuggest := false
+	if len(block.Labels) > 0 {
+		// We make some naive assumptions here for simplicity
+		// and because this works just well enough for Terraform.
+		// - if there is "completable" label it's the first one and the only one
+		// - the label has some candidates based on DependentSchema
+		//
+		// The implementation can certainly be more sophisticated
+		// but it would likely involve changes in snippet placeholder
+		// numbering and full understanding of UX implications.
+		triggerSuggest = block.Labels[0].IsDepKey
+	}
+
 	return lang.Candidate{
 		Label:        blockType,
 		Detail:       detailForBlock(block),
@@ -21,6 +34,7 @@ func blockSchemaToCandidate(blockType string, block *schema.BlockSchema, rng hcl
 			Snippet: snippetForBlock(blockType, block),
 			Range:   rng,
 		},
+		TriggerSuggest: triggerSuggest,
 	}
 }
 

--- a/decoder/candidates_test.go
+++ b/decoder/candidates_test.go
@@ -474,7 +474,8 @@ func TestDecoder_CandidatesAtPos_zeroByteContent(t *testing.T) {
 				NewText: "resource",
 				Snippet: "resource \"${1}\" \"${2:name}\" {\n  ${3}\n}",
 			},
-			Kind: 2,
+			Kind: lang.BlockCandidateKind,
+			TriggerSuggest: true,
 		},
 	})
 	if diff := cmp.Diff(expectedCandidates, candidates); diff != "" {
@@ -536,6 +537,7 @@ func TestDecoder_CandidatesAtPos_endOfFilePos(t *testing.T) {
 					Snippet: "resource \"${1}\" \"${2:name}\" {\n  ${3}\n}",
 				},
 				Kind: lang.BlockCandidateKind,
+				TriggerSuggest: true,
 			},
 		},
 		IsComplete: true,
@@ -726,6 +728,7 @@ resource "random_resource" "test" {
 						Snippet: "resource \"${1}\" \"${2:name}\" {\n  ${3}\n}",
 					},
 					Kind: lang.BlockCandidateKind,
+					TriggerSuggest: true,
 				},
 			}),
 		},
@@ -746,6 +749,7 @@ resource "random_resource" "test" {
 						Snippet: "resource \"${1}\" \"${2:name}\" {\n  ${3}\n}",
 					},
 					Kind: lang.BlockCandidateKind,
+					TriggerSuggest: true,
 				},
 			}),
 		},

--- a/lang/candidate.go
+++ b/lang/candidate.go
@@ -23,6 +23,10 @@ type Candidate struct {
 	TextEdit            TextEdit
 	AdditionalTextEdits []TextEdit
 	Kind                CandidateKind
+
+	// TriggerSuggest allows server to instruct the client whether
+	// to reopen candidate suggestion popup after insertion
+	TriggerSuggest bool
 }
 
 // TextEdit represents a change (edit) of an HCL config file


### PR DESCRIPTION
See https://github.com/hashicorp/vscode-terraform/issues/373

The inline comments hopefully explain the implementation and how it can be used.

I think this might survive even if/when the problem is solved on the LSP level https://github.com/microsoft/language-server-protocol/issues/565 because the server still needs to decide which blocks have labels that are in fact completable.