### PR TITLE
Add Traversal as symbol kind

### DIFF
--- a/decoder/symbols.go
+++ b/decoder/symbols.go
@@ -90,6 +90,8 @@ func symbolsForBody(body *hclsyntax.Body) []Symbol {
 
 func symbolExprKind(expr hcl.Expression) lang.SymbolExprKind {
 	switch e := expr.(type) {
+	case *hclsyntax.ScopeTraversalExpr:
+		return lang.TraversalExprKind{}
 	case *hclsyntax.LiteralValueExpr:
 		return lang.LiteralTypeKind{Type: e.Val.Type()}
 	case *hclsyntax.TemplateExpr:

--- a/decoder/symbols_test.go
+++ b/decoder/symbols_test.go
@@ -426,6 +426,7 @@ resource "aws_instance" "test" {
 				},
 				&AttributeSymbol{
 					AttrName: "random_kw",
+					ExprKind: lang.TraversalExprKind{},
 					rng: hcl.Range{
 						Filename: "test.tf",
 						Start: hcl.Pos{

--- a/lang/symbol_kind.go
+++ b/lang/symbol_kind.go
@@ -29,3 +29,9 @@ type ObjectConsExprKind struct{}
 func (ObjectConsExprKind) isSymbolExprKindSigil() exprKindSigil {
 	return exprKindSigil{}
 }
+
+type TraversalExprKind struct{}
+
+func (TraversalExprKind) isSymbolExprKindSigil() exprKindSigil {
+	return exprKindSigil{}
+}


### PR DESCRIPTION
Because symbol navigation is (intentionally) _not_ schema driven we cannot tell whether the `ScopeTraversalExpr` represents a keyword or any more complex reference/traversal. However it's still helpful to differentiate such an expression from other (unrecognized) expressions.