### PR TITLE
Provide relevant HoverURL in hover over block types

### DIFF
--- a/decoder/hover.go
+++ b/decoder/hover.go
@@ -94,7 +94,7 @@ func (d *Decoder) hoverAtPos(body *hclsyntax.Body, bodySchema *schema.BodySchema
 
 			if block.TypeRange.ContainsPos(pos) {
 				return &lang.HoverData{
-					Content: hoverContentForBlock(block.Type, bSchema),
+					Content: d.hoverContentForBlock(block.Type, bSchema),
 					Range:   block.TypeRange,
 				}, nil
 			}
@@ -198,11 +198,20 @@ func hoverContentForAttribute(name string, schema *schema.AttributeSchema) lang.
 	}
 }
 
-func hoverContentForBlock(bType string, schema *schema.BlockSchema) lang.MarkupContent {
+func (d *Decoder) hoverContentForBlock(bType string, schema *schema.BlockSchema) lang.MarkupContent {
 	value := fmt.Sprintf("**%s** _%s_", bType, detailForBlock(schema))
 	if schema.Description.Value != "" {
 		value += fmt.Sprintf("\n\n%s", schema.Description.Value)
 	}
+
+	if schema.Body.HoverURL != "" {
+		u, err := d.docsURL(schema.Body.HoverURL, "documentHover")
+		if err == nil {
+			value += fmt.Sprintf("\n\n[`%s` on %s](%s)",
+				bType, u.Hostname(), u.String())
+		}
+	}
+
 	return lang.MarkupContent{
 		Kind:  lang.MarkdownKind,
 		Value: value,

--- a/decoder/hover_test.go
+++ b/decoder/hover_test.go
@@ -418,8 +418,9 @@ func TestDecoder_HoverAtPos_URL(t *testing.T) {
 	}
 	blockSchema := &schema.BlockSchema{
 		Labels:      resourceLabelSchema,
-		Description: lang.Markdown("My special block"),
+		Description: lang.Markdown("My food block"),
 		Body: &schema.BodySchema{
+			HoverURL: "https://en.wikipedia.org/wiki/Food",
 			Attributes: map[string]*schema.AttributeSchema{
 				"any_attr": {Expr: schema.LiteralTypeOnly(cty.Number)},
 			},
@@ -522,6 +523,41 @@ Sushi, the Rolls-Rice of Japanese cuisine
 						Line:   1,
 						Column: 16,
 						Byte:   15,
+					},
+				},
+			},
+		},
+		{
+			"",
+			`myblock "ramen" "tonkotsu" {
+  any_attr = 42
+}
+`,
+			hcl.Pos{
+				Line:   1,
+				Column: 2,
+				Byte:   1,
+			},
+			&lang.HoverData{
+				Content: lang.MarkupContent{
+					Value: `**myblock** _Block_
+
+My food block
+
+[` + "`myblock`" + ` on en.wikipedia.org](https://en.wikipedia.org/wiki/Food)`,
+					Kind: lang.MarkdownKind,
+				},
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start: hcl.Pos{
+						Line:   1,
+						Column: 1,
+						Byte:   0,
+					},
+					End: hcl.Pos{
+						Line:   1,
+						Column: 8,
+						Byte:   7,
 					},
 				},
 			},


### PR DESCRIPTION
Previously we only added links to dependent labels on hover.

This also enables links for block types:

![Screenshot 2021-06-03 at 12 10 32](https://user-images.githubusercontent.com/287584/120635725-b78a4d00-c464-11eb-9758-ce6cd2f3ae23.png)
![Screenshot 2021-06-03 at 12 10 23](https://user-images.githubusercontent.com/287584/120635729-b822e380-c464-11eb-94ad-06cc854eea77.png)
