### PR TITLE
Introduce LinksInFile method

### DIFF
--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -20,6 +20,14 @@ type Decoder struct {
 	rootSchema    *schema.BodySchema
 	rootSchemaMu  *sync.RWMutex
 	maxCandidates uint
+
+	// UTM parameters for docs URLs
+	// utm_source parameter, typically language server identification
+	utmSource string
+	// utm_medium parameter, typically language client identification
+	utmMedium string
+	// utm_content parameter, e.g. documentHover or documentLink
+	useUtmContent bool
 }
 
 // NewDecoder creates a new Decoder
@@ -45,6 +53,18 @@ func (d *Decoder) SetSchema(schema *schema.BodySchema) {
 	defer d.rootSchemaMu.Unlock()
 
 	d.rootSchema = schema
+}
+
+func (d *Decoder) SetUtmSource(src string) {
+	d.utmSource = src
+}
+
+func (d *Decoder) SetUtmMedium(medium string) {
+	d.utmMedium = medium
+}
+
+func (d *Decoder) UseUtmContent(use bool) {
+	d.useUtmContent = use
 }
 
 // LoadFile loads a new (non-empty) parsed file

--- a/decoder/hover.go
+++ b/decoder/hover.go
@@ -90,7 +90,7 @@ func (d *Decoder) hoverAtPos(body *hclsyntax.Body, bodySchema *schema.BodySchema
 					}
 
 					return &lang.HoverData{
-						Content: hoverContentForLabel(i, block, bSchema),
+						Content: d.hoverContentForLabel(i, block, bSchema),
 						Range:   labelRange,
 					}, nil
 				}
@@ -123,7 +123,7 @@ func (d *Decoder) hoverAtPos(body *hclsyntax.Body, bodySchema *schema.BodySchema
 	}
 }
 
-func hoverContentForLabel(i int, block *hclsyntax.Block, bSchema *schema.BlockSchema) lang.MarkupContent {
+func (d *Decoder) hoverContentForLabel(i int, block *hclsyntax.Block, bSchema *schema.BlockSchema) lang.MarkupContent {
 	value := block.Labels[i]
 	labelSchema := bSchema.Labels[i]
 
@@ -142,6 +142,16 @@ func hoverContentForLabel(i int, block *hclsyntax.Block, bSchema *schema.BlockSc
 			} else if labelSchema.Description.Value != "" {
 				content += "\n\n" + labelSchema.Description.Value
 			}
+
+			if bs.DocsLink != nil {
+				link := bs.DocsLink
+				u, err := d.docsURL(link.URL, "documentHover")
+				if err == nil {
+					content += fmt.Sprintf("\n\n[`%s` on %s](%s)",
+						value, u.Hostname(), u.String())
+				}
+			}
+
 			return lang.Markdown(content)
 		}
 	}

--- a/decoder/links.go
+++ b/decoder/links.go
@@ -1,0 +1,89 @@
+package decoder
+
+import (
+	"net/url"
+
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+// LinksInFile returns links relevant to parts of config in the given file
+//
+// A link (URI) typically points to the documentation.
+func (d *Decoder) LinksInFile(filename string) ([]lang.Link, error) {
+	f, err := d.fileByName(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := d.bodyForFileAndPos(filename, f, hcl.InitialPos)
+	if err != nil {
+		return nil, err
+	}
+
+	d.rootSchemaMu.RLock()
+	defer d.rootSchemaMu.RUnlock()
+
+	if d.rootSchema == nil {
+		return []lang.Link{}, &NoSchemaError{}
+	}
+
+	return d.linksInBody(body, d.rootSchema)
+}
+
+func (d *Decoder) linksInBody(body *hclsyntax.Body, bodySchema *schema.BodySchema) ([]lang.Link, error) {
+	links := make([]lang.Link, 0)
+
+	for _, block := range body.Blocks {
+		blockSchema, ok := bodySchema.Blocks[block.Type]
+		if !ok {
+			// Ignore unknown block
+			continue
+		}
+
+		// Currently only block bodies have links associated
+		if block.Body != nil {
+			dk := dependencyKeysFromBlock(block, blockSchema)
+			depSchema, ok := blockSchema.DependentBodySchema(dk)
+			if ok && depSchema.DocsLink != nil {
+				for _, labelDep := range dk.Labels {
+					link := depSchema.DocsLink
+					u, err := d.docsURL(link.URL, "documentLink")
+					if err == nil {
+						links = append(links, lang.Link{
+							URI:     u.String(),
+							Tooltip: link.Tooltip,
+							Range:   block.LabelRanges[labelDep.Index],
+						})
+					}
+				}
+			}
+		}
+
+	}
+
+	return links, nil
+}
+
+func (d *Decoder) docsURL(uri, utmContent string) (*url.URL, error) {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return nil, err
+	}
+
+	q := u.Query()
+	if d.utmSource != "" {
+		q.Set("utm_source", d.utmSource)
+	}
+	if d.utmMedium != "" {
+		q.Set("utm_medium", d.utmMedium)
+	}
+	if d.useUtmContent {
+		q.Set("utm_content", utmContent)
+	}
+	u.RawQuery = q.Encode()
+
+	return u, nil
+}

--- a/decoder/links_test.go
+++ b/decoder/links_test.go
@@ -1,0 +1,100 @@
+package decoder
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestLinksInFile(t *testing.T) {
+	resourceLabelSchema := []*schema.LabelSchema{
+		{Name: "type", IsDepKey: true},
+		{Name: "name"},
+	}
+	blockSchema := &schema.BlockSchema{
+		Labels:      resourceLabelSchema,
+		Description: lang.Markdown("My special block"),
+		Body: &schema.BodySchema{
+			Attributes: map[string]*schema.AttributeSchema{
+				"num_attr": {ValueType: cty.Number},
+				"str_attr": {ValueType: cty.String, Description: lang.PlainText("Special attribute")},
+			},
+		},
+		DependentBody: map[schema.SchemaKey]*schema.BodySchema{
+			schema.NewSchemaKey(schema.DependencyKeys{
+				Labels: []schema.LabelDependent{
+					{Index: 0, Value: "sushi"},
+				},
+			}): {
+				DocsLink:    &schema.DocsLink{URL: "https://en.wikipedia.org/wiki/Sushi"},
+				Detail:      "rice, fish etc.",
+				Description: lang.Markdown("Sushi, the Rolls-Rice of Japanese cuisine"),
+			},
+			schema.NewSchemaKey(schema.DependencyKeys{
+				Labels: []schema.LabelDependent{
+					{Index: 0, Value: "ramen"},
+				},
+			}): {
+				DocsLink:    &schema.DocsLink{URL: "https://en.wikipedia.org/wiki/Ramen"},
+				Detail:      "noodles, broth etc.",
+				Description: lang.Markdown("Ramen, a Japanese noodle soup"),
+			},
+		},
+	}
+	bodySchema := &schema.BodySchema{
+		Blocks: map[string]*schema.BlockSchema{
+			"myblock": blockSchema,
+		},
+	}
+	testConfig := []byte(`myblock "sushi" "salmon" {
+  str_attr = "test"
+  num_attr = 4
+}
+`)
+
+	d := NewDecoder()
+	f, pDiags := hclsyntax.ParseConfig(testConfig, "test.tf", hcl.InitialPos)
+	if len(pDiags) > 0 {
+		t.Fatal(pDiags)
+	}
+	err := d.LoadFile("test.tf", f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	d.SetSchema(bodySchema)
+
+	links, err := d.LinksInFile("test.tf")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedLinks := []lang.Link{
+		{
+			URI: "https://en.wikipedia.org/wiki/Sushi",
+			Range: hcl.Range{
+				Filename: "test.tf",
+				Start: hcl.Pos{
+					Line:   1,
+					Column: 9,
+					Byte:   8,
+				},
+				End: hcl.Pos{
+					Line:   1,
+					Column: 16,
+					Byte:   15,
+				},
+			},
+		},
+	}
+
+	diff := cmp.Diff(expectedLinks, links)
+	if diff != "" {
+		t.Fatalf("unexpected links: %s", diff)
+	}
+}

--- a/lang/link.go
+++ b/lang/link.go
@@ -1,0 +1,11 @@
+package lang
+
+import (
+	"github.com/hashicorp/hcl/v2"
+)
+
+type Link struct {
+	URI     string
+	Tooltip string
+	Range   hcl.Range
+}

--- a/schema/body_schema.go
+++ b/schema/body_schema.go
@@ -17,7 +17,14 @@ type BodySchema struct {
 	Detail       string
 	Description  lang.MarkupContent
 
+	DocsLink *DocsLink
+
 	// TODO: Functions
+}
+
+type DocsLink struct {
+	URL     string
+	Tooltip string
 }
 
 func (*BodySchema) isSchemaImpl() schemaImplSigil {


### PR DESCRIPTION
This is in preparation for implementation of `textDocument/documentLink` on the language server side:
https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_documentLink

https://github.com/hashicorp/terraform-schema/pull/10 adds the actual links to the Registry for Terraform providers and depends on this PR

Initially I decided to only implement this for _dependent_ block bodies, which in case of Terraform applies to provider, resource and data source blocks as that's the part of configuration which has more easily linkable and versioned docs.

Relatedly I also limited the implementation initially for the 1st level, as we don't have dependent bodies at any deeper levels.
