### PR TITLE
Introduce `ReferenceOriginAtPos` & `ReferenceTargetForOrigin`

### DIFF
--- a/decoder/expression_candidates.go
+++ b/decoder/expression_candidates.go
@@ -330,12 +330,12 @@ func (d *Decoder) candidatesForTraversalConstraint(tc schema.TraversalExpr, oute
 
 	refs := ReferenceTargets(d.refTargetReader())
 
-	refs.MatchWalk(tc, string(prefix), func(ref lang.ReferenceTarget) {
+	refs.MatchWalk(tc, string(prefix), func(ref lang.ReferenceTarget) error {
 		// avoid suggesting references to block's own fields from within (for now)
 		if ref.RangePtr != nil &&
 			(outerBodyRng.ContainsPos(ref.RangePtr.Start) ||
 				posEqual(outerBodyRng.End, ref.RangePtr.End)) {
-			return
+			return nil
 		}
 
 		candidates = append(candidates, lang.Candidate{
@@ -349,6 +349,7 @@ func (d *Decoder) candidatesForTraversalConstraint(tc schema.TraversalExpr, oute
 				Range:   editRng,
 			},
 		})
+		return nil
 	})
 
 	return candidates

--- a/decoder/reference_origins.go
+++ b/decoder/reference_origins.go
@@ -1,0 +1,62 @@
+package decoder
+
+import (
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+// ReferenceOriginAtPos returns the ReferenceOrigin
+// enclosing the position in a file, if one exists, else nil
+func (d *Decoder) ReferenceOriginAtPos(filename string, pos hcl.Pos) (*lang.ReferenceOrigin, error) {
+	f, err := d.fileByName(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	rootBody, err := d.bodyForFileAndPos(filename, f, pos)
+	if err != nil {
+		return nil, err
+	}
+
+	return d.referenceOriginAtPos(rootBody, pos)
+}
+
+func (d *Decoder) referenceOriginAtPos(body *hclsyntax.Body, pos hcl.Pos) (*lang.ReferenceOrigin, error) {
+	for _, attr := range body.Attributes {
+		if d.isPosInsideAttrExpr(attr, pos) {
+			traversal, ok := d.traversalAtPos(attr.Expr, pos)
+			if ok {
+				addr, err := lang.TraversalToAddress(traversal)
+				if err == nil {
+					return &lang.ReferenceOrigin{
+						Addr:  addr,
+						Range: traversal.SourceRange(),
+					}, nil
+				}
+			}
+
+			return nil, nil
+		}
+	}
+
+	for _, block := range body.Blocks {
+		if block.Range().ContainsPos(pos) {
+			if block.Body != nil && block.Body.Range().ContainsPos(pos) {
+				return d.referenceOriginAtPos(block.Body, pos)
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+func (d *Decoder) traversalAtPos(expr hclsyntax.Expression, pos hcl.Pos) (hcl.Traversal, bool) {
+	for _, traversal := range expr.Variables() {
+		if traversal.SourceRange().ContainsPos(pos) {
+			return traversal, true
+		}
+	}
+
+	return nil, false
+}

--- a/decoder/reference_origins_test.go
+++ b/decoder/reference_origins_test.go
@@ -1,0 +1,211 @@
+package decoder
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty-debug/ctydebug"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestReferenceOriginAtPos(t *testing.T) {
+	testCases := []struct {
+		name           string
+		cfg            string
+		pos            hcl.Pos
+		expectedOrigin *lang.ReferenceOrigin
+	}{
+		{
+			"empty config",
+			``,
+			hcl.InitialPos,
+			nil,
+		},
+		{
+			"single-step traversal in root attribute",
+			`attr = blah`,
+			hcl.Pos{
+				Line:   1,
+				Column: 9,
+				Byte:   8,
+			},
+			&lang.ReferenceOrigin{
+				Addr: lang.Address{
+					lang.RootStep{Name: "blah"},
+				},
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start: hcl.Pos{
+						Line:   1,
+						Column: 8,
+						Byte:   7,
+					},
+					End: hcl.Pos{
+						Line:   1,
+						Column: 12,
+						Byte:   11,
+					},
+				},
+			},
+		},
+		{
+			"string literal in root attribute",
+			`attr = "blah"`,
+			hcl.Pos{
+				Line:   1,
+				Column: 9,
+				Byte:   8,
+			},
+			nil,
+		},
+		{
+			"multi-step traversal in root attribute",
+			`attr = var.myobj.attr.foo.bar`,
+			hcl.Pos{
+				Line:   1,
+				Column: 9,
+				Byte:   8,
+			},
+			&lang.ReferenceOrigin{
+				Addr: lang.Address{
+					lang.RootStep{Name: "var"},
+					lang.AttrStep{Name: "myobj"},
+					lang.AttrStep{Name: "attr"},
+					lang.AttrStep{Name: "foo"},
+					lang.AttrStep{Name: "bar"},
+				},
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start: hcl.Pos{
+						Line:   1,
+						Column: 8,
+						Byte:   7,
+					},
+					End: hcl.Pos{
+						Line:   1,
+						Column: 30,
+						Byte:   29,
+					},
+				},
+			},
+		},
+		{
+			"multi-step traversal with map index step in root attribute",
+			`attr = var.myobj.mapattr["key"]`,
+			hcl.Pos{
+				Line:   1,
+				Column: 9,
+				Byte:   8,
+			},
+			&lang.ReferenceOrigin{
+				Addr: lang.Address{
+					lang.RootStep{Name: "var"},
+					lang.AttrStep{Name: "myobj"},
+					lang.AttrStep{Name: "mapattr"},
+					lang.IndexStep{Key: cty.StringVal("key")},
+				},
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start: hcl.Pos{
+						Line:   1,
+						Column: 8,
+						Byte:   7,
+					},
+					End: hcl.Pos{
+						Line:   1,
+						Column: 32,
+						Byte:   31,
+					},
+				},
+			},
+		},
+		{
+			"multi-step traversal with list index step in root attribute",
+			`attr = var.myobj.listattr[4]`,
+			hcl.Pos{
+				Line:   1,
+				Column: 9,
+				Byte:   8,
+			},
+			&lang.ReferenceOrigin{
+				Addr: lang.Address{
+					lang.RootStep{Name: "var"},
+					lang.AttrStep{Name: "myobj"},
+					lang.AttrStep{Name: "listattr"},
+					lang.IndexStep{Key: cty.NumberIntVal(4)},
+				},
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start: hcl.Pos{
+						Line:   1,
+						Column: 8,
+						Byte:   7,
+					},
+					End: hcl.Pos{
+						Line:   1,
+						Column: 29,
+						Byte:   28,
+					},
+				},
+			},
+		},
+		{
+			"multi-step traversal in block body",
+			`customblock "foo" {
+  attr = var.myobj.listattr[4]
+}
+`,
+			hcl.Pos{
+				Line:   2,
+				Column: 11,
+				Byte:   30,
+			},
+			&lang.ReferenceOrigin{
+				Addr: lang.Address{
+					lang.RootStep{Name: "var"},
+					lang.AttrStep{Name: "myobj"},
+					lang.AttrStep{Name: "listattr"},
+					lang.IndexStep{Key: cty.NumberIntVal(4)},
+				},
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start: hcl.Pos{
+						Line:   2,
+						Column: 10,
+						Byte:   29,
+					},
+					End: hcl.Pos{
+						Line:   2,
+						Column: 31,
+						Byte:   50,
+					},
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {
+			d := NewDecoder()
+
+			f, _ := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+			err := d.LoadFile("test.tf", f)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			refOrigin, err := d.ReferenceOriginAtPos("test.tf", tc.pos)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedOrigin, refOrigin, ctydebug.CmpOptions); diff != "" {
+				t.Fatalf("mismatched reference origin: %s", diff)
+			}
+		})
+	}
+}

--- a/lang/reference_origin.go
+++ b/lang/reference_origin.go
@@ -1,0 +1,8 @@
+package lang
+
+import "github.com/hashicorp/hcl/v2"
+
+type ReferenceOrigin struct {
+	Addr  Address
+	Range hcl.Range
+}


### PR DESCRIPTION
This is to provide support for "go to definition" and "go to declaration", as described in hashicorp/vscode-terraform#671