### PR TITLE
ci: Enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels: ["dependencies"]


### PR DESCRIPTION
This enables [dependabot](https://dependabot.com/) integration, which can help us keep our dependencies up to date.

The proposed configuration is the taken from [`hashicorp/terraform-ls`](https://github.com/hashicorp/terraform-ls/blob/main/.github/dependabot.yml), but obviously we can tweak it accordingly if necessary.