### PR TITLE
schema: Make types of references more flexible

### DIFF
--- a/schema/attribute_schema.go
+++ b/schema/attribute_schema.go
@@ -33,10 +33,13 @@ type AttributeAddrSchema struct {
 	FriendlyName string
 	ScopeId      lang.ScopeId
 
-	// AsData defines whether the value of the attribute
-	// is addressable as a matching literal type
-	// included in Expr
-	AsData bool
+	// AsExprType defines whether the value of the attribute
+	// is addressable as a matching literal type constraint included
+	// in attribute Expr.
+	//
+	// cty.DynamicPseudoType (also known as "any type") will create
+	// reference of the real type if value is present else cty.DynamicPseudoType.
+	AsExprType bool
 
 	// AsReference defines whether the attribute
 	// is addressable as a type-less reference
@@ -61,8 +64,8 @@ func (as *AttributeSchema) Validate() error {
 	}
 
 	if as.Address != nil {
-		if !as.Address.AsData && !as.Address.AsReference {
-			return fmt.Errorf("Address: at least one of AsData or AsReference must be set")
+		if !as.Address.AsExprType && !as.Address.AsReference {
+			return fmt.Errorf("Address: at least one of AsExprType or AsReference must be set")
 		}
 
 		for i, step := range as.Address.Steps {
@@ -92,7 +95,28 @@ func (as *AttributeSchema) Copy() *AttributeSchema {
 		IsDepKey:     as.IsDepKey,
 		Description:  as.Description,
 		Expr:         as.Expr.Copy(),
+		Address:      as.Address.Copy(),
 	}
 
 	return newAs
+}
+
+func (aas *AttributeAddrSchema) Copy() *AttributeAddrSchema {
+	if aas == nil {
+		return nil
+	}
+
+	newAas := &AttributeAddrSchema{
+		FriendlyName: aas.FriendlyName,
+		ScopeId:      aas.ScopeId,
+		AsExprType:   aas.AsExprType,
+		AsReference:  aas.AsReference,
+	}
+
+	newAas.Steps = make([]AddrStep, len(aas.Steps))
+	for i, step := range aas.Steps {
+		newAas.Steps[i] = step
+	}
+
+	return newAas
 }

--- a/schema/attribute_schema_test.go
+++ b/schema/attribute_schema_test.go
@@ -145,7 +145,7 @@ func TestAttributeSchema_Validate(t *testing.T) {
 				},
 				IsOptional: true,
 			},
-			errors.New("Address: at least one of AsData or AsReference must be set"),
+			errors.New("Address: at least one of AsExprType or AsReference must be set"),
 		},
 		{
 			&AttributeSchema{
@@ -154,7 +154,7 @@ func TestAttributeSchema_Validate(t *testing.T) {
 						AttrNameStep{},
 					},
 					AsReference: true,
-					AsData:      true,
+					AsExprType:  true,
 				},
 				IsOptional: true,
 			},

--- a/schema/block_schema.go
+++ b/schema/block_schema.go
@@ -44,20 +44,41 @@ type BlockAddrSchema struct {
 	// is addressable as cty.Object or cty.List(cty.Object),
 	// cty.Set(cty.Object) etc. depending on block type
 	BodyAsData bool
+
 	// InferBody defines whether (static) Body's
 	// blocks and attributes are also walked
 	// and their addresses inferred as data
 	InferBody bool
+
+	// AsTypeOf makes the block addressable based on type
+	// of an attribute
+	AsTypeOf *BlockAsTypeOf
 
 	// DependentBodyAsData defines whether the data in
 	// the dependent block body is addressable as cty.Object
 	// or cty.List(cty.Object), cty.Set(cty.Object) etc.
 	// depending on block type
 	DependentBodyAsData bool
+
 	// InferDependentBody defines whether DependentBody's
 	// blocks and attributes are also walked
 	// and their addresses inferred as data
 	InferDependentBody bool
+}
+
+type BlockAsTypeOf struct {
+	// AttributeExpr defines whether the block
+	// is addressable as a particular type declared
+	// directly as expression of the attribute
+	AttributeExpr string
+
+	// AttributeValue defines whether the block
+	// is addressable as a type of the attribute value.
+	//
+	// This will be used as a fallback if AttributeExpr
+	// is also defined, or when the attribute defined there
+	// is of cty.DynamicPseudoType.
+	AttributeValue string
 }
 
 func (bas *BlockAddrSchema) Validate() error {
@@ -87,6 +108,7 @@ func (bas *BlockAddrSchema) Copy() *BlockAddrSchema {
 		FriendlyName:        bas.FriendlyName,
 		ScopeId:             bas.ScopeId,
 		AsReference:         bas.AsReference,
+		AsTypeOf:            bas.AsTypeOf.Copy(),
 		BodyAsData:          bas.BodyAsData,
 		InferBody:           bas.InferBody,
 		DependentBodyAsData: bas.DependentBodyAsData,
@@ -99,6 +121,17 @@ func (bas *BlockAddrSchema) Copy() *BlockAddrSchema {
 	}
 
 	return newBas
+}
+
+func (bato *BlockAsTypeOf) Copy() *BlockAsTypeOf {
+	if bato == nil {
+		return nil
+	}
+
+	return &BlockAsTypeOf{
+		AttributeExpr:  bato.AttributeExpr,
+		AttributeValue: bato.AttributeValue,
+	}
 }
 
 func (*BlockSchema) isSchemaImpl() schemaImplSigil {


### PR DESCRIPTION
This enables the schema to represent Terraform's locals and variables, including untyped variable defaults.

Related to https://github.com/hashicorp/terraform-ls/issues/491
