### PR TITLE
Introduce ListExpr, SetExpr and TupleExpr

### DIFF
--- a/decoder/expression_candidates_test.go
+++ b/decoder/expression_candidates_test.go
@@ -131,10 +131,10 @@ func TestDecoder_CandidateAtPos_expressions(t *testing.T) {
 					Expr: schema.ExprConstraints{
 						schema.ObjectExpr{
 							Attributes: schema.ObjectExprAttributes{
-								"first": schema.ObjectAttribute{
+								"first": &schema.AttributeSchema{
 									Expr: schema.LiteralTypeOnly(cty.String),
 								},
-								"second": schema.ObjectAttribute{
+								"second": &schema.AttributeSchema{
 									Expr: schema.LiteralTypeOnly(cty.Number),
 								},
 							},
@@ -178,10 +178,10 @@ func TestDecoder_CandidateAtPos_expressions(t *testing.T) {
 					Expr: schema.ExprConstraints{
 						schema.ObjectExpr{
 							Attributes: schema.ObjectExprAttributes{
-								"first": schema.ObjectAttribute{
+								"first": &schema.AttributeSchema{
 									Expr: schema.LiteralTypeOnly(cty.String),
 								},
-								"second": schema.ObjectAttribute{
+								"second": &schema.AttributeSchema{
 									Expr: schema.LiteralTypeOnly(cty.Number),
 								},
 							},
@@ -248,10 +248,10 @@ func TestDecoder_CandidateAtPos_expressions(t *testing.T) {
 					Expr: schema.ExprConstraints{
 						schema.ObjectExpr{
 							Attributes: schema.ObjectExprAttributes{
-								"first": schema.ObjectAttribute{
+								"first": &schema.AttributeSchema{
 									Expr: schema.LiteralTypeOnly(cty.String),
 								},
-								"second": schema.ObjectAttribute{
+								"second": &schema.AttributeSchema{
 									Expr: schema.LiteralTypeOnly(cty.Number),
 								},
 							},
@@ -297,10 +297,10 @@ func TestDecoder_CandidateAtPos_expressions(t *testing.T) {
 					Expr: schema.ExprConstraints{
 						schema.ObjectExpr{
 							Attributes: schema.ObjectExprAttributes{
-								"first": schema.ObjectAttribute{
+								"first": &schema.AttributeSchema{
 									Expr: schema.LiteralTypeOnly(cty.String),
 								},
-								"second": schema.ObjectAttribute{
+								"second": &schema.AttributeSchema{
 									Expr: schema.LiteralTypeOnly(cty.Number),
 								},
 							},
@@ -759,6 +759,387 @@ func TestDecoder_CandidateAtPos_expressions(t *testing.T) {
 `,
 			hcl.Pos{Line: 1, Column: 10, Byte: 9},
 			lang.ZeroCandidates(),
+		},
+		{
+			"attribute as list expression",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Expr: schema.ExprConstraints{
+						schema.ListExpr{
+							Elem: schema.LiteralTypeOnly(cty.String),
+						},
+					},
+				},
+			},
+			`
+`,
+			hcl.Pos{Line: 1, Column: 1, Byte: 0},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "attr",
+					Detail: "list",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+							End:      hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						},
+						NewText: "attr",
+						Snippet: "attr = [\n  ${0}\n]",
+					},
+					Kind: lang.AttributeCandidateKind,
+				},
+			}),
+		},
+		{
+			"list expression",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Expr: schema.ExprConstraints{
+						schema.ListExpr{
+							Elem: schema.LiteralTypeOnly(cty.String),
+						},
+					},
+				},
+			},
+			`attr = 
+`,
+			hcl.Pos{Line: 1, Column: 8, Byte: 7},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "[ string ]",
+					Detail: "list",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+						NewText: "[ ]",
+						Snippet: "[ ${0} ]",
+					},
+					Kind:           lang.ListCandidateKind,
+					TriggerSuggest: true,
+				},
+			}),
+		},
+		{
+			"list expression inside",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Expr: schema.ExprConstraints{
+						schema.ListExpr{
+							Elem: schema.LiteralTypeOnly(cty.Bool),
+						},
+					},
+				},
+			},
+			`attr = [  ]
+`,
+			hcl.Pos{Line: 1, Column: 10, Byte: 9},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "true",
+					Detail: "bool",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start: hcl.Pos{
+								Line:   1,
+								Column: 10,
+								Byte:   9,
+							},
+							End: hcl.Pos{
+								Line:   1,
+								Column: 10,
+								Byte:   9,
+							},
+						},
+						NewText: "true",
+						Snippet: "${1:true}",
+					},
+					Kind: lang.BoolCandidateKind,
+				},
+				{
+					Label:  "false",
+					Detail: "bool",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start: hcl.Pos{
+								Line:   1,
+								Column: 10,
+								Byte:   9,
+							},
+							End: hcl.Pos{
+								Line:   1,
+								Column: 10,
+								Byte:   9,
+							},
+						},
+						NewText: "false",
+						Snippet: "${1:false}",
+					},
+					Kind: lang.BoolCandidateKind,
+				},
+			}),
+		},
+		{
+			"attribute as set expression",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Expr: schema.ExprConstraints{
+						schema.SetExpr{
+							Elem: schema.LiteralTypeOnly(cty.String),
+						},
+					},
+				},
+			},
+			`
+`,
+			hcl.Pos{Line: 1, Column: 1, Byte: 0},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "attr",
+					Detail: "set",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+							End:      hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						},
+						NewText: "attr",
+						Snippet: "attr = [\n  ${0}\n]",
+					},
+					Kind: lang.AttributeCandidateKind,
+				},
+			}),
+		},
+		{
+			"set expression",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Expr: schema.ExprConstraints{
+						schema.SetExpr{
+							Elem: schema.LiteralTypeOnly(cty.String),
+						},
+					},
+				},
+			},
+			`attr = 
+`,
+			hcl.Pos{Line: 1, Column: 8, Byte: 7},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "[ string ]",
+					Detail: "set",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+						NewText: "[ ]",
+						Snippet: "[ ${0} ]",
+					},
+					Kind:           lang.SetCandidateKind,
+					TriggerSuggest: true,
+				},
+			}),
+		},
+		{
+			"set expression inside",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Expr: schema.ExprConstraints{
+						schema.SetExpr{
+							Elem: schema.LiteralTypeOnly(cty.Bool),
+						},
+					},
+				},
+			},
+			`attr = [  ]
+`,
+			hcl.Pos{Line: 1, Column: 10, Byte: 9},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "true",
+					Detail: "bool",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start: hcl.Pos{
+								Line:   1,
+								Column: 10,
+								Byte:   9,
+							},
+							End: hcl.Pos{
+								Line:   1,
+								Column: 10,
+								Byte:   9,
+							},
+						},
+						NewText: "true",
+						Snippet: "${1:true}",
+					},
+					Kind: lang.BoolCandidateKind,
+				},
+				{
+					Label:  "false",
+					Detail: "bool",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start: hcl.Pos{
+								Line:   1,
+								Column: 10,
+								Byte:   9,
+							},
+							End: hcl.Pos{
+								Line:   1,
+								Column: 10,
+								Byte:   9,
+							},
+						},
+						NewText: "false",
+						Snippet: "${1:false}",
+					},
+					Kind: lang.BoolCandidateKind,
+				},
+			}),
+		},
+		{
+			"attribute as tuple expression",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Expr: schema.ExprConstraints{
+						schema.TupleExpr{
+							Elems: []schema.ExprConstraints{
+								schema.LiteralTypeOnly(cty.String),
+								schema.LiteralTypeOnly(cty.Number),
+							},
+						},
+					},
+				},
+			},
+			`
+`,
+			hcl.Pos{Line: 1, Column: 1, Byte: 0},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "attr",
+					Detail: "tuple",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+							End:      hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						},
+						NewText: "attr",
+						Snippet: "attr = [\n  ${0}\n]",
+					},
+					Kind: lang.AttributeCandidateKind,
+				},
+			}),
+		},
+		{
+			"tuple expression",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Expr: schema.ExprConstraints{
+						schema.TupleExpr{
+							Elems: []schema.ExprConstraints{
+								schema.LiteralTypeOnly(cty.String),
+								schema.LiteralTypeOnly(cty.Number),
+							},
+						},
+					},
+				},
+			},
+			`attr = 
+`,
+			hcl.Pos{Line: 1, Column: 8, Byte: 7},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "[ string ]",
+					Detail: "tuple",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+						NewText: "[ ]",
+						Snippet: "[ ${0} ]",
+					},
+					Kind:           lang.TupleCandidateKind,
+					TriggerSuggest: true,
+				},
+			}),
+		},
+		{
+			"tuple expression inside",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Expr: schema.ExprConstraints{
+						schema.TupleExpr{
+							Elems: []schema.ExprConstraints{
+								schema.LiteralTypeOnly(cty.Bool),
+								schema.LiteralTypeOnly(cty.Number),
+							},
+						},
+					},
+				},
+			},
+			`attr = [  ]
+`,
+			hcl.Pos{Line: 1, Column: 10, Byte: 9},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "true",
+					Detail: "bool",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start: hcl.Pos{
+								Line:   1,
+								Column: 10,
+								Byte:   9,
+							},
+							End: hcl.Pos{
+								Line:   1,
+								Column: 10,
+								Byte:   9,
+							},
+						},
+						NewText: "true",
+						Snippet: "${1:true}",
+					},
+					Kind: lang.BoolCandidateKind,
+				},
+				{
+					Label:  "false",
+					Detail: "bool",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start: hcl.Pos{
+								Line:   1,
+								Column: 10,
+								Byte:   9,
+							},
+							End: hcl.Pos{
+								Line:   1,
+								Column: 10,
+								Byte:   9,
+							},
+						},
+						NewText: "false",
+						Snippet: "${1:false}",
+					},
+					Kind: lang.BoolCandidateKind,
+				},
+			}),
 		},
 		{
 			"keyword",

--- a/decoder/expression_constraints.go
+++ b/decoder/expression_constraints.go
@@ -56,6 +56,33 @@ func (ec ExprConstraints) TupleConsExpr() (schema.TupleConsExpr, bool) {
 	return schema.TupleConsExpr{}, false
 }
 
+func (ec ExprConstraints) SetExpr() (schema.SetExpr, bool) {
+	for _, c := range ec {
+		if se, ok := c.(schema.SetExpr); ok {
+			return se, ok
+		}
+	}
+	return schema.SetExpr{}, false
+}
+
+func (ec ExprConstraints) ListExpr() (schema.ListExpr, bool) {
+	for _, c := range ec {
+		if le, ok := c.(schema.ListExpr); ok {
+			return le, ok
+		}
+	}
+	return schema.ListExpr{}, false
+}
+
+func (ec ExprConstraints) TupleExpr() (schema.TupleExpr, bool) {
+	for _, c := range ec {
+		if te, ok := c.(schema.TupleExpr); ok {
+			return te, ok
+		}
+	}
+	return schema.TupleExpr{}, false
+}
+
 func (ec ExprConstraints) HasLiteralTypeOf(exprType cty.Type) bool {
 	for _, c := range ec {
 		if lt, ok := c.(schema.LiteralTypeExpr); ok && lt.Type.Equals(exprType) {

--- a/decoder/hover_expressions_test.go
+++ b/decoder/hover_expressions_test.go
@@ -216,7 +216,10 @@ EOT
 					"bool":       cty.Bool,
 					"notbool":    cty.String,
 					"nested_map": cty.Map(cty.String),
-					"nested_obj": cty.Object(map[string]cty.Type{}),
+					"nested_obj": cty.Object(map[string]cty.Type{
+						"one": cty.String,
+						"two": cty.Number,
+					}),
 				}))},
 			},
 			`litobj = {
@@ -231,7 +234,10 @@ EOT
 {
   bool = bool
   nested_map = map of string
-  nested_obj = object
+  nested_obj = {
+    one = string
+    two = number
+  }
   notbool = string
   source = string
 }
@@ -300,24 +306,266 @@ _object_`),
 			nil,
 		},
 		{
+			"list of object expressions",
+			map[string]*schema.AttributeSchema{
+				"objects": {Expr: schema.ExprConstraints{
+					schema.ListExpr{
+						Elem: schema.ExprConstraints{
+							schema.ObjectExpr{
+								Attributes: schema.ObjectExprAttributes{
+									"source": &schema.AttributeSchema{
+										Expr: schema.LiteralTypeOnly(cty.String),
+									},
+									"bool": &schema.AttributeSchema{
+										Expr: schema.LiteralTypeOnly(cty.Bool),
+									},
+									"notbool": &schema.AttributeSchema{
+										Expr: schema.LiteralTypeOnly(cty.String),
+									},
+									"nested_map": &schema.AttributeSchema{
+										Expr: schema.LiteralTypeOnly(cty.Map(cty.String)),
+									},
+									"nested_obj": &schema.AttributeSchema{
+										Expr: schema.LiteralTypeOnly(cty.Object(map[string]cty.Type{})),
+									},
+								},
+							},
+						},
+					},
+				}},
+			},
+			`objects = [
+    {
+        source = "blah"
+        different = 42
+        bool = true
+        notbool = "test"
+    }
+]`,
+			hcl.Pos{Line: 1, Column: 3, Byte: 2},
+			&lang.HoverData{
+				Content: lang.Markdown(`**objects** _list_`),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start: hcl.Pos{
+						Line:   1,
+						Column: 1,
+						Byte:   0,
+					},
+					End: hcl.Pos{
+						Line:   8,
+						Column: 2,
+						Byte:   117,
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"list of object expressions element",
+			map[string]*schema.AttributeSchema{
+				"objects": {Expr: schema.ExprConstraints{
+					schema.ListExpr{
+						Elem: schema.ExprConstraints{
+							schema.ObjectExpr{
+								Attributes: schema.ObjectExprAttributes{
+									"source": &schema.AttributeSchema{
+										Expr: schema.LiteralTypeOnly(cty.String),
+									},
+									"bool": &schema.AttributeSchema{
+										Expr: schema.LiteralTypeOnly(cty.Bool),
+									},
+									"notbool": &schema.AttributeSchema{
+										Expr: schema.LiteralTypeOnly(cty.String),
+									},
+									"nested_map": &schema.AttributeSchema{
+										Expr: schema.LiteralTypeOnly(cty.Map(cty.String)),
+									},
+									"nested_obj": &schema.AttributeSchema{
+										Expr: schema.LiteralTypeOnly(cty.Object(map[string]cty.Type{})),
+									},
+								},
+							},
+						},
+					},
+				}},
+			},
+			`objects = [
+    {
+        source = "blah"
+        different = 42
+        bool = true
+        notbool = "test"
+    }
+]`,
+			hcl.Pos{Line: 3, Column: 12, Byte: 29},
+			&lang.HoverData{
+				Content: lang.Markdown(`**source** _string_`),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start: hcl.Pos{
+						Line:   3,
+						Column: 9,
+						Byte:   26,
+					},
+					End: hcl.Pos{
+						Line:   3,
+						Column: 24,
+						Byte:   41,
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"nested object expression",
+			map[string]*schema.AttributeSchema{
+				"object": {Expr: schema.ExprConstraints{
+					schema.ObjectExpr{
+						Attributes: schema.ObjectExprAttributes{
+							"nested": &schema.AttributeSchema{
+								Expr: schema.ExprConstraints{
+									schema.ObjectExpr{
+										Attributes: schema.ObjectExprAttributes{
+											"source": &schema.AttributeSchema{
+												Expr: schema.LiteralTypeOnly(cty.String),
+											},
+											"bool": &schema.AttributeSchema{
+												Expr: schema.LiteralTypeOnly(cty.Bool),
+											},
+											"notbool": &schema.AttributeSchema{
+												Expr: schema.LiteralTypeOnly(cty.String),
+											},
+											"nested_map": &schema.AttributeSchema{
+												Expr: schema.LiteralTypeOnly(cty.Map(cty.String)),
+											},
+											"nested_obj": &schema.AttributeSchema{
+												Expr: schema.LiteralTypeOnly(cty.Object(map[string]cty.Type{})),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}},
+			},
+			`object = {
+    nested = {
+        source = "blah"
+        different = 42
+        bool = true
+        notbool = "test"
+    }
+}`,
+			hcl.Pos{Line: 1, Column: 10, Byte: 9},
+			&lang.HoverData{
+				Content: lang.Markdown("```" + `
+{
+  nested = {
+    bool = bool
+    nested_map = map of string
+    nested_obj = object
+    notbool = string
+    source = string
+  }
+}
+` + "```\n_object_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start: hcl.Pos{
+						Line:   1,
+						Column: 10,
+						Byte:   9,
+					},
+					End: hcl.Pos{
+						Line:   8,
+						Column: 2,
+						Byte:   125,
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"nested object expression inside",
+			map[string]*schema.AttributeSchema{
+				"object": {Expr: schema.ExprConstraints{
+					schema.ObjectExpr{
+						Attributes: schema.ObjectExprAttributes{
+							"nested": &schema.AttributeSchema{
+								Expr: schema.ExprConstraints{
+									schema.ObjectExpr{
+										Attributes: schema.ObjectExprAttributes{
+											"source": &schema.AttributeSchema{
+												Expr: schema.LiteralTypeOnly(cty.String),
+											},
+											"bool": &schema.AttributeSchema{
+												Expr: schema.LiteralTypeOnly(cty.Bool),
+											},
+											"notbool": &schema.AttributeSchema{
+												Expr: schema.LiteralTypeOnly(cty.String),
+											},
+											"nested_map": &schema.AttributeSchema{
+												Expr: schema.LiteralTypeOnly(cty.Map(cty.String)),
+											},
+											"nested_obj": &schema.AttributeSchema{
+												Expr: schema.LiteralTypeOnly(cty.Object(map[string]cty.Type{})),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}},
+			},
+			`object = {
+    nested = {
+        source = "blah"
+        different = 42
+        bool = true
+        notbool = "test"
+    }
+}`,
+			hcl.Pos{Line: 3, Column: 12, Byte: 37},
+			&lang.HoverData{
+				Content: lang.Markdown(`**source** _string_`),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start: hcl.Pos{
+						Line:   3,
+						Column: 9,
+						Byte:   34,
+					},
+					End: hcl.Pos{
+						Line:   3,
+						Column: 24,
+						Byte:   49,
+					},
+				},
+			},
+			nil,
+		},
+		{
 			"object as expression",
 			map[string]*schema.AttributeSchema{
 				"obj": {Expr: schema.ExprConstraints{
 					schema.ObjectExpr{
 						Attributes: schema.ObjectExprAttributes{
-							"source": schema.ObjectAttribute{
+							"source": &schema.AttributeSchema{
 								Expr: schema.LiteralTypeOnly(cty.String),
 							},
-							"bool": schema.ObjectAttribute{
+							"bool": &schema.AttributeSchema{
 								Expr: schema.LiteralTypeOnly(cty.Bool),
 							},
-							"notbool": schema.ObjectAttribute{
+							"notbool": &schema.AttributeSchema{
 								Expr: schema.LiteralTypeOnly(cty.String),
 							},
-							"nested_map": schema.ObjectAttribute{
+							"nested_map": &schema.AttributeSchema{
 								Expr: schema.LiteralTypeOnly(cty.Map(cty.String)),
 							},
-							"nested_obj": schema.ObjectAttribute{
+							"nested_obj": &schema.AttributeSchema{
 								Expr: schema.LiteralTypeOnly(cty.Object(map[string]cty.Type{})),
 							},
 						},
@@ -355,19 +603,19 @@ _object_`),
 				"obj": {Expr: schema.ExprConstraints{
 					schema.ObjectExpr{
 						Attributes: schema.ObjectExprAttributes{
-							"source": schema.ObjectAttribute{
+							"source": &schema.AttributeSchema{
 								Expr: schema.LiteralTypeOnly(cty.String),
 							},
-							"bool": schema.ObjectAttribute{
+							"bool": &schema.AttributeSchema{
 								Expr: schema.LiteralTypeOnly(cty.Bool),
 							},
-							"notbool": schema.ObjectAttribute{
+							"notbool": &schema.AttributeSchema{
 								Expr: schema.LiteralTypeOnly(cty.String),
 							},
-							"nested_map": schema.ObjectAttribute{
+							"nested_map": &schema.AttributeSchema{
 								Expr: schema.LiteralTypeOnly(cty.Map(cty.String)),
 							},
-							"nested_obj": schema.ObjectAttribute{
+							"nested_obj": &schema.AttributeSchema{
 								Expr: schema.LiteralTypeOnly(cty.Object(map[string]cty.Type{})),
 							},
 						},
@@ -406,19 +654,19 @@ _object_`),
 				"obj": {Expr: schema.ExprConstraints{
 					schema.ObjectExpr{
 						Attributes: schema.ObjectExprAttributes{
-							"source": schema.ObjectAttribute{
+							"source": &schema.AttributeSchema{
 								Expr: schema.LiteralTypeOnly(cty.String),
 							},
-							"bool": schema.ObjectAttribute{
+							"bool": &schema.AttributeSchema{
 								Expr: schema.LiteralTypeOnly(cty.Bool),
 							},
-							"notbool": schema.ObjectAttribute{
+							"notbool": &schema.AttributeSchema{
 								Expr: schema.LiteralTypeOnly(cty.String),
 							},
-							"nested_map": schema.ObjectAttribute{
+							"nested_map": &schema.AttributeSchema{
 								Expr: schema.LiteralTypeOnly(cty.Map(cty.String)),
 							},
-							"nested_obj": schema.ObjectAttribute{
+							"nested_obj": &schema.AttributeSchema{
 								Expr: schema.LiteralTypeOnly(cty.Object(map[string]cty.Type{})),
 							},
 						},
@@ -465,19 +713,19 @@ _object_`),
 				"obj": {Expr: schema.ExprConstraints{
 					schema.ObjectExpr{
 						Attributes: schema.ObjectExprAttributes{
-							"source": schema.ObjectAttribute{
+							"source": &schema.AttributeSchema{
 								Expr: schema.LiteralTypeOnly(cty.String),
 							},
-							"bool": schema.ObjectAttribute{
+							"bool": &schema.AttributeSchema{
 								Expr: schema.LiteralTypeOnly(cty.Bool),
 							},
-							"notbool": schema.ObjectAttribute{
+							"notbool": &schema.AttributeSchema{
 								Expr: schema.LiteralTypeOnly(cty.String),
 							},
-							"nested_map": schema.ObjectAttribute{
+							"nested_map": &schema.AttributeSchema{
 								Expr: schema.LiteralTypeOnly(cty.Map(cty.String)),
 							},
-							"nested_obj": schema.ObjectAttribute{
+							"nested_obj": &schema.AttributeSchema{
 								Expr: schema.LiteralTypeOnly(cty.Object(map[string]cty.Type{})),
 							},
 						},
@@ -691,7 +939,7 @@ _object_`),
 				"tuplecons": {Expr: schema.ExprConstraints{
 					schema.TupleConsExpr{
 						Name:    "special tuple",
-						AnyElem: schema.LiteralTypeOnly(cty.List(cty.String)),
+						AnyElem: schema.LiteralTypeOnly(cty.String),
 					},
 				}},
 			},
@@ -710,6 +958,187 @@ _object_`),
 						Line:   1,
 						Column: 29,
 						Byte:   28,
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"list expression",
+			map[string]*schema.AttributeSchema{
+				"list": {Expr: schema.ExprConstraints{
+					schema.ListExpr{
+						Description: lang.Markdown("Special list"),
+						Elem:        schema.LiteralTypeOnly(cty.String),
+					},
+				}},
+			},
+			`list = [ "one", "two" ]`,
+			hcl.Pos{Line: 1, Column: 8, Byte: 7},
+			&lang.HoverData{
+				Content: lang.Markdown("_list_\n\nSpecial list"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start: hcl.Pos{
+						Line:   1,
+						Column: 8,
+						Byte:   7,
+					},
+					End: hcl.Pos{
+						Line:   1,
+						Column: 24,
+						Byte:   23,
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"list expression element",
+			map[string]*schema.AttributeSchema{
+				"list": {Expr: schema.ExprConstraints{
+					schema.ListExpr{
+						Elem: schema.LiteralTypeOnly(cty.String),
+					},
+				}},
+			},
+			`list = [ "one", "two" ]`,
+			hcl.Pos{Line: 1, Column: 12, Byte: 11},
+			&lang.HoverData{
+				Content: lang.Markdown("`\"one\"` _string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start: hcl.Pos{
+						Line:   1,
+						Column: 10,
+						Byte:   9,
+					},
+					End: hcl.Pos{
+						Line:   1,
+						Column: 15,
+						Byte:   14,
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"set expression",
+			map[string]*schema.AttributeSchema{
+				"set": {Expr: schema.ExprConstraints{
+					schema.SetExpr{
+						Description: lang.Markdown("Special set"),
+						Elem:        schema.LiteralTypeOnly(cty.String),
+					},
+				}},
+			},
+			`set = [ "one", "two" ]`,
+			hcl.Pos{Line: 1, Column: 7, Byte: 6},
+			&lang.HoverData{
+				Content: lang.Markdown("_set_\n\nSpecial set"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start: hcl.Pos{
+						Line:   1,
+						Column: 7,
+						Byte:   6,
+					},
+					End: hcl.Pos{
+						Line:   1,
+						Column: 23,
+						Byte:   22,
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"set expression element",
+			map[string]*schema.AttributeSchema{
+				"set": {Expr: schema.ExprConstraints{
+					schema.SetExpr{
+						Elem: schema.LiteralTypeOnly(cty.String),
+					},
+				}},
+			},
+			`set = [ "one", "two" ]`,
+			hcl.Pos{Line: 1, Column: 12, Byte: 11},
+			&lang.HoverData{
+				Content: lang.Markdown("`\"one\"` _string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start: hcl.Pos{
+						Line:   1,
+						Column: 9,
+						Byte:   8,
+					},
+					End: hcl.Pos{
+						Line:   1,
+						Column: 14,
+						Byte:   13,
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"tuple expression",
+			map[string]*schema.AttributeSchema{
+				"tup": {Expr: schema.ExprConstraints{
+					schema.TupleExpr{
+						Description: lang.Markdown("Special tuple"),
+						Elems: []schema.ExprConstraints{
+							schema.LiteralTypeOnly(cty.String),
+						},
+					},
+				}},
+			},
+			`tup = [ "one", "two" ]`,
+			hcl.Pos{Line: 1, Column: 7, Byte: 6},
+			&lang.HoverData{
+				Content: lang.Markdown("_tuple_\n\nSpecial tuple"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start: hcl.Pos{
+						Line:   1,
+						Column: 7,
+						Byte:   6,
+					},
+					End: hcl.Pos{
+						Line:   1,
+						Column: 23,
+						Byte:   22,
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"tuple expression element",
+			map[string]*schema.AttributeSchema{
+				"tup": {Expr: schema.ExprConstraints{
+					schema.TupleExpr{
+						Elems: []schema.ExprConstraints{
+							schema.LiteralTypeOnly(cty.String),
+						},
+					},
+				}},
+			},
+			`tup = [ "one", "two" ]`,
+			hcl.Pos{Line: 1, Column: 12, Byte: 11},
+			&lang.HoverData{
+				Content: lang.Markdown("`\"one\"` _string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start: hcl.Pos{
+						Line:   1,
+						Column: 9,
+						Byte:   8,
+					},
+					End: hcl.Pos{
+						Line:   1,
+						Column: 14,
+						Byte:   13,
 					},
 				},
 			},

--- a/decoder/semantic_tokens.go
+++ b/decoder/semantic_tokens.go
@@ -159,8 +159,35 @@ func tokensForExpression(expr hclsyntax.Expression, constraints ExprConstraints)
 	case *hclsyntax.TupleConsExpr:
 		tc, ok := constraints.TupleConsExpr()
 		if ok {
+			ec := ExprConstraints(tc.AnyElem)
 			for _, expr := range eType.Exprs {
-				ec := ExprConstraints(tc.AnyElem)
+				tokens = append(tokens, tokensForExpression(expr, ec)...)
+			}
+			return tokens
+		}
+		se, ok := constraints.SetExpr()
+		if ok {
+			ec := ExprConstraints(se.Elem)
+			for _, expr := range eType.Exprs {
+				tokens = append(tokens, tokensForExpression(expr, ec)...)
+			}
+			return tokens
+		}
+		le, ok := constraints.ListExpr()
+		if ok {
+			ec := ExprConstraints(le.Elem)
+			for _, expr := range eType.Exprs {
+				tokens = append(tokens, tokensForExpression(expr, ec)...)
+			}
+			return tokens
+		}
+		te, ok := constraints.TupleExpr()
+		if ok {
+			for i, expr := range eType.Exprs {
+				if i >= len(te.Elems) {
+					break
+				}
+				ec := ExprConstraints(te.Elems[i])
 				tokens = append(tokens, tokensForExpression(expr, ec)...)
 			}
 			return tokens
@@ -169,9 +196,9 @@ func tokensForExpression(expr hclsyntax.Expression, constraints ExprConstraints)
 		if ok {
 			return tokensForTupleConsExpr(eType, lt.Type)
 		}
-		litVal, ok := constraints.LiteralValueOfTupleExpr(eType)
+		lv, ok := constraints.LiteralValueOfTupleExpr(eType)
 		if ok {
-			return tokensForTupleConsExpr(eType, litVal.Val.Type())
+			return tokensForTupleConsExpr(eType, lv.Val.Type())
 		}
 	case *hclsyntax.ObjectConsExpr:
 		oe, ok := constraints.ObjectExpr()

--- a/decoder/semantic_tokens_expr_test.go
+++ b/decoder/semantic_tokens_expr_test.go
@@ -968,6 +968,211 @@ EOT
 			},
 		},
 		{
+			"list expression",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Expr: schema.ExprConstraints{
+						schema.ListExpr{
+							Elem: schema.LiteralTypeOnly(cty.String),
+						},
+					},
+				},
+			},
+			`attr = [ "one", 42, "two" ]
+`,
+			[]lang.SemanticToken{
+				{ // attr
+					Type:      lang.TokenAttrName,
+					Modifiers: []lang.SemanticTokenModifier{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+							Byte:   0,
+						},
+						End: hcl.Pos{
+							Line:   1,
+							Column: 5,
+							Byte:   4,
+						},
+					},
+				},
+				{ // "one"
+					Type:      lang.TokenString,
+					Modifiers: []lang.SemanticTokenModifier{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 10,
+							Byte:   9,
+						},
+						End: hcl.Pos{
+							Line:   1,
+							Column: 15,
+							Byte:   14,
+						},
+					},
+				},
+				{ // "two"
+					Type:      lang.TokenString,
+					Modifiers: []lang.SemanticTokenModifier{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 21,
+							Byte:   20,
+						},
+						End: hcl.Pos{
+							Line:   1,
+							Column: 26,
+							Byte:   25,
+						},
+					},
+				},
+			},
+		},
+		{
+			"set expression",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Expr: schema.ExprConstraints{
+						schema.SetExpr{
+							Elem: schema.LiteralTypeOnly(cty.String),
+						},
+					},
+				},
+			},
+			`attr = [ "one", 42, "two" ]
+`,
+			[]lang.SemanticToken{
+				{ // attr
+					Type:      lang.TokenAttrName,
+					Modifiers: []lang.SemanticTokenModifier{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+							Byte:   0,
+						},
+						End: hcl.Pos{
+							Line:   1,
+							Column: 5,
+							Byte:   4,
+						},
+					},
+				},
+				{ // "one"
+					Type:      lang.TokenString,
+					Modifiers: []lang.SemanticTokenModifier{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 10,
+							Byte:   9,
+						},
+						End: hcl.Pos{
+							Line:   1,
+							Column: 15,
+							Byte:   14,
+						},
+					},
+				},
+				{ // "two"
+					Type:      lang.TokenString,
+					Modifiers: []lang.SemanticTokenModifier{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 21,
+							Byte:   20,
+						},
+						End: hcl.Pos{
+							Line:   1,
+							Column: 26,
+							Byte:   25,
+						},
+					},
+				},
+			},
+		},
+		{
+			"tuple expression",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Expr: schema.ExprConstraints{
+						schema.TupleExpr{
+							Elems: []schema.ExprConstraints{
+								schema.LiteralTypeOnly(cty.String),
+								schema.LiteralTypeOnly(cty.Number),
+								schema.LiteralTypeOnly(cty.Bool),
+							},
+						},
+					},
+				},
+			},
+			`attr = [ "one", 42, "two" ]
+`,
+			[]lang.SemanticToken{
+				{ // attr
+					Type:      lang.TokenAttrName,
+					Modifiers: []lang.SemanticTokenModifier{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+							Byte:   0,
+						},
+						End: hcl.Pos{
+							Line:   1,
+							Column: 5,
+							Byte:   4,
+						},
+					},
+				},
+				{ // "one"
+					Type:      lang.TokenString,
+					Modifiers: []lang.SemanticTokenModifier{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 10,
+							Byte:   9,
+						},
+						End: hcl.Pos{
+							Line:   1,
+							Column: 15,
+							Byte:   14,
+						},
+					},
+				},
+				{ // 42
+					Type:      lang.TokenNumber,
+					Modifiers: []lang.SemanticTokenModifier{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 17,
+							Byte:   16,
+						},
+						End: hcl.Pos{
+							Line:   1,
+							Column: 19,
+							Byte:   18,
+						},
+					},
+				},
+			},
+		},
+		{
 			"tuple as list",
 			map[string]*schema.AttributeSchema{
 				"attr": {

--- a/schema/expressions.go
+++ b/schema/expressions.go
@@ -64,6 +64,8 @@ func (lv LiteralValue) FriendlyName() string {
 	return lv.Val.Type().FriendlyNameForConstraint()
 }
 
+// TODO: Consider removing TupleConsExpr
+// in favour of ListExpr, SetExpr and TupleExpr
 type TupleConsExpr struct {
 	AnyElem     ExprConstraints
 	Name        string
@@ -81,10 +83,55 @@ func (tc TupleConsExpr) FriendlyName() string {
 	return tc.Name
 }
 
+type ListExpr struct {
+	Elem        ExprConstraints
+	Description lang.MarkupContent
+	MinItems    uint64
+	MaxItems    uint64
+}
+
+func (ListExpr) isExprConstraintImpl() exprConstrSigil {
+	return exprConstrSigil{}
+}
+
+func (ListExpr) FriendlyName() string {
+	return "list"
+}
+
+type SetExpr struct {
+	Elem        ExprConstraints
+	Description lang.MarkupContent
+	MinItems    uint64
+	MaxItems    uint64
+}
+
+func (SetExpr) isExprConstraintImpl() exprConstrSigil {
+	return exprConstrSigil{}
+}
+
+func (SetExpr) FriendlyName() string {
+	return "set"
+}
+
+type TupleExpr struct {
+	Elems       []ExprConstraints
+	Description lang.MarkupContent
+}
+
+func (TupleExpr) isExprConstraintImpl() exprConstrSigil {
+	return exprConstrSigil{}
+}
+
+func (le TupleExpr) FriendlyName() string {
+	return "tuple"
+}
+
 type MapExpr struct {
 	Elem        ExprConstraints
 	Name        string
 	Description lang.MarkupContent
+	MinItems    uint64
+	MaxItems    uint64
 }
 
 func (MapExpr) isExprConstraintImpl() exprConstrSigil {
@@ -115,7 +162,7 @@ func (oe ObjectExpr) FriendlyName() string {
 	return oe.Name
 }
 
-type ObjectExprAttributes map[string]ObjectAttribute
+type ObjectExprAttributes map[string]*AttributeSchema
 
 func (ObjectExprAttributes) isExprConstraintImpl() exprConstrSigil {
 	return exprConstrSigil{}
@@ -123,15 +170,6 @@ func (ObjectExprAttributes) isExprConstraintImpl() exprConstrSigil {
 
 func (oe ObjectExprAttributes) FriendlyName() string {
 	return "attributes"
-}
-
-type ObjectAttribute struct {
-	Expr        ExprConstraints
-	Description lang.MarkupContent
-}
-
-func (oa ObjectAttribute) FriendlyName() string {
-	return oa.Expr.FriendlyName()
 }
 
 type KeywordExpr struct {


### PR DESCRIPTION
This aims to support "nested attribute type" introduced as part of Terraform 0.15, support for which was added to `terraform-json` in https://github.com/hashicorp/terraform-json/pull/28

None of these expression types are currently supported by the Terraform SDK, so providers can't really produce them yet (unless they somehow bypass the SDK and talk gRPC directly).

Additionally tuples are not supported in the SDK at all:
https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk@v1.16.1/helper/schema#ValueType