### PR TITLE
BodySchema: Introduce (dedicated) HoverURL

### DIFF
--- a/decoder/hover.go
+++ b/decoder/hover.go
@@ -163,9 +163,8 @@ func (d *Decoder) hoverContentForLabel(i int, block *hclsyntax.Block, bSchema *s
 				content += "\n\n" + labelSchema.Description.Value
 			}
 
-			if bs.DocsLink != nil {
-				link := bs.DocsLink
-				u, err := d.docsURL(link.URL, "documentHover")
+			if bs.HoverURL != "" {
+				u, err := d.docsURL(bs.HoverURL, "documentHover")
 				if err == nil {
 					content += fmt.Sprintf("\n\n[`%s` on %s](%s)",
 						value, u.Hostname(), u.String())

--- a/schema/body_schema.go
+++ b/schema/body_schema.go
@@ -17,7 +17,14 @@ type BodySchema struct {
 	Detail       string
 	Description  lang.MarkupContent
 
+	// DocsLink represents a link to docs that will be exposed
+	// as part of LinksInFile()
 	DocsLink *DocsLink
+
+	// HoverURL represents a URL that will be appended to the end
+	// of hover data in HoverAtPos(). This can differ from DocsLink,
+	// but often will match.
+	HoverURL string
 
 	// TODO: Functions
 }
@@ -78,6 +85,7 @@ func (bs *BodySchema) Copy() *BodySchema {
 		Detail:       bs.Detail,
 		Description:  bs.Description,
 		AnyAttribute: bs.AnyAttribute.Copy(),
+		HoverURL:     bs.HoverURL,
 		DocsLink:     bs.DocsLink.Copy(),
 	}
 


### PR DESCRIPTION
For provider linking we initially wanted (and still want) links both in hover and explicitly exposed via `LinksInFile` and corresponding [`textDocument/documentLink` LSP method](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_documentLink).

However there are cases where direct linking would be too distracting and inappropriate, given how it's implemented in VS Code and probably elsewhere. In other words we don't want so much code to be underlined all the time.

Providing a link in a more subtle way in hover data is still valuable, so this field aims to strike the balance.