### PR TITLE
Fix attribute lookup for dependent schemas

### DIFF
--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -277,15 +277,15 @@ func traversalToAddress(traversal hcl.Traversal) (lang.Address, error) {
 	addr := lang.Address{}
 	for _, tr := range traversal {
 		switch t := tr.(type) {
-		case *hcl.TraverseRoot:
+		case hcl.TraverseRoot:
 			addr = append(addr, lang.RootStep{
 				Name: t.Name,
 			})
-		case *hcl.TraverseAttr:
+		case hcl.TraverseAttr:
 			addr = append(addr, lang.AttrStep{
 				Name: t.Name,
 			})
-		case *hcl.TraverseIndex:
+		case hcl.TraverseIndex:
 			addr = append(addr, lang.IndexStep{
 				Key: t.Key,
 			})

--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -1,10 +1,15 @@
 package decoder
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty-debug/ctydebug"
+	"github.com/zclconf/go-cty/cty"
 )
 
 func TestDecoder_LoadFile_nilFile(t *testing.T) {
@@ -29,5 +34,58 @@ func TestDecoder_LoadFile_nilRootBody(t *testing.T) {
 	}
 	if diff := cmp.Diff(`test.tf: file has no body`, err.Error()); diff != "" {
 		t.Fatalf("unexpected error: %s", diff)
+	}
+}
+
+func TestTraversalToAddress(t *testing.T) {
+	testCases := []struct {
+		rawTraversal string
+		expectedAddr lang.Address
+	}{
+		{
+			"one",
+			lang.Address{
+				lang.RootStep{Name: "one"},
+			},
+		},
+		{
+			"first.second",
+			lang.Address{
+				lang.RootStep{Name: "first"},
+				lang.AttrStep{Name: "second"},
+			},
+		},
+		{
+			"foo[2]",
+			lang.Address{
+				lang.RootStep{Name: "foo"},
+				lang.IndexStep{Key: cty.NumberIntVal(2)},
+			},
+		},
+		{
+			`foo["bar"]`,
+			lang.Address{
+				lang.RootStep{Name: "foo"},
+				lang.IndexStep{Key: cty.StringVal("bar")},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			traversal, diags := hclsyntax.ParseTraversalAbs([]byte(tc.rawTraversal), "test.tf", hcl.InitialPos)
+			if len(diags) > 0 {
+				t.Fatal(diags)
+			}
+
+			addr, err := traversalToAddress(traversal)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedAddr, addr, ctydebug.CmpOptions); diff != "" {
+				t.Fatalf("address mismatch: %s", diff)
+			}
+		})
 	}
 }


### PR DESCRIPTION
This fixes a conversion function which was previously not covered by tests.

This bug in combination with another bug https://github.com/hashicorp/terraform-schema/pull/28 caused the dependent schemas of `resource` or `data` block to be looked up basically freely without the `provider` attribute being considered.

In other words most of the time it _looked like_ everything is working fine, but there were some configurations being misinterpreted, e.g.

```hcl
terraform {
  required_providers {
    rand = {
      source  = "hashicorp/random"
      version = "3.0.0"
    }
  }
}

resource "random_string" "name" {
  provider = rand
}
```

It is true that providers of `hashicorp` (default) namespace do not require explicit `required_providers` entry, however if they do have one, it should be respected.

Here due to the combination of the two bugs we would look up `hashicorp/random` schema for `random_string` resource block, but that provider really isn't supposed to be available under that name. It requires explicit association.