### PR TITLE
Avoid registering copystructure copiers globally

### DIFF
--- a/decoder/copiers.go
+++ b/decoder/copiers.go
@@ -1,0 +1,22 @@
+package decoder
+
+import (
+	"reflect"
+
+	"github.com/mitchellh/copystructure"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// Some types have private fields, so we declare custom copiers for them
+var copiers = map[reflect.Type]copystructure.CopierFunc{
+	reflect.TypeOf(cty.NilType): ctyTypeCopier,
+	reflect.TypeOf(cty.Value{}): ctyValueCopier,
+}
+
+func ctyTypeCopier(v interface{}) (interface{}, error) {
+	return v.(cty.Type), nil
+}
+
+func ctyValueCopier(v interface{}) (interface{}, error) {
+	return v.(cty.Value), nil
+}


### PR DESCRIPTION
This follows an upstream bug fix in copystructure: https://github.com/mitchellh/copystructure/pull/35

Whilst working on a new feature of the Terraform LS which also uses `copystructure` I needed to register some other (different) custom copiers there and I observed misbehaviours caused by the fact that we register custom copiers here globally and then as a result of calling `mergeBlockBodySchemas` these custom _global_ copiers would get overwritten downstream.

This patch eliminates that problem by avoiding global state for copiers and instead declares them locally.

--- 

I already used a similar patch in LS, so the global state doesn't affect me there, but I'm patching it here anyway to prevent future weirdness from occurring.