### PR TITLE
Add support for TraversalExpr

### DIFF
--- a/decoder/attribute_candidates.go
+++ b/decoder/attribute_candidates.go
@@ -23,6 +23,7 @@ func attributeSchemaToCandidate(name string, attr *schema.AttributeSchema, rng h
 			Snippet: snippetForAttribute(name, attr),
 			Range:   rng,
 		},
+		TriggerSuggest: triggerSuggestForExprConstraints(attr.Expr),
 	}
 }
 

--- a/decoder/candidates_test.go
+++ b/decoder/candidates_test.go
@@ -909,7 +909,8 @@ resource "random_resource" "test" {
 						NewText: "three",
 						Snippet: "three = ${1:false}",
 					},
-					Kind: lang.AttributeCandidateKind,
+					Kind:           lang.AttributeCandidateKind,
+					TriggerSuggest: true,
 				},
 				{
 					Label:  "two",
@@ -957,7 +958,8 @@ resource "random_resource" "test" {
 						NewText: "three",
 						Snippet: "three = ${1:false}",
 					},
-					Kind: lang.AttributeCandidateKind,
+					Kind:           lang.AttributeCandidateKind,
+					TriggerSuggest: true,
 				},
 				{
 					Label:  "two",
@@ -1206,31 +1208,6 @@ resource "any" "ref" {
 				},
 			}),
 		},
-		{
-			"new block or attribute inside a block",
-			`
-resource "any" "ref" {
-  co
-}
-`,
-			hcl.Pos{Line: 3, Column: 5, Byte: 28},
-			lang.CompleteCandidates([]lang.Candidate{
-				{
-					Label:  "count",
-					Detail: "Optional, number",
-					TextEdit: lang.TextEdit{
-						Range: hcl.Range{
-							Filename: "test.tf",
-							Start:    hcl.Pos{Line: 3, Column: 3, Byte: 26},
-							End:      hcl.Pos{Line: 3, Column: 5, Byte: 28},
-						},
-						NewText: "count",
-						Snippet: "count = ${1:1}",
-					},
-					Kind: lang.AttributeCandidateKind,
-				},
-			}),
-		},
 	}
 
 	for i, tc := range testCases {
@@ -1318,31 +1295,6 @@ res
 						Snippet: "resource \"${1:type}\" \"${2:name}\" {\n  ${3}\n}",
 					},
 					Kind: lang.BlockCandidateKind,
-				},
-			}),
-		},
-		{
-			"new block or attribute inside a block",
-			`
-resource "any" "ref" {
-  co
-}
-`,
-			hcl.Pos{Line: 3, Column: 5, Byte: 28},
-			lang.CompleteCandidates([]lang.Candidate{
-				{
-					Label:  "count",
-					Detail: "Optional, number",
-					TextEdit: lang.TextEdit{
-						Range: hcl.Range{
-							Filename: "test.tf",
-							Start:    hcl.Pos{Line: 3, Column: 3, Byte: 26},
-							End:      hcl.Pos{Line: 3, Column: 5, Byte: 28},
-						},
-						NewText: "count",
-						Snippet: "count = ${1:1}",
-					},
-					Kind: lang.AttributeCandidateKind,
 				},
 			}),
 		},

--- a/decoder/errors.go
+++ b/decoder/errors.go
@@ -12,6 +12,12 @@ func (*NoSchemaError) Error() string {
 	return fmt.Sprintf("no schema available")
 }
 
+type NoReferenceFound struct{}
+
+func (*NoReferenceFound) Error() string {
+	return fmt.Sprintf("no matching reference found")
+}
+
 type ConstraintMismatch struct {
 	Expr hcl.Expression
 }

--- a/decoder/expression_constraints.go
+++ b/decoder/expression_constraints.go
@@ -29,6 +29,15 @@ func (ec ExprConstraints) KeywordExpr() (schema.KeywordExpr, bool) {
 	return schema.KeywordExpr{}, false
 }
 
+func (ec ExprConstraints) TraversalExpr() (schema.TraversalExpr, bool) {
+	for _, c := range ec {
+		if te, ok := c.(schema.TraversalExpr); ok {
+			return te, ok
+		}
+	}
+	return schema.TraversalExpr{}, false
+}
+
 func (ec ExprConstraints) MapExpr() (schema.MapExpr, bool) {
 	for _, c := range ec {
 		if me, ok := c.(schema.MapExpr); ok {
@@ -90,6 +99,15 @@ func (ec ExprConstraints) HasLiteralTypeOf(exprType cty.Type) bool {
 		}
 	}
 	return false
+}
+
+func (ec ExprConstraints) LiteralType() (cty.Type, bool) {
+	for _, c := range ec {
+		if lt, ok := c.(schema.LiteralTypeExpr); ok {
+			return lt.Type, true
+		}
+	}
+	return cty.NilType, false
 }
 
 func (ec ExprConstraints) HasLiteralValueOf(val cty.Value) bool {

--- a/decoder/references.go
+++ b/decoder/references.go
@@ -1,0 +1,626 @@
+package decoder
+
+import (
+	"sort"
+
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+)
+
+type Reference lang.Reference
+
+func (ref Reference) MatchesConstraint(te schema.TraversalExpr) bool {
+	if te.OfScopeId != "" && te.OfScopeId != ref.ScopeId {
+		return false
+	}
+
+	conformsToType := false
+	if te.OfType != cty.NilType && ref.Type != cty.NilType {
+		if errs := ref.Type.TestConformance(te.OfType); len(errs) == 0 {
+			conformsToType = true
+		}
+	}
+
+	return conformsToType || (te.OfType == cty.NilType && ref.Type == cty.NilType)
+}
+
+func (ref Reference) AddrMatchesTraversal(t hcl.Traversal) bool {
+	addr, err := traversalToAddress(t)
+	if err != nil {
+		return false
+	}
+
+	rAddr := Address(ref.Addr)
+	return rAddr.Equals(Address(addr))
+}
+
+type References lang.References
+
+type RefWalkFunc func(lang.Reference)
+
+func (refs References) Walk(f RefWalkFunc) {
+	for _, ref := range refs {
+		f(ref)
+		if len(ref.InsideReferences) > 0 {
+			irefs := References(ref.InsideReferences)
+			irefs.Walk(f)
+		}
+	}
+}
+
+func (refs References) FirstTraversalMatch(expr hcl.Traversal, tSchema schema.TraversalExpr) (lang.Reference, error) {
+	var matchingReference *lang.Reference
+
+	refs.Walk(func(r lang.Reference) {
+		ref := Reference(r)
+		if ref.AddrMatchesTraversal(expr) && ref.MatchesConstraint(tSchema) {
+			matchingReference = &r
+			return
+		}
+	})
+
+	if matchingReference == nil {
+		return lang.Reference{}, &NoReferenceFound{}
+	}
+
+	return *matchingReference, nil
+}
+
+type Address lang.Address
+
+func (a Address) Equals(addr Address) bool {
+	if len(a) != len(addr) {
+		return false
+	}
+	for i, step := range a {
+		if step.String() != addr[i].String() {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (d *Decoder) DecodeReferences() (lang.References, error) {
+	d.rootSchemaMu.RLock()
+	defer d.rootSchemaMu.RUnlock()
+	if d.rootSchema == nil {
+		// unable to collect references without schema
+		return nil, &NoSchemaError{}
+	}
+
+	refs := make(lang.References, 0)
+	files := d.Filenames()
+	for _, filename := range files {
+		f, err := d.fileByName(filename)
+		if err != nil {
+			// skip unparseable file
+			continue
+		}
+
+		body, ok := f.Body.(*hclsyntax.Body)
+		if !ok {
+			// skip JSON or other body format
+			continue
+		}
+
+		refs = append(refs, decodeReferencesForBody(body, d.rootSchema)...)
+	}
+
+	return refs, nil
+}
+
+func decodeReferencesForBody(body *hclsyntax.Body, bodySchema *schema.BodySchema) lang.References {
+	refs := make(lang.References, 0)
+
+	if bodySchema == nil {
+		return lang.References{}
+	}
+
+	for _, attr := range body.Attributes {
+		attrSchema, ok := bodySchema.Attributes[attr.Name]
+		if !ok {
+			if bodySchema.AnyAttribute == nil {
+				// unknown attribute (no schema)
+				continue
+			}
+			attrSchema = bodySchema.AnyAttribute
+		}
+
+		attrAddr, ok := resolveAttributeAddress(attr, attrSchema.Address)
+		if ok {
+			if attrSchema.Address.AsReference {
+				ref := lang.Reference{
+					Addr:     attrAddr,
+					ScopeId:  attrSchema.Address.ScopeId,
+					RangePtr: attr.SrcRange.Ptr(),
+					Name:     attrSchema.Address.FriendlyName,
+				}
+				refs = append(refs, ref)
+			}
+
+			if attrSchema.Address.AsData {
+				t, ok := exprConstraintToDataType(attrSchema.Expr)
+				if !ok {
+					// impossible to create a data reference if we don't know the type
+					continue
+				}
+
+				ref := lang.Reference{
+					Addr:     attrAddr,
+					Type:     t,
+					ScopeId:  attrSchema.Address.ScopeId,
+					RangePtr: attr.SrcRange.Ptr(),
+					Name:     attrSchema.Address.FriendlyName,
+				}
+				refs = append(refs, ref)
+			}
+		}
+
+		ec := ExprConstraints(attrSchema.Expr)
+		refs = append(refs, referencesForExpr(attr.Expr, ec)...)
+	}
+
+	for _, block := range body.Blocks {
+		bSchema, ok := bodySchema.Blocks[block.Type]
+		if !ok {
+			// unknown block (no schema)
+			continue
+		}
+
+		iRefs := decodeReferencesForBody(block.Body, bSchema.Body)
+		refs = append(refs, iRefs...)
+
+		addr, ok := resolveBlockAddress(block, bSchema.Address)
+		if !ok {
+			// skip unresolvable address
+			continue
+		}
+
+		if bSchema.Address.AsReference {
+			ref := lang.Reference{
+				Addr:     addr,
+				ScopeId:  bSchema.Address.ScopeId,
+				RangePtr: block.Range().Ptr(),
+				Name:     bSchema.Address.FriendlyName,
+			}
+			refs = append(refs, ref)
+		}
+
+		var bodyRef lang.Reference
+
+		if bSchema.Address.BodyAsData {
+			bodyRef = lang.Reference{
+				Addr:     addr,
+				ScopeId:  bSchema.Address.ScopeId,
+				RangePtr: block.Range().Ptr(),
+			}
+
+			if bSchema.Body != nil {
+				bodyRef.Description = bSchema.Body.Description
+			}
+
+			if bSchema.Address.InferBody && bSchema.Body != nil {
+				bodyRef.InsideReferences = append(bodyRef.InsideReferences,
+					collectInferredReferencesForBody(addr, bSchema.Address.ScopeId, block.Body, bSchema.Body)...)
+			}
+
+			bodyRef.Type = bodyToDataType(bSchema.Type, bSchema.Body)
+
+			refs = append(refs, bodyRef)
+		}
+
+		if bSchema.Address.DependentBodyAsData {
+			if !bSchema.Address.BodyAsData {
+				bodyRef = lang.Reference{
+					Addr:     addr,
+					ScopeId:  bSchema.Address.ScopeId,
+					RangePtr: block.Range().Ptr(),
+				}
+			}
+
+			dk := dependencyKeysFromBlock(block, bSchema)
+			depSchema, ok := bSchema.DependentBodySchema(dk)
+			if ok {
+				fullSchema := depSchema
+				if bSchema.Address.BodyAsData {
+					mergedSchema, err := mergeBlockBodySchemas(block, bSchema)
+					if err != nil {
+						continue
+					}
+					bodyRef.InsideReferences = make(lang.References, 0)
+					fullSchema = mergedSchema
+				}
+
+				bodyRef.Type = bodyToDataType(bSchema.Type, fullSchema)
+
+				if bSchema.Address.InferDependentBody && len(bSchema.DependentBody) > 0 {
+					bodyRef.InsideReferences = append(bodyRef.InsideReferences,
+						collectInferredReferencesForBody(addr, bSchema.Address.ScopeId, block.Body, fullSchema)...)
+				}
+
+				if !bSchema.Address.BodyAsData {
+					refs = append(refs, bodyRef)
+				}
+			}
+		}
+		sort.Sort(bodyRef.InsideReferences)
+	}
+
+	sort.Sort(refs)
+
+	return refs
+}
+
+func exprConstraintToDataType(expr schema.ExprConstraints) (cty.Type, bool) {
+	ec := ExprConstraints(expr)
+
+	lt, ok := ec.LiteralType()
+	if ok {
+		return lt, true
+	}
+
+	le, ok := ec.ListExpr()
+	if ok {
+		elemType, elemOk := exprConstraintToDataType(le.Elem)
+		if elemOk {
+			return cty.List(elemType), true
+		}
+	}
+
+	se, ok := ec.SetExpr()
+	if ok {
+		elemType, elemOk := exprConstraintToDataType(se.Elem)
+		if elemOk {
+			return cty.Set(elemType), true
+		}
+	}
+
+	te, ok := ec.TupleExpr()
+	if ok {
+		elems := make([]cty.Type, len(te.Elems))
+		elemsOk := true
+		for i, elem := range te.Elems {
+			elemType, ok := exprConstraintToDataType(elem)
+			if ok {
+				elems[i] = elemType
+			} else {
+				elemsOk = false
+				break
+			}
+		}
+		if elemsOk {
+			return cty.Tuple(elems), true
+		}
+	}
+
+	oe, ok := ec.ObjectExpr()
+	if ok {
+		attributes := make(map[string]cty.Type, 0)
+		for name, attr := range oe.Attributes {
+			attrType, ok := exprConstraintToDataType(attr.Expr)
+			if ok {
+				attributes[name] = attrType
+			}
+		}
+		return cty.Object(attributes), true
+	}
+
+	me, ok := ec.MapExpr()
+	if ok {
+		elemType, elemOk := exprConstraintToDataType(me.Elem)
+		if elemOk {
+			return cty.Map(elemType), true
+		}
+	}
+
+	return cty.NilType, false
+}
+
+func referencesForExpr(expr hcl.Expression, ec ExprConstraints) lang.References {
+	refs := make(lang.References, 0)
+
+	switch e := expr.(type) {
+	// TODO: Support all expression types
+	case *hclsyntax.ScopeTraversalExpr:
+		te, ok := ec.TraversalExpr()
+		if !ok {
+			// unknown traversal
+			return lang.References{}
+		}
+		if te.Address == nil {
+			// traversal not addressable
+			return lang.References{}
+		}
+
+		addr, err := traversalToAddress(e.AsTraversal())
+		if err != nil {
+			return lang.References{}
+		}
+		refs = append(refs, lang.Reference{
+			Addr:     addr,
+			ScopeId:  te.Address.ScopeId,
+			RangePtr: e.SrcRange.Ptr(),
+			Name:     te.Name,
+		})
+	case *hclsyntax.ObjectConsExpr:
+		oe, ok := ec.ObjectExpr()
+		if ok {
+			for _, item := range e.Items {
+				key, _ := item.KeyExpr.Value(nil)
+				if key.IsNull() || !key.IsWhollyKnown() || key.Type() != cty.String {
+					// skip items keys that can't be interpolated
+					// without further context
+					continue
+				}
+				attr, ok := oe.Attributes[key.AsString()]
+				if !ok {
+					continue
+				}
+
+				refs = append(refs, referencesForExpr(item.ValueExpr, ExprConstraints(attr.Expr))...)
+			}
+		}
+		me, ok := ec.MapExpr()
+		if ok {
+			for _, item := range e.Items {
+				refs = append(refs, referencesForExpr(item.ValueExpr, ExprConstraints(me.Elem))...)
+			}
+		}
+	case *hclsyntax.TupleConsExpr:
+		le, ok := ec.ListExpr()
+		if ok {
+			for _, itemExpr := range e.Exprs {
+				refs = append(refs, referencesForExpr(itemExpr, ExprConstraints(le.Elem))...)
+			}
+		}
+		se, ok := ec.SetExpr()
+		if ok {
+			for _, itemExpr := range e.Exprs {
+				refs = append(refs, referencesForExpr(itemExpr, ExprConstraints(se.Elem))...)
+			}
+		}
+		te, ok := ec.TupleExpr()
+		if ok {
+			for i, itemExpr := range e.Exprs {
+				if i >= len(te.Elems) {
+					break
+				}
+				refs = append(refs, referencesForExpr(itemExpr, ExprConstraints(te.Elems[i]))...)
+			}
+		}
+		tce, ok := ec.TupleConsExpr()
+		if ok {
+			for _, itemExpr := range e.Exprs {
+				refs = append(refs, referencesForExpr(itemExpr, ExprConstraints(tce.AnyElem))...)
+			}
+		}
+	}
+
+	return refs
+}
+
+func bodySchemaAsAttrTypes(bodySchema *schema.BodySchema) map[string]cty.Type {
+	attrTypes := make(map[string]cty.Type, 0)
+
+	if bodySchema == nil {
+		return attrTypes
+	}
+
+	for name, attr := range bodySchema.Attributes {
+		attrType, ok := exprConstraintToDataType(attr.Expr)
+		if ok {
+			attrTypes[name] = attrType
+		}
+	}
+
+	for name, block := range bodySchema.Blocks {
+		attrTypes[name] = bodyToDataType(block.Type, block.Body)
+	}
+
+	return attrTypes
+}
+
+func collectInferredReferencesForBody(addr lang.Address, scopeId lang.ScopeId, body *hclsyntax.Body, bodySchema *schema.BodySchema) lang.References {
+	refs := make(lang.References, 0)
+
+	for name, aSchema := range bodySchema.Attributes {
+		attrType, ok := exprConstraintToDataType(aSchema.Expr)
+		if !ok {
+			// unknown type
+			continue
+		}
+
+		attrAddr := make(lang.Address, len(addr))
+		copy(attrAddr, addr)
+		attrAddr = append(attrAddr, lang.AttrStep{Name: name})
+
+		ref := lang.Reference{
+			Addr:        attrAddr,
+			ScopeId:     scopeId,
+			Type:        attrType,
+			Description: aSchema.Description,
+			RangePtr:    body.EndRange.Ptr(),
+		}
+
+		if body != nil {
+			if attr, ok := body.Attributes[name]; ok {
+				ref.RangePtr = attr.Range().Ptr()
+			}
+		}
+
+		refs = append(refs, ref)
+	}
+
+	for name, bSchema := range bodySchema.Blocks {
+		blockAddr := make(lang.Address, len(addr))
+		copy(blockAddr, addr)
+		blockAddr = append(blockAddr, lang.AttrStep{Name: name})
+
+		ref := lang.Reference{
+			Addr:        blockAddr,
+			ScopeId:     scopeId,
+			Type:        bodyToDataType(bSchema.Type, bSchema.Body),
+			Description: bSchema.Description,
+			RangePtr:    body.EndRange.Ptr(),
+		}
+
+		if body != nil {
+			for i, block := range body.Blocks {
+				if name == block.Type {
+					switch bSchema.Type {
+					case schema.BlockTypeObject:
+						ref.RangePtr = block.Range().Ptr()
+						insideRefs := collectInferredReferencesForBody(blockAddr, scopeId, block.Body, bSchema.Body)
+						ref.InsideReferences = append(ref.InsideReferences, insideRefs...)
+						break
+					case schema.BlockTypeList:
+						elemAddr := make(lang.Address, len(blockAddr))
+						copy(elemAddr, blockAddr)
+						elemAddr = append(elemAddr, lang.IndexStep{
+							Key: cty.NumberIntVal(int64(i)),
+						})
+						insideRefs := collectInferredReferencesForBody(elemAddr, scopeId, block.Body, bSchema.Body)
+						ref.InsideReferences = append(ref.InsideReferences, insideRefs...)
+
+					case schema.BlockTypeMap:
+						if len(block.Labels) != 1 {
+							// this should never happen
+							continue
+						}
+						elemAddr := make(lang.Address, len(blockAddr))
+						copy(elemAddr, blockAddr)
+						elemAddr = append(elemAddr, lang.IndexStep{
+							Key: cty.StringVal(block.Labels[0]),
+						})
+						insideRefs := collectInferredReferencesForBody(elemAddr, scopeId, block.Body, bSchema.Body)
+						ref.InsideReferences = append(ref.InsideReferences, insideRefs...)
+					}
+				}
+			}
+		}
+
+		sort.Sort(ref.InsideReferences)
+
+		refs = append(refs, ref)
+	}
+
+	return refs
+}
+
+func bodyToDataType(blockType schema.BlockType, body *schema.BodySchema) cty.Type {
+	switch blockType {
+	case schema.BlockTypeObject:
+		return cty.Object(bodySchemaAsAttrTypes(body))
+	case schema.BlockTypeList:
+		return cty.List(cty.Object(bodySchemaAsAttrTypes(body)))
+	case schema.BlockTypeMap:
+		return cty.Map(cty.Object(bodySchemaAsAttrTypes(body)))
+	case schema.BlockTypeSet:
+		return cty.Set(cty.Object(bodySchemaAsAttrTypes(body)))
+	}
+	return cty.Object(bodySchemaAsAttrTypes(body))
+}
+
+func resolveAttributeAddress(attr *hclsyntax.Attribute, addr *schema.AttributeAddrSchema) (lang.Address, bool) {
+	address := make(lang.Address, 0)
+
+	if addr == nil {
+		// attribute not addressable
+		return lang.Address{}, false
+	}
+
+	for i, s := range addr.Steps {
+		var stepName string
+
+		switch step := s.(type) {
+		case schema.StaticStep:
+			stepName = step.Name
+		case schema.AttrNameStep:
+			stepName = attr.Name
+		// TODO: AttrValueStep? Currently no use case for it
+		default:
+			// unknown step
+			return lang.Address{}, false
+		}
+
+		if i == 0 {
+			address = append(address, lang.RootStep{
+				Name: stepName,
+			})
+			continue
+		}
+		address = append(address, lang.AttrStep{
+			Name: stepName,
+		})
+	}
+
+	return address, true
+}
+
+func resolveBlockAddress(block *hclsyntax.Block, addr *schema.BlockAddrSchema) (lang.Address, bool) {
+	address := make(lang.Address, 0)
+
+	if addr == nil {
+		// block not addressable
+		return lang.Address{}, false
+	}
+
+	for i, s := range addr.Steps {
+		var stepName string
+
+		switch step := s.(type) {
+		case schema.StaticStep:
+			stepName = step.Name
+		case schema.LabelStep:
+			if uint(len(block.Labels)-1) < step.Index {
+				// label not present
+				return lang.Address{}, false
+			}
+			stepName = block.Labels[step.Index]
+		case schema.AttrValueStep:
+			attr, ok := block.Body.Attributes[step.Name]
+			if !ok && step.IsOptional {
+				// skip step if not found and optional
+				continue
+			}
+
+			if !ok {
+				// attribute not present
+				return lang.Address{}, false
+			}
+			if attr.Expr == nil {
+				// empty attribute
+				return lang.Address{}, false
+			}
+			val, _ := attr.Expr.Value(nil)
+			if !val.IsWhollyKnown() {
+				// unknown value
+				return lang.Address{}, false
+			}
+			if val.Type() != cty.String {
+				// non-string attributes are currently unsupported
+				return lang.Address{}, false
+			}
+			stepName = val.AsString()
+		default:
+			// unknown step
+			return lang.Address{}, false
+		}
+
+		if i == 0 {
+			address = append(address, lang.RootStep{
+				Name: stepName,
+			})
+			continue
+		}
+		address = append(address, lang.AttrStep{
+			Name: stepName,
+		})
+	}
+
+	return address, true
+}

--- a/decoder/references_test.go
+++ b/decoder/references_test.go
@@ -1,0 +1,1713 @@
+package decoder
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty-debug/ctydebug"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestAddress_Equals_basic(t *testing.T) {
+	originalAddr := Address(lang.Address{
+		lang.RootStep{Name: "provider"},
+		lang.AttrStep{Name: "aws"},
+	})
+
+	matchingAddr := lang.Address{
+		lang.RootStep{Name: "provider"},
+		lang.AttrStep{Name: "aws"},
+	}
+	if !originalAddr.Equals(Address(matchingAddr)) {
+		t.Fatalf("expected %q to match %q", originalAddr, matchingAddr)
+	}
+
+	mismatchingAddr := lang.Address{
+		lang.RootStep{Name: "provider"},
+		lang.AttrStep{Name: "aaa"},
+	}
+	if originalAddr.Equals(Address(mismatchingAddr)) {
+		t.Fatalf("expected %q not to match %q", originalAddr, mismatchingAddr)
+	}
+}
+
+func TestAddress_Equals_numericIndexStep(t *testing.T) {
+	originalAddr := Address(lang.Address{
+		lang.RootStep{Name: "aws_alb"},
+		lang.AttrStep{Name: "example"},
+		lang.IndexStep{Key: cty.NumberIntVal(0)},
+	})
+
+	matchingAddr := lang.Address{
+		lang.RootStep{Name: "aws_alb"},
+		lang.AttrStep{Name: "example"},
+		lang.IndexStep{Key: cty.NumberIntVal(0)},
+	}
+	if !originalAddr.Equals(Address(matchingAddr)) {
+		t.Fatalf("expected %q to match %q", originalAddr, matchingAddr)
+	}
+
+	mismatchingAddr := lang.Address{
+		lang.RootStep{Name: "aws_alb"},
+		lang.AttrStep{Name: "example"},
+		lang.IndexStep{Key: cty.NumberIntVal(4)},
+	}
+	if originalAddr.Equals(Address(mismatchingAddr)) {
+		t.Fatalf("expected %q not to match %q", originalAddr, mismatchingAddr)
+	}
+}
+
+func TestAddress_Equals_stringIndexStep(t *testing.T) {
+	originalAddr := Address(lang.Address{
+		lang.RootStep{Name: "aws_alb"},
+		lang.AttrStep{Name: "example"},
+		lang.IndexStep{Key: cty.StringVal("first")},
+	})
+
+	matchingAddr := lang.Address{
+		lang.RootStep{Name: "aws_alb"},
+		lang.AttrStep{Name: "example"},
+		lang.IndexStep{Key: cty.StringVal("first")},
+	}
+	if !originalAddr.Equals(Address(matchingAddr)) {
+		t.Fatalf("expected %q to match %q", originalAddr, matchingAddr)
+	}
+
+	mismatchingAddr := lang.Address{
+		lang.RootStep{Name: "aws_alb"},
+		lang.AttrStep{Name: "example"},
+		lang.IndexStep{Key: cty.StringVal("second")},
+	}
+	if originalAddr.Equals(Address(mismatchingAddr)) {
+		t.Fatalf("expected %q not to match %q", originalAddr, mismatchingAddr)
+	}
+}
+
+func TestDecodeReferences_noSchema(t *testing.T) {
+	d := NewDecoder()
+	_, err := d.DecodeReferences()
+	if err == nil {
+		t.Fatal("expected error when no schema is set")
+	}
+
+	noSchemaErr := &NoSchemaError{}
+	if !errors.As(err, &noSchemaErr) {
+		t.Fatalf("unexpected error: %#v, expected %#v", err, noSchemaErr)
+	}
+}
+
+func TestDecodeReferences_basic(t *testing.T) {
+	testCases := []struct {
+		name         string
+		schema       *schema.BodySchema
+		cfg          string
+		expectedRefs lang.References
+	}{
+		{
+			"root attribute as reference",
+			&schema.BodySchema{
+				Attributes: map[string]*schema.AttributeSchema{
+					"testattr": {
+						Address: &schema.AttributeAddrSchema{
+							Steps: []schema.AddrStep{
+								schema.StaticStep{Name: "special"},
+								schema.AttrNameStep{},
+							},
+							AsReference: true,
+							ScopeId:     lang.ScopeId("specialthing"),
+						},
+						IsOptional: true,
+						Expr:       schema.LiteralTypeOnly(cty.String),
+					},
+				},
+			},
+			`testattr = "example"
+`,
+			lang.References{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "special"},
+						lang.AttrStep{Name: "testattr"},
+					},
+					ScopeId: lang.ScopeId("specialthing"),
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+							Byte:   0,
+						},
+						End: hcl.Pos{
+							Line:   1,
+							Column: 21,
+							Byte:   20,
+						},
+					},
+				},
+			},
+		},
+		{
+			"root attribute as data",
+			&schema.BodySchema{
+				Attributes: map[string]*schema.AttributeSchema{
+					"testattr": {
+						Address: &schema.AttributeAddrSchema{
+							Steps: []schema.AddrStep{
+								schema.StaticStep{Name: "special"},
+								schema.AttrNameStep{},
+							},
+							AsData: true,
+						},
+						IsOptional: true,
+						Expr:       schema.LiteralTypeOnly(cty.String),
+					},
+				},
+			},
+			`testattr = "example"
+`,
+			lang.References{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "special"},
+						lang.AttrStep{Name: "testattr"},
+					},
+					Type: cty.String,
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+							Byte:   0,
+						},
+						End: hcl.Pos{
+							Line:   1,
+							Column: 21,
+							Byte:   20,
+						},
+					},
+				},
+			},
+		},
+		{
+			"block with mismatching steps",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource": {
+						Labels: []*schema.LabelSchema{
+							{Name: "type"},
+							{Name: "name"},
+						},
+						Address: &schema.BlockAddrSchema{
+							Steps: []schema.AddrStep{
+								schema.LabelStep{Index: 0},
+								schema.LabelStep{Index: 1},
+							},
+							AsReference: true,
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"attr": {
+									Expr:       schema.LiteralTypeOnly(cty.Number),
+									IsOptional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			`resource "blah" {
+	attr = 3
+}
+`,
+			lang.References{},
+		},
+		{
+			"block as ref only",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource": {
+						Labels: []*schema.LabelSchema{
+							{Name: "type"},
+							{Name: "name"},
+						},
+						Address: &schema.BlockAddrSchema{
+							Steps: []schema.AddrStep{
+								schema.LabelStep{Index: 0},
+								schema.LabelStep{Index: 1},
+							},
+							AsReference: true,
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"attr": {
+									Expr:       schema.LiteralTypeOnly(cty.Number),
+									IsOptional: true,
+								},
+								"name": {
+									Expr:       schema.LiteralTypeOnly(cty.String),
+									IsOptional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			`resource "blah" "test" {
+	attr = 3
+	name = "lorem ipsum"
+}
+`,
+			lang.References{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "blah"},
+						lang.AttrStep{Name: "test"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+							Byte:   0,
+						},
+						End: hcl.Pos{
+							Line:   4,
+							Column: 2,
+							Byte:   58,
+						},
+					},
+				},
+			},
+		},
+		{
+			"block as data - single object",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource": {
+						Labels: []*schema.LabelSchema{
+							{Name: "type"},
+							{Name: "name"},
+						},
+						Address: &schema.BlockAddrSchema{
+							Steps: []schema.AddrStep{
+								schema.LabelStep{Index: 0},
+								schema.LabelStep{Index: 1},
+							},
+							BodyAsData: true,
+						},
+						Type: schema.BlockTypeObject,
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"attr": {
+									Expr:       schema.LiteralTypeOnly(cty.Number),
+									IsOptional: true,
+								},
+								"name": {
+									Expr:       schema.LiteralTypeOnly(cty.String),
+									IsOptional: true,
+								},
+								"map_attr": {
+									Expr: schema.ExprConstraints{
+										schema.MapExpr{Elem: schema.LiteralTypeOnly(cty.String)},
+									},
+									IsOptional: true,
+								},
+								"list_attr": {
+									Expr: schema.ExprConstraints{
+										schema.ListExpr{Elem: schema.LiteralTypeOnly(cty.String)},
+									},
+									IsOptional: true,
+								},
+								"set_attr": {
+									Expr: schema.ExprConstraints{
+										schema.SetExpr{Elem: schema.LiteralTypeOnly(cty.String)},
+									},
+									IsOptional: true,
+								},
+								"tuple_attr": {
+									Expr: schema.ExprConstraints{
+										schema.TupleExpr{Elems: []schema.ExprConstraints{
+											schema.LiteralTypeOnly(cty.String),
+											schema.LiteralTypeOnly(cty.Number),
+										}},
+									},
+									IsOptional: true,
+								},
+								"obj_attr": {
+									Expr: schema.ExprConstraints{
+										schema.ObjectExpr{
+											Attributes: schema.ObjectExprAttributes{
+												"example": &schema.AttributeSchema{
+													Expr: schema.LiteralTypeOnly(cty.String),
+												},
+											},
+										},
+									},
+									IsOptional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			`resource "blah" "test" {
+	attr = 3
+	name = "lorem ipsum"
+	map_attr = {
+		one = "hello"
+		two = "world"
+	}
+	list_attr = [ "one", "two" ]
+	set_attr = [ "one", "two" ]
+	tuple_attr = [ "one", 42 ]
+	obj_attr = {
+		example = "blah"
+	}
+}
+`,
+			lang.References{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "blah"},
+						lang.AttrStep{Name: "test"},
+					},
+					Type: cty.Object(map[string]cty.Type{
+						"attr":       cty.Number,
+						"name":       cty.String,
+						"map_attr":   cty.Map(cty.String),
+						"list_attr":  cty.List(cty.String),
+						"set_attr":   cty.Set(cty.String),
+						"tuple_attr": cty.Tuple([]cty.Type{cty.String, cty.Number}),
+						"obj_attr": cty.Object(map[string]cty.Type{
+							"example": cty.String,
+						}),
+					}),
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+							Byte:   0,
+						},
+						End: hcl.Pos{
+							Line:   14,
+							Column: 2,
+							Byte:   230,
+						},
+					},
+				},
+			},
+		},
+		{
+			"block as data - list of objects",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource": {
+						Labels: []*schema.LabelSchema{
+							{Name: "type"},
+							{Name: "name"},
+						},
+						Address: &schema.BlockAddrSchema{
+							Steps: []schema.AddrStep{
+								schema.LabelStep{Index: 0},
+								schema.LabelStep{Index: 1},
+							},
+							BodyAsData: true,
+						},
+						Type: schema.BlockTypeList,
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"attr": {
+									Expr:       schema.LiteralTypeOnly(cty.Number),
+									IsOptional: true,
+								},
+								"name": {
+									Expr:       schema.LiteralTypeOnly(cty.String),
+									IsOptional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			`resource "blah" "test" {
+	attr = 3
+	name = "lorem ipsum"
+}
+`,
+			lang.References{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "blah"},
+						lang.AttrStep{Name: "test"},
+					},
+					Type: cty.List(cty.Object(map[string]cty.Type{
+						"attr": cty.Number,
+						"name": cty.String,
+					})),
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+							Byte:   0,
+						},
+						End: hcl.Pos{
+							Line:   4,
+							Column: 2,
+							Byte:   58,
+						},
+					},
+				},
+			},
+		},
+		{
+			"block as data - set of objects",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource": {
+						Labels: []*schema.LabelSchema{
+							{Name: "type"},
+							{Name: "name"},
+						},
+						Address: &schema.BlockAddrSchema{
+							Steps: []schema.AddrStep{
+								schema.LabelStep{Index: 0},
+								schema.LabelStep{Index: 1},
+							},
+							BodyAsData: true,
+						},
+						Type: schema.BlockTypeSet,
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"attr": {
+									Expr:       schema.LiteralTypeOnly(cty.Number),
+									IsOptional: true,
+								},
+								"name": {
+									Expr:       schema.LiteralTypeOnly(cty.String),
+									IsOptional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			`resource "blah" "test" {
+	attr = 3
+	name = "lorem ipsum"
+}
+`,
+			lang.References{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "blah"},
+						lang.AttrStep{Name: "test"},
+					},
+					Type: cty.Set(cty.Object(map[string]cty.Type{
+						"attr": cty.Number,
+						"name": cty.String,
+					})),
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+							Byte:   0,
+						},
+						End: hcl.Pos{
+							Line:   4,
+							Column: 2,
+							Byte:   58,
+						},
+					},
+				},
+			},
+		},
+		{
+			"block as data - map",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"listener": {
+						Labels: []*schema.LabelSchema{
+							{Name: "name"},
+						},
+						Address: &schema.BlockAddrSchema{
+							Steps: []schema.AddrStep{
+								schema.LabelStep{Index: 0},
+							},
+							BodyAsData: true,
+						},
+						Type: schema.BlockTypeMap,
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"source_port": {
+									Expr:       schema.LiteralTypeOnly(cty.Number),
+									IsOptional: true,
+								},
+								"protocol": {
+									Expr:       schema.LiteralTypeOnly(cty.String),
+									IsOptional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			`listener "http" {
+	source_port = 80
+	protocol = "tcp"
+}
+listener "https" {
+	source_port = 443
+	protocol = "tcp"
+}
+`,
+			lang.References{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "http"},
+					},
+					Type: cty.Map(cty.Object(map[string]cty.Type{
+						"source_port": cty.Number,
+						"protocol":    cty.String,
+					})),
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+							Byte:   0,
+						},
+						End: hcl.Pos{
+							Line:   4,
+							Column: 2,
+							Byte:   55,
+						},
+					},
+				},
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "https"},
+					},
+					Type: cty.Map(cty.Object(map[string]cty.Type{
+						"source_port": cty.Number,
+						"protocol":    cty.String,
+					})),
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   5,
+							Column: 1,
+							Byte:   56,
+						},
+						End: hcl.Pos{
+							Line:   8,
+							Column: 2,
+							Byte:   113,
+						},
+					},
+				},
+			},
+		},
+		{
+			"block with inferred body as data",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"provider": {
+						Labels: []*schema.LabelSchema{
+							{Name: "name"},
+						},
+						Address: &schema.BlockAddrSchema{
+							Steps: []schema.AddrStep{
+								schema.LabelStep{Index: 0},
+							},
+							BodyAsData: true,
+							InferBody:  true,
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"attr": {
+									Expr:       schema.LiteralTypeOnly(cty.Number),
+									IsOptional: true,
+								},
+								"name": {
+									Expr:       schema.LiteralTypeOnly(cty.String),
+									IsOptional: true,
+								},
+								"map_attr": {
+									Expr: schema.ExprConstraints{
+										schema.MapExpr{Elem: schema.LiteralTypeOnly(cty.String)},
+									},
+									IsOptional: true,
+								},
+								"list_attr": {
+									Expr: schema.ExprConstraints{
+										schema.ListExpr{Elem: schema.LiteralTypeOnly(cty.String)},
+									},
+									IsOptional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			`provider "aws" {
+  attr = 42
+  name = "hello world"
+  map_attr = {
+		one = "hello"
+		two = "world"
+	}
+	list_attr = [ "one", "two" ]
+}
+`,
+			lang.References{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "aws"},
+					},
+					Type: cty.Object(map[string]cty.Type{
+						"attr":      cty.Number,
+						"name":      cty.String,
+						"map_attr":  cty.Map(cty.String),
+						"list_attr": cty.List(cty.String),
+					}),
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+							Byte:   0,
+						},
+						End: hcl.Pos{
+							Line:   9,
+							Column: 2,
+							Byte:   133,
+						},
+					},
+					InsideReferences: lang.References{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "aws"},
+								lang.AttrStep{Name: "attr"},
+							},
+							Type: cty.Number,
+							RangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start: hcl.Pos{
+									Line:   2,
+									Column: 3,
+									Byte:   19,
+								},
+								End: hcl.Pos{
+									Line:   2,
+									Column: 12,
+									Byte:   28,
+								},
+							},
+						},
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "aws"},
+								lang.AttrStep{Name: "list_attr"},
+							},
+							Type: cty.List(cty.String),
+							RangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start: hcl.Pos{
+									Line:   8,
+									Column: 2,
+									Byte:   103,
+								},
+								End: hcl.Pos{
+									Line:   8,
+									Column: 30,
+									Byte:   131,
+								},
+							},
+						},
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "aws"},
+								lang.AttrStep{Name: "map_attr"},
+							},
+							Type: cty.Map(cty.String),
+							RangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start: hcl.Pos{
+									Line:   4,
+									Column: 3,
+									Byte:   54,
+								},
+								End: hcl.Pos{
+									Line:   7,
+									Column: 3,
+									Byte:   101,
+								},
+							},
+						},
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "aws"},
+								lang.AttrStep{Name: "name"},
+							},
+							Type: cty.String,
+							RangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start: hcl.Pos{
+									Line:   3,
+									Column: 3,
+									Byte:   31,
+								},
+								End: hcl.Pos{
+									Line:   3,
+									Column: 23,
+									Byte:   51,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"block with dependent body as data",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"provider": {
+						Labels: []*schema.LabelSchema{
+							{Name: "name", IsDepKey: true},
+						},
+						Address: &schema.BlockAddrSchema{
+							Steps: []schema.AddrStep{
+								schema.LabelStep{Index: 0},
+							},
+							DependentBodyAsData: true,
+							// InferDependentBody:  true,
+						},
+						Type: schema.BlockTypeObject,
+						DependentBody: map[schema.SchemaKey]*schema.BodySchema{
+							schema.NewSchemaKey(schema.DependencyKeys{
+								Labels: []schema.LabelDependent{
+									{Index: 0, Value: "aws"},
+								},
+							}): {
+								Attributes: map[string]*schema.AttributeSchema{
+									"attr": {
+										Expr:       schema.LiteralTypeOnly(cty.Number),
+										IsOptional: true,
+									},
+									"name": {
+										Expr:       schema.LiteralTypeOnly(cty.String),
+										IsOptional: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			`provider "aws" {
+  attr = 42
+  name = "hello world"
+}
+provider "test" {
+  attr = 42
+  name = "hello world"
+}
+`,
+			lang.References{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "aws"},
+					},
+					Type: cty.Object(map[string]cty.Type{
+						"attr": cty.Number,
+						"name": cty.String,
+					}),
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+							Byte:   0,
+						},
+						End: hcl.Pos{
+							Line:   4,
+							Column: 2,
+							Byte:   53,
+						},
+					},
+				},
+			},
+		},
+		{
+			"block with inferred body data",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"provider": {
+						Labels: []*schema.LabelSchema{
+							{Name: "name", IsDepKey: true},
+						},
+						Address: &schema.BlockAddrSchema{
+							Steps: []schema.AddrStep{
+								schema.LabelStep{Index: 0},
+							},
+							DependentBodyAsData: true,
+							InferDependentBody:  true,
+						},
+						Type: schema.BlockTypeObject,
+						DependentBody: map[schema.SchemaKey]*schema.BodySchema{
+							schema.NewSchemaKey(schema.DependencyKeys{
+								Labels: []schema.LabelDependent{
+									{Index: 0, Value: "aws"},
+								},
+							}): {
+								Attributes: map[string]*schema.AttributeSchema{
+									"attr": {
+										Expr:       schema.LiteralTypeOnly(cty.Number),
+										IsOptional: true,
+									},
+									"name": {
+										Expr:       schema.LiteralTypeOnly(cty.String),
+										IsOptional: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			`provider "aws" {
+  attr = 42
+  name = "hello world"
+}
+provider "test" {
+  attr = 42
+  name = "hello world"
+}
+`,
+			lang.References{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "aws"},
+					},
+					Type: cty.Object(map[string]cty.Type{
+						"attr": cty.Number,
+						"name": cty.String,
+					}),
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+							Byte:   0,
+						},
+						End: hcl.Pos{
+							Line:   4,
+							Column: 2,
+							Byte:   53,
+						},
+					},
+					InsideReferences: lang.References{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "aws"},
+								lang.AttrStep{Name: "attr"},
+							},
+							Type: cty.Number,
+							RangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start: hcl.Pos{
+									Line:   2,
+									Column: 3,
+									Byte:   19,
+								},
+								End: hcl.Pos{
+									Line:   2,
+									Column: 12,
+									Byte:   28,
+								},
+							},
+						},
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "aws"},
+								lang.AttrStep{Name: "name"},
+							},
+							Type: cty.String,
+							RangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start: hcl.Pos{
+									Line:   3,
+									Column: 3,
+									Byte:   31,
+								},
+								End: hcl.Pos{
+									Line:   3,
+									Column: 23,
+									Byte:   51,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"nested single object block with inferred body data",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"rootblock": {
+						Labels: []*schema.LabelSchema{
+							{Name: "name", IsDepKey: true},
+						},
+						Address: &schema.BlockAddrSchema{
+							Steps: []schema.AddrStep{
+								schema.StaticStep{Name: "root"},
+								schema.LabelStep{Index: 0},
+							},
+							BodyAsData: true,
+							InferBody:  true,
+						},
+						Type: schema.BlockTypeObject,
+						Body: &schema.BodySchema{
+							Blocks: map[string]*schema.BlockSchema{
+								"objblock": {
+									Type: schema.BlockTypeObject,
+									Body: &schema.BodySchema{
+										Attributes: map[string]*schema.AttributeSchema{
+											"protocol": {
+												Expr:       schema.LiteralTypeOnly(cty.String),
+												IsOptional: true,
+											},
+											"port": {
+												Expr:       schema.LiteralTypeOnly(cty.Number),
+												IsOptional: true,
+											},
+										},
+									},
+								},
+							},
+							Attributes: map[string]*schema.AttributeSchema{
+								"attr": {
+									Expr:       schema.LiteralTypeOnly(cty.Number),
+									IsOptional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			`rootblock "aws" {
+  attr = 42
+  objblock {
+    port = 80
+    protocol = "tcp"
+  }
+}
+`,
+			lang.References{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "root"},
+						lang.AttrStep{Name: "aws"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+							Byte:   0,
+						},
+						End: hcl.Pos{
+							Line:   7,
+							Column: 2,
+							Byte:   83,
+						},
+					},
+					Type: cty.Object(map[string]cty.Type{
+						"attr": cty.Number,
+						"objblock": cty.Object(map[string]cty.Type{
+							"port":     cty.Number,
+							"protocol": cty.String,
+						}),
+					}),
+					InsideReferences: lang.References{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "root"},
+								lang.AttrStep{Name: "aws"},
+								lang.AttrStep{Name: "attr"},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start: hcl.Pos{
+									Line:   2,
+									Column: 3,
+									Byte:   20,
+								},
+								End: hcl.Pos{
+									Line:   2,
+									Column: 12,
+									Byte:   29,
+								},
+							},
+							Type: cty.Number,
+						},
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "root"},
+								lang.AttrStep{Name: "aws"},
+								lang.AttrStep{Name: "objblock"},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start: hcl.Pos{
+									Line:   3,
+									Column: 3,
+									Byte:   32,
+								},
+								End: hcl.Pos{
+									Line:   6,
+									Column: 4,
+									Byte:   81,
+								},
+							},
+							Type: cty.Object(map[string]cty.Type{
+								"port":     cty.Number,
+								"protocol": cty.String,
+							}),
+							InsideReferences: lang.References{
+								{
+									Addr: lang.Address{
+										lang.RootStep{Name: "root"},
+										lang.AttrStep{Name: "aws"},
+										lang.AttrStep{Name: "objblock"},
+										lang.AttrStep{Name: "port"},
+									},
+									RangePtr: &hcl.Range{
+										Filename: "test.tf",
+										Start: hcl.Pos{
+											Line:   4,
+											Column: 5,
+											Byte:   47,
+										},
+										End: hcl.Pos{
+											Line:   4,
+											Column: 14,
+											Byte:   56,
+										},
+									},
+									Type: cty.Number,
+								},
+								{
+									Addr: lang.Address{
+										lang.RootStep{Name: "root"},
+										lang.AttrStep{Name: "aws"},
+										lang.AttrStep{Name: "objblock"},
+										lang.AttrStep{Name: "protocol"},
+									},
+									RangePtr: &hcl.Range{
+										Filename: "test.tf",
+										Start: hcl.Pos{
+											Line:   5,
+											Column: 5,
+											Byte:   61,
+										},
+										End: hcl.Pos{
+											Line:   5,
+											Column: 21,
+											Byte:   77,
+										},
+									},
+									Type: cty.String,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"nested list block with inferred body data",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"rootblock": {
+						Labels: []*schema.LabelSchema{
+							{Name: "name", IsDepKey: true},
+						},
+						Address: &schema.BlockAddrSchema{
+							Steps: []schema.AddrStep{
+								schema.StaticStep{Name: "root"},
+								schema.LabelStep{Index: 0},
+							},
+							BodyAsData: true,
+							InferBody:  true,
+						},
+						Type: schema.BlockTypeObject,
+						Body: &schema.BodySchema{
+							Blocks: map[string]*schema.BlockSchema{
+								"listblock": {
+									Type: schema.BlockTypeList,
+									Body: &schema.BodySchema{
+										Attributes: map[string]*schema.AttributeSchema{
+											"protocol": {
+												Expr:       schema.LiteralTypeOnly(cty.String),
+												IsOptional: true,
+											},
+											"port": {
+												Expr:       schema.LiteralTypeOnly(cty.Number),
+												IsOptional: true,
+											},
+										},
+									},
+								},
+							},
+							Attributes: map[string]*schema.AttributeSchema{
+								"attr": {
+									Expr:       schema.LiteralTypeOnly(cty.Number),
+									IsOptional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			`rootblock "aws" {
+  attr = 42
+  listblock {
+    port = 80
+    protocol = "tcp"
+  }
+  listblock {
+    port = 443
+    protocol = "tcp"
+  }
+}
+`,
+			lang.References{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "root"},
+						lang.AttrStep{Name: "aws"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+							Byte:   0,
+						},
+						End: hcl.Pos{
+							Line:   11,
+							Column: 2,
+							Byte:   138,
+						},
+					},
+					Type: cty.Object(map[string]cty.Type{
+						"attr": cty.Number,
+						"listblock": cty.List(cty.Object(map[string]cty.Type{
+							"port":     cty.Number,
+							"protocol": cty.String,
+						})),
+					}),
+					InsideReferences: lang.References{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "root"},
+								lang.AttrStep{Name: "aws"},
+								lang.AttrStep{Name: "attr"},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start: hcl.Pos{
+									Line:   2,
+									Column: 3,
+									Byte:   20,
+								},
+								End: hcl.Pos{
+									Line:   2,
+									Column: 12,
+									Byte:   29,
+								},
+							},
+							Type: cty.Number,
+						},
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "root"},
+								lang.AttrStep{Name: "aws"},
+								lang.AttrStep{Name: "listblock"},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start: hcl.Pos{
+									Line:   11,
+									Column: 2,
+									Byte:   138,
+								},
+								End: hcl.Pos{
+									Line:   11,
+									Column: 2,
+									Byte:   138,
+								},
+							},
+							Type: cty.List(cty.Object(map[string]cty.Type{
+								"port":     cty.Number,
+								"protocol": cty.String,
+							})),
+							InsideReferences: lang.References{
+								{
+									Addr: lang.Address{
+										lang.RootStep{Name: "root"},
+										lang.AttrStep{Name: "aws"},
+										lang.AttrStep{Name: "listblock"},
+										lang.IndexStep{Key: cty.NumberIntVal(0)},
+										lang.AttrStep{Name: "port"},
+									},
+									RangePtr: &hcl.Range{
+										Filename: "test.tf",
+										Start: hcl.Pos{
+											Line:   4,
+											Column: 5,
+											Byte:   48,
+										},
+										End: hcl.Pos{
+											Line:   4,
+											Column: 14,
+											Byte:   57,
+										},
+									},
+									Type: cty.Number,
+								},
+								{
+									Addr: lang.Address{
+										lang.RootStep{Name: "root"},
+										lang.AttrStep{Name: "aws"},
+										lang.AttrStep{Name: "listblock"},
+										lang.IndexStep{Key: cty.NumberIntVal(0)},
+										lang.AttrStep{Name: "protocol"},
+									},
+									RangePtr: &hcl.Range{
+										Filename: "test.tf",
+										Start: hcl.Pos{
+											Line:   5,
+											Column: 5,
+											Byte:   62,
+										},
+										End: hcl.Pos{
+											Line:   5,
+											Column: 21,
+											Byte:   78,
+										},
+									},
+									Type: cty.String,
+								},
+								{
+									Addr: lang.Address{
+										lang.RootStep{Name: "root"},
+										lang.AttrStep{Name: "aws"},
+										lang.AttrStep{Name: "listblock"},
+										lang.IndexStep{Key: cty.NumberIntVal(1)},
+										lang.AttrStep{Name: "port"},
+									},
+									RangePtr: &hcl.Range{
+										Filename: "test.tf",
+										Start: hcl.Pos{
+											Line:   8,
+											Column: 5,
+											Byte:   101,
+										},
+										End: hcl.Pos{
+											Line:   8,
+											Column: 15,
+											Byte:   111,
+										},
+									},
+									Type: cty.Number,
+								},
+								{
+									Addr: lang.Address{
+										lang.RootStep{Name: "root"},
+										lang.AttrStep{Name: "aws"},
+										lang.AttrStep{Name: "listblock"},
+										lang.IndexStep{Key: cty.NumberIntVal(1)},
+										lang.AttrStep{Name: "protocol"},
+									},
+									RangePtr: &hcl.Range{
+										Filename: "test.tf",
+										Start: hcl.Pos{
+											Line:   9,
+											Column: 5,
+											Byte:   116,
+										},
+										End: hcl.Pos{
+											Line:   9,
+											Column: 21,
+											Byte:   132,
+										},
+									},
+									Type: cty.String,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"nested map blocks with inferred body data",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"load_balancer": {
+						Labels: []*schema.LabelSchema{
+							{Name: "name", IsDepKey: true},
+						},
+						Address: &schema.BlockAddrSchema{
+							Steps: []schema.AddrStep{
+								schema.StaticStep{Name: "lb"},
+								schema.LabelStep{Index: 0},
+							},
+							BodyAsData: true,
+							InferBody:  true,
+						},
+						Type: schema.BlockTypeObject,
+						Body: &schema.BodySchema{
+							Blocks: map[string]*schema.BlockSchema{
+								"listener": {
+									Labels: []*schema.LabelSchema{
+										{Name: "name"},
+									},
+									Type: schema.BlockTypeMap,
+									Body: &schema.BodySchema{
+										Attributes: map[string]*schema.AttributeSchema{
+											"protocol": {
+												Expr:       schema.LiteralTypeOnly(cty.String),
+												IsOptional: true,
+											},
+											"port": {
+												Expr:       schema.LiteralTypeOnly(cty.Number),
+												IsOptional: true,
+											},
+										},
+									},
+								},
+							},
+							Attributes: map[string]*schema.AttributeSchema{
+								"attr": {
+									Expr:       schema.LiteralTypeOnly(cty.Number),
+									IsOptional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			`load_balancer "aws" {
+  attr = 42
+  listener "http" {
+    port = 80
+    protocol = "tcp"
+  }
+  listener "https" {
+    port = 443
+  }
+}
+`,
+			lang.References{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "lb"},
+						lang.AttrStep{Name: "aws"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+							Byte:   0,
+						},
+						End: hcl.Pos{
+							Line:   10,
+							Column: 2,
+							Byte:   134,
+						},
+					},
+					Type: cty.Object(map[string]cty.Type{
+						"attr": cty.Number,
+						"listener": cty.Map(cty.Object(map[string]cty.Type{
+							"port":     cty.Number,
+							"protocol": cty.String,
+						})),
+					}),
+					InsideReferences: lang.References{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "lb"},
+								lang.AttrStep{Name: "aws"},
+								lang.AttrStep{Name: "attr"},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start: hcl.Pos{
+									Line:   2,
+									Column: 3,
+									Byte:   24,
+								},
+								End: hcl.Pos{
+									Line:   2,
+									Column: 12,
+									Byte:   33,
+								},
+							},
+							Type: cty.Number,
+						},
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "lb"},
+								lang.AttrStep{Name: "aws"},
+								lang.AttrStep{Name: "listener"},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start: hcl.Pos{
+									Line:   10,
+									Column: 2,
+									Byte:   134,
+								},
+								End: hcl.Pos{
+									Line:   10,
+									Column: 2,
+									Byte:   134,
+								},
+							},
+							Type: cty.Map(cty.Object(map[string]cty.Type{
+								"port":     cty.Number,
+								"protocol": cty.String,
+							})),
+							InsideReferences: lang.References{
+								{
+									Addr: lang.Address{
+										lang.RootStep{Name: "lb"},
+										lang.AttrStep{Name: "aws"},
+										lang.AttrStep{Name: "listener"},
+										lang.IndexStep{Key: cty.StringVal("http")},
+										lang.AttrStep{Name: "port"},
+									},
+									RangePtr: &hcl.Range{
+										Filename: "test.tf",
+										Start: hcl.Pos{
+											Line:   4,
+											Column: 5,
+											Byte:   58,
+										},
+										End: hcl.Pos{
+											Line:   4,
+											Column: 14,
+											Byte:   67,
+										},
+									},
+									Type: cty.Number,
+								},
+								{
+									Addr: lang.Address{
+										lang.RootStep{Name: "lb"},
+										lang.AttrStep{Name: "aws"},
+										lang.AttrStep{Name: "listener"},
+										lang.IndexStep{Key: cty.StringVal("http")},
+										lang.AttrStep{Name: "protocol"},
+									},
+									RangePtr: &hcl.Range{
+										Filename: "test.tf",
+										Start: hcl.Pos{
+											Line:   5,
+											Column: 5,
+											Byte:   72,
+										},
+										End: hcl.Pos{
+											Line:   5,
+											Column: 21,
+											Byte:   88,
+										},
+									},
+									Type: cty.String,
+								},
+								{
+									Addr: lang.Address{
+										lang.RootStep{Name: "lb"},
+										lang.AttrStep{Name: "aws"},
+										lang.AttrStep{Name: "listener"},
+										lang.IndexStep{Key: cty.StringVal("https")},
+										lang.AttrStep{Name: "port"},
+									},
+									RangePtr: &hcl.Range{
+										Filename: "test.tf",
+										Start: hcl.Pos{
+											Line:   8,
+											Column: 5,
+											Byte:   118,
+										},
+										End: hcl.Pos{
+											Line:   8,
+											Column: 15,
+											Byte:   128,
+										},
+									},
+									Type: cty.Number,
+								},
+								{
+									Addr: lang.Address{
+										lang.RootStep{Name: "lb"},
+										lang.AttrStep{Name: "aws"},
+										lang.AttrStep{Name: "listener"},
+										lang.IndexStep{Key: cty.StringVal("https")},
+										lang.AttrStep{Name: "protocol"},
+									},
+									RangePtr: &hcl.Range{
+										Filename: "test.tf",
+										Start: hcl.Pos{
+											Line:   9,
+											Column: 4,
+											Byte:   132,
+										},
+										End: hcl.Pos{
+											Line:   9,
+											Column: 4,
+											Byte:   132,
+										},
+									},
+									Type: cty.String,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"traversal reference",
+			&schema.BodySchema{
+				Attributes: map[string]*schema.AttributeSchema{
+					"testattr": {
+						IsOptional: true,
+						Expr: schema.ExprConstraints{
+							schema.TraversalExpr{
+								Address: &schema.TraversalAddrSchema{
+									ScopeId: lang.ScopeId("specialthing"),
+								},
+							},
+						},
+					},
+				},
+			},
+			`testattr = special.test
+`,
+			lang.References{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "special"},
+						lang.AttrStep{Name: "test"},
+					},
+					ScopeId: lang.ScopeId("specialthing"),
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 12,
+							Byte:   11,
+						},
+						End: hcl.Pos{
+							Line:   1,
+							Column: 24,
+							Byte:   23,
+						},
+					},
+				},
+			},
+		},
+		{
+			"block with attribute value in address",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"provider": {
+						Labels: []*schema.LabelSchema{
+							{Name: "name"},
+						},
+						Address: &schema.BlockAddrSchema{
+							Steps: []schema.AddrStep{
+								schema.LabelStep{Index: 0},
+								schema.AttrValueStep{Name: "alias"},
+							},
+							ScopeId:     lang.ScopeId("provider"),
+							AsReference: true,
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"alias": {
+									IsOptional: true,
+									Expr:       schema.LiteralTypeOnly(cty.String),
+								},
+							},
+						},
+					},
+				},
+			},
+			`provider "aws" {
+  alias = "euwest"
+}
+`,
+			lang.References{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "aws"},
+						lang.AttrStep{Name: "euwest"},
+					},
+					ScopeId: lang.ScopeId("provider"),
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+							Byte:   0,
+						},
+						End: hcl.Pos{
+							Line:   3,
+							Column: 2,
+							Byte:   37,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {
+			d := NewDecoder()
+			d.SetSchema(tc.schema)
+
+			f, _ := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+			err := d.LoadFile("test.tf", f)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			refs, err := d.DecodeReferences()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedRefs, refs, ctydebug.CmpOptions); diff != "" {
+				t.Fatalf("mismatch of references: %s", diff)
+			}
+		})
+	}
+}

--- a/decoder/symbols.go
+++ b/decoder/symbols.go
@@ -41,7 +41,6 @@ func (d *Decoder) Symbols(query string) ([]Symbol, error) {
 	symbols := make([]Symbol, 0)
 
 	files := d.Filenames()
-	sort.Strings(files)
 
 	for _, filename := range files {
 		fSymbols, err := d.SymbolsInFile(filename)

--- a/lang/candidate.go
+++ b/lang/candidate.go
@@ -22,6 +22,7 @@ const (
 	SetCandidateKind
 	StringCandidateKind
 	TupleCandidateKind
+	TraversalCandidateKind
 )
 
 //go:generate stringer -type=CandidateKind -output=candidate_kind_string.go

--- a/lang/candidate_kind_string.go
+++ b/lang/candidate_kind_string.go
@@ -21,11 +21,12 @@ func _() {
 	_ = x[SetCandidateKind-10]
 	_ = x[StringCandidateKind-11]
 	_ = x[TupleCandidateKind-12]
+	_ = x[TraversalCandidateKind-13]
 }
 
-const _CandidateKind_name = "NilCandidateKindAttributeCandidateKindBlockCandidateKindLabelCandidateKindBoolCandidateKindKeywordCandidateKindListCandidateKindMapCandidateKindNumberCandidateKindObjectCandidateKindSetCandidateKindStringCandidateKindTupleCandidateKind"
+const _CandidateKind_name = "NilCandidateKindAttributeCandidateKindBlockCandidateKindLabelCandidateKindBoolCandidateKindKeywordCandidateKindListCandidateKindMapCandidateKindNumberCandidateKindObjectCandidateKindSetCandidateKindStringCandidateKindTupleCandidateKindTraversalCandidateKind"
 
-var _CandidateKind_index = [...]uint8{0, 16, 38, 56, 74, 91, 111, 128, 144, 163, 182, 198, 217, 235}
+var _CandidateKind_index = [...]uint16{0, 16, 38, 56, 74, 91, 111, 128, 144, 163, 182, 198, 217, 235, 257}
 
 func (i CandidateKind) String() string {
 	if i >= CandidateKind(len(_CandidateKind_index)-1) {

--- a/lang/references.go
+++ b/lang/references.go
@@ -1,0 +1,58 @@
+package lang
+
+import (
+	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+)
+
+type ScopeId string
+
+type Reference struct {
+	Addr     Address
+	ScopeId  ScopeId
+	RangePtr *hcl.Range
+
+	Type        cty.Type
+	Name        string
+	Description MarkupContent
+
+	InsideReferences References
+}
+
+type References []Reference
+
+func (r References) Len() int {
+	return len(r)
+}
+
+func (r References) Less(i, j int) bool {
+	return r[i].Addr.String() < r[j].Addr.String()
+}
+
+func (r References) Swap(i, j int) {
+	r[i], r[j] = r[j], r[i]
+}
+
+func (r Reference) Address() Address {
+	return r.Addr
+}
+
+func (r Reference) FriendlyName() string {
+	if r.Name != "" {
+		return r.Name
+	}
+
+	if r.Type != cty.NilType {
+		return r.Type.FriendlyName()
+	}
+
+	return "reference"
+}
+
+func (r Reference) TargetRange() (hcl.Range, bool) {
+	if r.RangePtr == nil {
+		return hcl.Range{}, false
+	}
+
+	return *r.RangePtr, true
+}

--- a/lang/semantic_token.go
+++ b/lang/semantic_token.go
@@ -30,6 +30,7 @@ const (
 	TokenObjectKey
 	TokenMapKey
 	TokenKeyword
+	TokenTraversalStep
 )
 
 func (t SemanticTokenType) GoString() string {

--- a/lang/semantic_token_type_string.go
+++ b/lang/semantic_token_type_string.go
@@ -18,11 +18,12 @@ func _() {
 	_ = x[TokenObjectKey-7]
 	_ = x[TokenMapKey-8]
 	_ = x[TokenKeyword-9]
+	_ = x[TokenTraversalStep-10]
 }
 
-const _SemanticTokenType_name = "TokenNilTokenAttrNameTokenBlockTypeTokenBlockLabelTokenBoolTokenStringTokenNumberTokenObjectKeyTokenMapKeyTokenKeyword"
+const _SemanticTokenType_name = "TokenNilTokenAttrNameTokenBlockTypeTokenBlockLabelTokenBoolTokenStringTokenNumberTokenObjectKeyTokenMapKeyTokenKeywordTokenTraversalStep"
 
-var _SemanticTokenType_index = [...]uint8{0, 8, 21, 35, 50, 59, 70, 81, 95, 106, 118}
+var _SemanticTokenType_index = [...]uint8{0, 8, 21, 35, 50, 59, 70, 81, 95, 106, 118, 136}
 
 func (i SemanticTokenType) String() string {
 	if i >= SemanticTokenType(len(_SemanticTokenType_index)-1) {

--- a/schema/address_step.go
+++ b/schema/address_step.go
@@ -1,0 +1,38 @@
+package schema
+
+type addrStepImplSigil struct{}
+
+type AddrStep interface {
+	isAddrStepImpl() addrStepImplSigil
+}
+
+type StaticStep struct {
+	Name string
+}
+
+func (StaticStep) isAddrStepImpl() addrStepImplSigil {
+	return addrStepImplSigil{}
+}
+
+type LabelStep struct {
+	Index uint
+}
+
+func (LabelStep) isAddrStepImpl() addrStepImplSigil {
+	return addrStepImplSigil{}
+}
+
+type AttrNameStep struct{}
+
+func (AttrNameStep) isAddrStepImpl() addrStepImplSigil {
+	return addrStepImplSigil{}
+}
+
+type AttrValueStep struct {
+	Name       string
+	IsOptional bool
+}
+
+func (AttrValueStep) isAddrStepImpl() addrStepImplSigil {
+	return addrStepImplSigil{}
+}

--- a/schema/block_schema.go
+++ b/schema/block_schema.go
@@ -1,6 +1,10 @@
 package schema
 
 import (
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/hcl-lang/lang"
 )
 
@@ -16,8 +20,82 @@ type BlockSchema struct {
 	IsDeprecated bool
 	MinItems     uint64
 	MaxItems     uint64
+
+	Address *BlockAddrSchema
+}
+
+type BlockAddrSchema struct {
+	Steps []AddrStep
+
+	FriendlyName string
+	ScopeId      lang.ScopeId
+
+	// AsReference defines whether the block itself
+	// is addressable as a type-less reference
+	AsReference bool
+
+	// BodyAsData defines whether the data in the block body
+	// is addressable as cty.Object or cty.List(cty.Object),
+	// cty.Set(cty.Object) etc. depending on block type
+	BodyAsData bool
+	// InferBody defines whether (static) Body's
+	// blocks and attributes are also walked
+	// and their addresses inferred as data
+	InferBody bool
+
+	// DependentBodyAsData defines whether the data in
+	// the dependent block body is addressable as cty.Object
+	// or cty.List(cty.Object), cty.Set(cty.Object) etc.
+	// depending on block type
+	DependentBodyAsData bool
+	// InferDependentBody defines whether DependentBody's
+	// blocks and attributes are also walked
+	// and their addresses inferred as data
+	InferDependentBody bool
+}
+
+func (as *BlockAddrSchema) Validate() error {
+	for i, step := range as.Steps {
+		if _, ok := step.(AttrNameStep); ok {
+			return fmt.Errorf("Steps[%d]: AttrNameStep is not valid for attribute", i)
+		}
+	}
+
+	if as.InferBody && !as.BodyAsData {
+		return errors.New("InferBody requires BodyAsData")
+	}
+
+	if as.InferDependentBody && !as.DependentBodyAsData {
+		return errors.New("InferDependentBody requires DependentBodyAsData")
+	}
+
+	return nil
 }
 
 func (*BlockSchema) isSchemaImpl() schemaImplSigil {
 	return schemaImplSigil{}
+}
+
+func (bSchema *BlockSchema) Validate() error {
+	var errs *multierror.Error
+
+	if bSchema.Address != nil {
+		err := bSchema.Address.Validate()
+		if err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("Address: %w", err))
+		}
+	}
+
+	if bSchema.Body != nil {
+		err := bSchema.Body.Validate()
+		if err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("Body: %w", err))
+		}
+	}
+
+	if errs != nil && len(errs.Errors) == 1 {
+		return errs.Errors[0]
+	}
+
+	return errs.ErrorOrNil()
 }

--- a/schema/block_schema_test.go
+++ b/schema/block_schema_test.go
@@ -1,0 +1,79 @@
+package schema
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestBlockSchema_Validate(t *testing.T) {
+	testCases := []struct {
+		schema      *BlockSchema
+		expectedErr error
+	}{
+		{ // empty block (with just type) is valid
+			&BlockSchema{},
+			nil,
+		},
+		{
+			&BlockSchema{
+				Address: &BlockAddrSchema{
+					Steps: []AddrStep{
+						AttrNameStep{},
+					},
+				},
+			},
+			errors.New("Address: Steps[0]: AttrNameStep is not valid for attribute"),
+		},
+		{
+			&BlockSchema{
+				Labels: []*LabelSchema{
+					{Name: "name"},
+				},
+				Address: &BlockAddrSchema{
+					Steps: []AddrStep{
+						LabelStep{Index: 0},
+					},
+				},
+			},
+			nil,
+		},
+		{
+			&BlockSchema{
+				Address: &BlockAddrSchema{
+					Steps: []AddrStep{
+						StaticStep{Name: "bleh"},
+					},
+					InferBody: true,
+				},
+			},
+			errors.New("Address: InferBody requires BodyAsData"),
+		},
+		{
+			&BlockSchema{
+				Address: &BlockAddrSchema{
+					Steps: []AddrStep{
+						StaticStep{Name: "bleh"},
+					},
+					InferDependentBody: true,
+				},
+			},
+			errors.New("Address: InferDependentBody requires DependentBodyAsData"),
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			err := tc.schema.Validate()
+			if tc.expectedErr == nil && err != nil {
+				t.Fatal(err)
+			}
+			if tc.expectedErr != nil && err == nil {
+				t.Fatalf("expected error: %q, none given", tc.expectedErr.Error())
+			}
+			if tc.expectedErr != nil && tc.expectedErr.Error() != err.Error() {
+				t.Fatalf("error mismatch,\nexpected: %q\ngiven: %q", tc.expectedErr.Error(), err.Error())
+			}
+		})
+	}
+}

--- a/schema/block_type.go
+++ b/schema/block_type.go
@@ -15,7 +15,6 @@ const (
 	BlockTypeMap
 	BlockTypeObject
 	BlockTypeSet
-	BlockTypeTuple
 )
 
 func (t BlockType) String() string {
@@ -28,8 +27,6 @@ func (t BlockType) String() string {
 		return "object"
 	case BlockTypeSet:
 		return "set"
-	case BlockTypeTuple:
-		return "tuple"
 	}
 	return ""
 }
@@ -44,8 +41,6 @@ func (t BlockType) GoString() string {
 		return "BlockTypeObject"
 	case BlockTypeSet:
 		return "BlockTypeSet"
-	case BlockTypeTuple:
-		return "BlockTypeTuple"
 	}
 	return fmt.Sprintf("BlockType(%d)", t)
 }

--- a/schema/body_schema.go
+++ b/schema/body_schema.go
@@ -48,22 +48,19 @@ func (bs *BodySchema) Validate() error {
 	for name, attr := range bs.Attributes {
 		err := attr.Validate()
 		if err != nil {
-			result = multierror.Append(result, fmt.Errorf("%s: %s", name, err))
+			result = multierror.Append(result, fmt.Errorf("%s: %w", name, err))
 		}
 	}
 
 	for bType, block := range bs.Blocks {
-		if block.Body == nil {
-			continue
-		}
-		err := block.Body.Validate()
+		err := block.Validate()
 		if err != nil {
 			if me, ok := err.(*multierror.Error); ok {
 				for _, err := range me.Errors {
-					result = multierror.Append(result, fmt.Errorf("%s: %s", bType, err))
+					result = multierror.Append(result, fmt.Errorf("%s: %w", bType, err))
 				}
 			} else {
-				result = multierror.Append(result, fmt.Errorf("%s: %s", bType, err))
+				result = multierror.Append(result, fmt.Errorf("%s: %w", bType, err))
 			}
 		}
 	}

--- a/schema/expressions_test.go
+++ b/schema/expressions_test.go
@@ -1,0 +1,10 @@
+package schema
+
+var (
+	_ ExprConstraint = LiteralTypeExpr{}
+	_ ExprConstraint = LiteralValue{}
+	_ ExprConstraint = TupleConsExpr{}
+	_ ExprConstraint = MapExpr{}
+	_ ExprConstraint = KeywordExpr{}
+	_ ExprConstraint = TraversalExpr{}
+)


### PR DESCRIPTION
Closes #2

--- 

## (Schema) Reference types

In general the schema recognizes two types of references - (1) type-aware, and (2) type-less

In Terraform type-aware references are commonly used to set values of fields via reference. For example:

```hcl
key_name = aws_key_pair.iac_in_action.key_name
```
Here `key_name` is of type `string` and relatedly `aws_key_pair.iac_in_action.key_name` points to a field of type `string`.

Type-less references are used to draw an explicit dependency between resources, e.g.

```hcl
resource "aws_instance" "example" {
// ...
  depends_on = [ aws_s3_bucket.example ]
}
resource "aws_s3_bucket" "example" {
// ...
}
```

Here in this particular context of `depends_on`, `aws_s3_bucket.example` only represents a "pointer" to the lower block, but isn't concerned about what data (whether any) it points to.

### Type Declaration

It is only possible to declare type explicitly via the schema. e.g. schema sets `name` to `string` and that's what it will always be.

More dynamic declaration and inference would be also useful in Terraform, specifically for variables, where variable type is declared within the config, or is inferred in case of `local`s. This seemed like a scope-creep in this MVP, so I left it out, but it's certainly something to revisit.

TODO: Create issue for this.

--- 

There can be cases where the same address (such as `aws_s3_bucket.example`) can be type-less and type-aware, it only depends on the context. This is why we allow references with the same address to exist and then filter based on context.

## Functionality

This PR adds support for traversal expressions in the following areas:

### Completion

This is the trickiest and most complex part with most edge cases - many of which are yet to be covered in follow-up PRs.

Currently we decode all steps of a traversal and also return such "fully expanded" traversals instead of letting the user complete step-by-step.

e.g. given a config & schema

```hcl
resource "aws_lb" "example" {
  listener {
    port = 80
    protocol = "tcp"
  }
}
```
we would complete just `aws_lb.example.listener[0].protocol` for traversal of type `string` and `aws_lb.example.listener[0].port` for traversal of type `number`. This may be good/better UX in this particular context and small snippet, but might not scale with larger configurations.

The internal structure will allow us to explore some alternative approaches though and possibly even combine them, so that e.g. we can complete just all resource types (e.g. `aws_lb`), then after `.` we complete all reference names for that resource type (e.g. `example`), then after `.` all the attributes of that particular resource instance and so on.

The completion does _not_ take any external sources (such as Terraform state) into effect, but relies purely on configuration and schema. This means that e.g. if a map/list/set has some elements computed outside of the configuration these would _NOT_ be surfaced as elements of a given field via `[0]`, `[1]`, `["key"]` etc. This will likely be a useful feature for Terraform, but it is intentionally left out from this MVP for complexity.

Another edge case which is not entirely related to this PR, but perhaps becomes more visible is that we don't provide completion inside nested expressions in most cases yet. I implemented some of the simple ones, such as

```hcl
depends_on = [ HERE ]
```
where `depends_on` is `SetExpr`, but only where the wrapping expression (SetExpr, ListExpr) is empty - i.e. for the first element only. Again - this is certainly something that _should_ be implemented, but was left out for complexity.

### Hover

Due to the way things are structured, we would only provide hover data for a matching reference, for example

```hcl
number_field = data.aws_instance.example.number_field # hover data here
```
```hcl
number_field = data.aws_instance.example.string_field # hover data NOT available here
```

I believe this is ok trade-off for now, but we can revisit later, if necessary.

### Semantic Tokens

The same limitation as in hover applies here - if the traversal expression doesn't exist/match, then it won't be reported as token at all.

There is a new token type `lang.TokenTraversalStep` which represents the parts between dots in addresses. This is cleaner than reporting the whole traversal as token, because clients could otherwise paint it all the same colour (including index numbers/keys, brackets and dots).

We could go further here and report individual tokens with some more context/meaning, but this would also require collecting such meaning via schema somehow. See https://github.com/hashicorp/vscode-terraform/issues/574 for related discussion.