### PR TITLE
Add support for ObjectExpr expression type

### DIFF
--- a/decoder/attribute_candidates.go
+++ b/decoder/attribute_candidates.go
@@ -30,15 +30,17 @@ func detailForAttribute(attr *schema.AttributeSchema) string {
 	var detail string
 	if attr.IsRequired {
 		detail = "Required"
-	} else {
+	} else if attr.IsOptional {
 		detail = "Optional"
 	}
 
-	ec := ExprConstraints(attr.Expr)
-	names := ec.FriendlyNames()
-
-	if len(names) > 0 {
-		detail += fmt.Sprintf(", %s", strings.Join(names, " or "))
+	friendlyName := attr.Expr.FriendlyName()
+	if friendlyName != "" {
+		if detail != "" {
+			detail = strings.Join([]string{detail, friendlyName}, ", ")
+		} else {
+			detail = friendlyName
+		}
 	}
 
 	return detail

--- a/decoder/body_decoder_test.go
+++ b/decoder/body_decoder_test.go
@@ -56,7 +56,7 @@ func TestDecoder_CandidateAtPos_incompleteAttributes(t *testing.T) {
 		List: []lang.Candidate{
 			{
 				Label:  "attr1",
-				Detail: "Optional, number",
+				Detail: "number",
 				TextEdit: lang.TextEdit{
 					Range: hcl.Range{
 						Filename: "test.tf",

--- a/decoder/candidates_test.go
+++ b/decoder/candidates_test.go
@@ -664,8 +664,8 @@ func TestDecoder_CandidatesAtPos_basic(t *testing.T) {
 			}): {
 				Attributes: map[string]*schema.AttributeSchema{
 					"one":   {Expr: schema.LiteralTypeOnly(cty.String), IsRequired: true},
-					"two":   {Expr: schema.LiteralTypeOnly(cty.Number)},
-					"three": {Expr: schema.LiteralTypeOnly(cty.Bool)},
+					"two":   {Expr: schema.LiteralTypeOnly(cty.Number), IsOptional: true},
+					"three": {Expr: schema.LiteralTypeOnly(cty.Bool), IsOptional: true},
 				},
 			},
 			schema.NewSchemaKey(schema.DependencyKeys{
@@ -944,7 +944,7 @@ func TestDecoder_CandidatesAtPos_AnyAttribute(t *testing.T) {
 	expectedCandidates := lang.CompleteCandidates([]lang.Candidate{
 		{
 			Label:  "name",
-			Detail: "Optional, object",
+			Detail: "object",
 			TextEdit: lang.TextEdit{
 				Range: hcl.Range{
 					Filename: "test.tf",
@@ -979,6 +979,7 @@ func TestDecoder_CandidatesAtPos_multipleTypes(t *testing.T) {
 						schema.LiteralTypeExpr{Type: cty.Set(cty.DynamicPseudoType)},
 						schema.LiteralTypeExpr{Type: cty.Map(cty.DynamicPseudoType)},
 					},
+					IsOptional: true,
 				},
 			},
 		},
@@ -1045,7 +1046,7 @@ func TestDecoder_CandidatesAtPos_incompleteAttrOrBlock(t *testing.T) {
 		Labels: resourceLabelSchema,
 		Body: &schema.BodySchema{
 			Attributes: map[string]*schema.AttributeSchema{
-				"count": {Expr: schema.LiteralTypeOnly(cty.Number)},
+				"count": {Expr: schema.LiteralTypeOnly(cty.Number), IsOptional: true},
 			},
 		},
 	}
@@ -1173,7 +1174,7 @@ func TestDecoder_CandidatesAtPos_incompleteLabel(t *testing.T) {
 		Labels: resourceLabelSchema,
 		Body: &schema.BodySchema{
 			Attributes: map[string]*schema.AttributeSchema{
-				"count": {Expr: schema.LiteralTypeOnly(cty.Number)},
+				"count": {Expr: schema.LiteralTypeOnly(cty.Number), IsOptional: true},
 			},
 		},
 		DependentBody: map[schema.SchemaKey]*schema.BodySchema{

--- a/decoder/expression_candidates_test.go
+++ b/decoder/expression_candidates_test.go
@@ -125,6 +125,172 @@ func TestDecoder_CandidateAtPos_expressions(t *testing.T) {
 			}),
 		},
 		{
+			"object as expression",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Expr: schema.ExprConstraints{
+						schema.ObjectExpr{
+							Attributes: schema.ObjectExprAttributes{
+								"first": schema.ObjectAttribute{
+									Expr: schema.LiteralTypeOnly(cty.String),
+								},
+								"second": schema.ObjectAttribute{
+									Expr: schema.LiteralTypeOnly(cty.Number),
+								},
+							},
+						},
+					},
+				},
+			},
+			`attr = 
+`,
+			hcl.Pos{Line: 1, Column: 8, Byte: 7},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "{ }",
+					Detail: "object",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start: hcl.Pos{
+								Line:   1,
+								Column: 8,
+								Byte:   7,
+							},
+							End: hcl.Pos{
+								Line:   1,
+								Column: 8,
+								Byte:   7,
+							},
+						},
+						NewText: "{\n  \n}",
+						Snippet: "{\n  ${1}\n}",
+					},
+					Kind:           lang.ObjectCandidateKind,
+					TriggerSuggest: true,
+				},
+			}),
+		},
+		{
+			"object as expression - attribute",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Expr: schema.ExprConstraints{
+						schema.ObjectExpr{
+							Attributes: schema.ObjectExprAttributes{
+								"first": schema.ObjectAttribute{
+									Expr: schema.LiteralTypeOnly(cty.String),
+								},
+								"second": schema.ObjectAttribute{
+									Expr: schema.LiteralTypeOnly(cty.Number),
+								},
+							},
+						},
+					},
+				},
+			},
+			`attr = {
+  
+}
+`,
+			hcl.Pos{Line: 2, Column: 3, Byte: 11},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "first",
+					Detail: "string",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start: hcl.Pos{
+								Line:   2,
+								Column: 3,
+								Byte:   11,
+							},
+							End: hcl.Pos{
+								Line:   2,
+								Column: 3,
+								Byte:   11,
+							},
+						},
+						NewText: `first = ""`,
+						Snippet: `first = "${1:value}"`,
+					},
+					Kind: lang.AttributeCandidateKind,
+				},
+				{
+					Label:  "second",
+					Detail: "number",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start: hcl.Pos{
+								Line:   2,
+								Column: 3,
+								Byte:   11,
+							},
+							End: hcl.Pos{
+								Line:   2,
+								Column: 3,
+								Byte:   11,
+							},
+						},
+						NewText: "second = 1",
+						Snippet: "second = ${1:1}",
+					},
+					Kind: lang.AttributeCandidateKind,
+				},
+			}),
+		},
+		{
+			"object as expression - attributes partially declared",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Expr: schema.ExprConstraints{
+						schema.ObjectExpr{
+							Attributes: schema.ObjectExprAttributes{
+								"first": schema.ObjectAttribute{
+									Expr: schema.LiteralTypeOnly(cty.String),
+								},
+								"second": schema.ObjectAttribute{
+									Expr: schema.LiteralTypeOnly(cty.Number),
+								},
+							},
+						},
+					},
+				},
+			},
+			`attr = {
+  first = "blah"
+  
+}
+`,
+			hcl.Pos{Line: 3, Column: 3, Byte: 28},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "second",
+					Detail: "number",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start: hcl.Pos{
+								Line:   3,
+								Column: 3,
+								Byte:   28,
+							},
+							End: hcl.Pos{
+								Line:   3,
+								Column: 3,
+								Byte:   28,
+							},
+						},
+						NewText: "second = 1",
+						Snippet: "second = ${1:1}",
+					},
+					Kind: lang.AttributeCandidateKind,
+				},
+			}),
+		},
+		{
 			"list as value",
 			map[string]*schema.AttributeSchema{
 				"attr": {

--- a/decoder/expression_constraints.go
+++ b/decoder/expression_constraints.go
@@ -8,26 +8,6 @@ import (
 
 type ExprConstraints schema.ExprConstraints
 
-func (ec ExprConstraints) FriendlyNames() []string {
-	names := make([]string, 0)
-	for _, constraint := range ec {
-		if name := constraint.FriendlyName(); name != "" &&
-			!namesContain(names, name) {
-			names = append(names, name)
-		}
-	}
-	return names
-}
-
-func namesContain(names []string, name string) bool {
-	for _, n := range names {
-		if n == name {
-			return true
-		}
-	}
-	return false
-}
-
 func (ec ExprConstraints) HasKeywordsOnly() bool {
 	hasKeywordExpr := false
 	for _, constraint := range ec {
@@ -56,6 +36,15 @@ func (ec ExprConstraints) MapExpr() (schema.MapExpr, bool) {
 		}
 	}
 	return schema.MapExpr{}, false
+}
+
+func (ec ExprConstraints) ObjectExpr() (schema.ObjectExpr, bool) {
+	for _, c := range ec {
+		if me, ok := c.(schema.ObjectExpr); ok {
+			return me, ok
+		}
+	}
+	return schema.ObjectExpr{}, false
 }
 
 func (ec ExprConstraints) TupleConsExpr() (schema.TupleConsExpr, bool) {

--- a/decoder/hover_expressions_test.go
+++ b/decoder/hover_expressions_test.go
@@ -254,6 +254,165 @@ _object_`),
 			nil,
 		},
 		{
+			"object as expression",
+			map[string]*schema.AttributeSchema{
+				"obj": {Expr: schema.ExprConstraints{
+					schema.ObjectExpr{
+						Attributes: schema.ObjectExprAttributes{
+							"source": schema.ObjectAttribute{
+								Expr: schema.LiteralTypeOnly(cty.String),
+							},
+							"bool": schema.ObjectAttribute{
+								Expr: schema.LiteralTypeOnly(cty.Bool),
+							},
+							"notbool": schema.ObjectAttribute{
+								Expr: schema.LiteralTypeOnly(cty.String),
+							},
+							"nested_map": schema.ObjectAttribute{
+								Expr: schema.LiteralTypeOnly(cty.Map(cty.String)),
+							},
+							"nested_obj": schema.ObjectAttribute{
+								Expr: schema.LiteralTypeOnly(cty.Object(map[string]cty.Type{})),
+							},
+						},
+					},
+				}},
+			},
+			`obj = {
+    source = "blah"
+    different = 42
+    bool = true
+    notbool = "test"
+}`,
+			hcl.Pos{Line: 1, Column: 3, Byte: 2},
+			&lang.HoverData{
+				Content: lang.Markdown(`**obj** _object_`),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start: hcl.Pos{
+						Line:   1,
+						Column: 1,
+						Byte:   0,
+					},
+					End: hcl.Pos{
+						Line:   6,
+						Column: 2,
+						Byte:   85,
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"object as expression - expression",
+			map[string]*schema.AttributeSchema{
+				"obj": {Expr: schema.ExprConstraints{
+					schema.ObjectExpr{
+						Attributes: schema.ObjectExprAttributes{
+							"source": schema.ObjectAttribute{
+								Expr: schema.LiteralTypeOnly(cty.String),
+							},
+							"bool": schema.ObjectAttribute{
+								Expr: schema.LiteralTypeOnly(cty.Bool),
+							},
+							"notbool": schema.ObjectAttribute{
+								Expr: schema.LiteralTypeOnly(cty.String),
+							},
+							"nested_map": schema.ObjectAttribute{
+								Expr: schema.LiteralTypeOnly(cty.Map(cty.String)),
+							},
+							"nested_obj": schema.ObjectAttribute{
+								Expr: schema.LiteralTypeOnly(cty.Object(map[string]cty.Type{})),
+							},
+						},
+					},
+				}},
+			},
+			`obj = {
+    source = "blah"
+    different = 42
+    bool = true
+    notbool = "test"
+}`,
+			hcl.Pos{Line: 2, Column: 2, Byte: 9},
+			&lang.HoverData{
+				Content: lang.Markdown("```" + `
+{
+  bool = bool
+  nested_map = map of string
+  nested_obj = object
+  notbool = string
+  source = string
+}
+` + "```" + `
+_object_`),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start: hcl.Pos{
+						Line:   1,
+						Column: 7,
+						Byte:   6,
+					},
+					End: hcl.Pos{
+						Line:   6,
+						Column: 2,
+						Byte:   85,
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"object as expression - attribute",
+			map[string]*schema.AttributeSchema{
+				"obj": {Expr: schema.ExprConstraints{
+					schema.ObjectExpr{
+						Attributes: schema.ObjectExprAttributes{
+							"source": schema.ObjectAttribute{
+								Expr: schema.LiteralTypeOnly(cty.String),
+							},
+							"bool": schema.ObjectAttribute{
+								Expr: schema.LiteralTypeOnly(cty.Bool),
+							},
+							"notbool": schema.ObjectAttribute{
+								Expr: schema.LiteralTypeOnly(cty.String),
+							},
+							"nested_map": schema.ObjectAttribute{
+								Expr: schema.LiteralTypeOnly(cty.Map(cty.String)),
+							},
+							"nested_obj": schema.ObjectAttribute{
+								Expr: schema.LiteralTypeOnly(cty.Object(map[string]cty.Type{})),
+							},
+						},
+					},
+				}},
+			},
+			`obj = {
+    source = "blah"
+    different = 42
+    bool = true
+    notbool = "test"
+}`,
+			hcl.Pos{Line: 2, Column: 8, Byte: 15},
+			&lang.HoverData{
+				Content: lang.Markdown(`**source** _string_`),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start: hcl.Pos{
+						Line:   2,
+						Column: 5,
+						Byte:   12,
+					},
+					End: hcl.Pos{
+						Line:   2,
+						Column: 20,
+						Byte:   27,
+					},
+				},
+			},
+			nil,
+		},
+		{
 			"map as type",
 			map[string]*schema.AttributeSchema{
 				"nummap": {Expr: schema.LiteralTypeOnly(cty.Map(cty.Number))},

--- a/decoder/hover_test.go
+++ b/decoder/hover_test.go
@@ -280,7 +280,11 @@ func TestDecoder_HoverAtPos_basic(t *testing.T) {
 		Body: &schema.BodySchema{
 			Attributes: map[string]*schema.AttributeSchema{
 				"num_attr": {Expr: schema.LiteralTypeOnly(cty.Number)},
-				"str_attr": {Expr: schema.LiteralTypeOnly(cty.String), Description: lang.PlainText("Special attribute")},
+				"str_attr": {
+					Expr:        schema.LiteralTypeOnly(cty.String),
+					IsOptional:  true,
+					Description: lang.PlainText("Special attribute"),
+				},
 			},
 		},
 		DependentBody: map[schema.SchemaKey]*schema.BodySchema{

--- a/decoder/semantic_tokens_expr_test.go
+++ b/decoder/semantic_tokens_expr_test.go
@@ -360,6 +360,79 @@ EOT
 			},
 		},
 		{
+			"object as expression",
+			map[string]*schema.AttributeSchema{
+				"obj": {
+					Expr: schema.ExprConstraints{
+						schema.ObjectExpr{
+							Attributes: schema.ObjectExprAttributes{
+								"knownkey": {
+									Expr: schema.LiteralTypeOnly(cty.Number),
+								},
+							},
+						},
+					},
+				},
+			},
+			`obj = {
+  knownkey = 42
+  unknownkey = "boo"
+}`,
+			[]lang.SemanticToken{
+				{ // obj
+					Type:      lang.TokenAttrName,
+					Modifiers: []lang.SemanticTokenModifier{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+							Byte:   0,
+						},
+						End: hcl.Pos{
+							Line:   1,
+							Column: 4,
+							Byte:   3,
+						},
+					},
+				},
+				{ // knownkey
+					Type:      lang.TokenObjectKey,
+					Modifiers: []lang.SemanticTokenModifier{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   2,
+							Column: 3,
+							Byte:   10,
+						},
+						End: hcl.Pos{
+							Line:   2,
+							Column: 11,
+							Byte:   18,
+						},
+					},
+				},
+				{ // 42
+					Type:      lang.TokenNumber,
+					Modifiers: []lang.SemanticTokenModifier{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   2,
+							Column: 14,
+							Byte:   21,
+						},
+						End: hcl.Pos{
+							Line:   2,
+							Column: 16,
+							Byte:   23,
+						},
+					},
+				},
+			},
+		},
+		{
 			"map literal keys",
 			map[string]*schema.AttributeSchema{
 				"mapkey": {


### PR DESCRIPTION
This is to support recent changes in core schema introduced in Terraform 0.15 where an object can contain traversals - i.e. not literals.