### PR TITLE
Introduce method for querying symbols across files

### DIFF
--- a/decoder/symbols.go
+++ b/decoder/symbols.go
@@ -89,5 +89,9 @@ func symbolsForBody(body *hclsyntax.Body) []Symbol {
 		})
 	}
 
+	sort.SliceStable(symbols, func(i, j int) bool {
+		return symbols[i].Range().Start.Byte < symbols[j].Range().Start.Byte
+	})
+
 	return symbols
 }

--- a/decoder/symbols.go
+++ b/decoder/symbols.go
@@ -1,12 +1,15 @@
 package decoder
 
 import (
+	"sort"
+	"strings"
+
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/zclconf/go-cty/cty"
 )
 
-// Symbols returns a hierarchy of symbols within the config file
+// SymbolsInFile returns a hierarchy of symbols within the config file
 //
 // A symbol is typically represented by a block or an attribute.
 func (d *Decoder) SymbolsInFile(filename string) ([]Symbol, error) {
@@ -22,6 +25,33 @@ func (d *Decoder) SymbolsInFile(filename string) ([]Symbol, error) {
 		return nil, err
 	}
 	symbols = append(symbols, symbolsForBody(body)...)
+
+	return symbols, nil
+}
+
+// Symbols returns a hierarchy of symbols matching the query
+// in all loaded files (typically whole module).
+// Query can be empty, as per LSP's workspace/symbol request,
+// in which case all symbols are returned.
+//
+// A symbol is typically represented by a block or an attribute.
+func (d *Decoder) Symbols(query string) ([]Symbol, error) {
+	symbols := make([]Symbol, 0)
+
+	files := d.Filenames()
+	files = sort.StringSlice(files)
+
+	for _, filename := range files {
+		fSymbols, err := d.SymbolsInFile(filename)
+		if err != nil {
+			return nil, err
+		}
+		for _, symbol := range fSymbols {
+			if query == "" || strings.Contains(symbol.Name(), query) {
+				symbols = append(symbols, symbol)
+			}
+		}
+	}
 
 	return symbols, nil
 }


### PR DESCRIPTION
This provides support for `workspace/symbol` method on the language server side:

https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_symbol

## Query Matching

Currently we'd do a simple exact match on the symbol's "name" - e.g. `resource "aws_vpc" "main"`, but I reckon longer term we may want to add some loose matching too, or perhaps compare the query against the common `block.label1.label2` pattern.

## Query Scope

Currently we only query the top-level symbols, but we may consider querying nested symbols, i.e. nested attributes and blocks too eventually. It just isn't clear to me yet what the UX implications of that would be in bigger modules with many blocks.
