### PR TITLE
schema/decoder: Make label completion more flexible

### DIFF
--- a/decoder/candidates.go
+++ b/decoder/candidates.go
@@ -111,6 +111,12 @@ func (d *Decoder) candidatesAtPos(body *hclsyntax.Body, outerBodyRng hcl.Range, 
 					}
 					prefixRng.End = pos
 
+					labelSchema := bSchema.Labels[i]
+
+					if !labelSchema.Completable {
+						return lang.ZeroCandidates(), nil
+					}
+
 					return d.labelCandidatesFromDependentSchema(i, bSchema.DependentBody, prefixRng, rng)
 				}
 			}

--- a/schema/label_schema.go
+++ b/schema/label_schema.go
@@ -12,6 +12,11 @@ type LabelSchema struct {
 	// IsDepKey describes whether to use this label as key
 	// when looking up dependent schema
 	IsDepKey bool
+
+	// In cases where label's IsDepKey=true any DependentKey label values
+	// within Blocks's DependentBody can be used for completion
+	// This enables such behaviour.
+	Completable bool
 }
 
 func (*LabelSchema) isSchemaImpl() schemaImplSigil {
@@ -25,6 +30,7 @@ func (ls *LabelSchema) Copy() *LabelSchema {
 
 	return &LabelSchema{
 		Name:        ls.Name,
+		Completable: ls.Completable,
 		Description: ls.Description,
 		IsDepKey:    ls.IsDepKey,
 	}


### PR DESCRIPTION
This aims to address an edge case where dependent body schemas are in use, but using them for completion wouldn't be appropriate.

See https://github.com/hashicorp/terraform-ls/issues/552 for more concrete example with variables.
