### PR TITLE
fix: Make sure Symbols() output is sorted

### DIFF
--- a/decoder/symbols.go
+++ b/decoder/symbols.go
@@ -39,7 +39,7 @@ func (d *Decoder) Symbols(query string) ([]Symbol, error) {
 	symbols := make([]Symbol, 0)
 
 	files := d.Filenames()
-	files = sort.StringSlice(files)
+	sort.Strings(files)
 
 	for _, filename := range files {
 		fSymbols, err := d.SymbolsInFile(filename)


### PR DESCRIPTION
This was an oversight where the string slice was just being converted to [`StringSlice`](https://golang.org/pkg/sort/#StringSlice) (type) which in itself (obviously) doesn't sort the slice.

This fixes the following flaky test:

```
=== RUN   TestDecoder_Symbols_basic
    symbols_test.go:236: unexpected symbols:   []decoder.Symbol{
        - 	&decoder.BlockSymbol{
        - 		Type:   "resource",
        - 		Labels: []string{"aws_vpc", "main"},
        - 		rng:    s"first.tf:2,1-4,2",
        - 		nestedSymbols: []decoder.Symbol{
        - 			&decoder.AttributeSymbol{AttrName: "cidr_block", Type: cty.Type{...}, rng: s"first.tf:3,3-29"},
        - 		},
        - 	},
        + 	&decoder.BlockSymbol{
        + 		Type:   "provider",
        + 		Labels: []string{"google"},
        + 		rng:    s"second.tf:2,1-5,2",
        + 		nestedSymbols: []decoder.Symbol{
        + 			&decoder.AttributeSymbol{AttrName: "project", Type: cty.Type{...}, rng: s"second.tf:3,3-32"},
        + 			&decoder.AttributeSymbol{AttrName: "region", Type: cty.Type{...}, rng: s"second.tf:4,3-30"},
        + 		},
        + 	},
        - 	&decoder.BlockSymbol{
        - 		Type:   "provider",
        - 		Labels: []string{"google"},
        - 		rng:    s"second.tf:2,1-5,2",
        - 		nestedSymbols: []decoder.Symbol{
        - 			&decoder.AttributeSymbol{AttrName: "project", Type: cty.Type{...}, rng: s"second.tf:3,3-32"},
        - 			&decoder.AttributeSymbol{AttrName: "region", Type: cty.Type{...}, rng: s"second.tf:4,3-30"},
        - 		},
        - 	},
        + 	&decoder.BlockSymbol{
        + 		Type:   "resource",
        + 		Labels: []string{"aws_vpc", "main"},
        + 		rng:    s"first.tf:2,1-4,2",
        + 		nestedSymbols: []decoder.Symbol{
        + 			&decoder.AttributeSymbol{AttrName: "cidr_block", Type: cty.Type{...}, rng: s"first.tf:3,3-29"},
        + 		},
        + 	},
          }
--- FAIL: TestDecoder_Symbols_basic (0.00s)
```