### PR TITLE
Introduce `ReferenceOriginsForTarget` & `CollectReferenceOrigins`

### DIFF
--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -16,6 +16,7 @@ type Decoder struct {
 	filesMu *sync.RWMutex
 
 	refTargetReader ReferenceTargetReader
+	refOriginReader ReferenceOriginReader
 	rootSchema      *schema.BodySchema
 	rootSchemaMu    *sync.RWMutex
 	maxCandidates   uint
@@ -30,6 +31,7 @@ type Decoder struct {
 }
 
 type ReferenceTargetReader func() lang.ReferenceTargets
+type ReferenceOriginReader func() lang.ReferenceOrigins
 
 // NewDecoder creates a new Decoder
 //
@@ -57,6 +59,10 @@ func (d *Decoder) SetSchema(schema *schema.BodySchema) {
 
 func (d *Decoder) SetReferenceTargetReader(f ReferenceTargetReader) {
 	d.refTargetReader = f
+}
+
+func (d *Decoder) SetReferenceOriginReader(f ReferenceOriginReader) {
+	d.refOriginReader = f
 }
 
 func (d *Decoder) SetUtmSource(src string) {

--- a/decoder/reference_origins.go
+++ b/decoder/reference_origins.go
@@ -1,6 +1,8 @@
 package decoder
 
 import (
+	"sort"
+
 	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -20,6 +22,67 @@ func (d *Decoder) ReferenceOriginAtPos(filename string, pos hcl.Pos) (*lang.Refe
 	}
 
 	return d.referenceOriginAtPos(rootBody, pos)
+}
+
+func (d *Decoder) ReferenceOriginsTargeting(refTarget lang.ReferenceTarget) (lang.ReferenceOrigins, error) {
+	if d.refOriginReader == nil {
+		return nil, nil
+	}
+
+	allOrigins := ReferenceOrigins(d.refOriginReader())
+
+	return allOrigins.Targeting(refTarget), nil
+}
+
+func (d *Decoder) CollectReferenceOrigins() (lang.ReferenceOrigins, error) {
+	refOrigins := make(lang.ReferenceOrigins, 0)
+	files := d.Filenames()
+	for _, filename := range files {
+		f, err := d.fileByName(filename)
+		if err != nil {
+			// skip unparseable file
+			continue
+		}
+
+		body, ok := f.Body.(*hclsyntax.Body)
+		if !ok {
+			// skip JSON or other body format
+			continue
+		}
+
+		refOrigins = append(refOrigins, d.referenceOriginsInBody(body)...)
+	}
+
+	sort.SliceStable(refOrigins, func(i, j int) bool {
+		return refOrigins[i].Range.Filename <= refOrigins[i].Range.Filename &&
+			refOrigins[i].Range.Start.Byte < refOrigins[j].Range.Start.Byte
+	})
+
+	return refOrigins, nil
+}
+
+func (d *Decoder) referenceOriginsInBody(body *hclsyntax.Body) lang.ReferenceOrigins {
+	origins := make(lang.ReferenceOrigins, 0)
+	for _, attr := range body.Attributes {
+		for _, traversal := range attr.Expr.Variables() {
+			addr, err := lang.TraversalToAddress(traversal)
+			if err != nil {
+				continue
+			}
+			origins = append(origins, lang.ReferenceOrigin{
+				Addr:  addr,
+				Range: traversal.SourceRange(),
+			})
+		}
+	}
+
+	for _, block := range body.Blocks {
+		if block.Body != nil {
+			origins = append(origins, d.referenceOriginsInBody(block.Body)...)
+		}
+	}
+
+	return origins
 }
 
 func (d *Decoder) referenceOriginAtPos(body *hclsyntax.Body, pos hcl.Pos) (*lang.ReferenceOrigin, error) {
@@ -59,4 +122,26 @@ func (d *Decoder) traversalAtPos(expr hclsyntax.Expression, pos hcl.Pos) (hcl.Tr
 	}
 
 	return nil, false
+}
+
+type ReferenceOrigins lang.ReferenceOrigins
+
+func (ro ReferenceOrigins) Targeting(refTarget lang.ReferenceTarget) lang.ReferenceOrigins {
+	origins := make(lang.ReferenceOrigins, 0)
+
+	// The O(n^2) here is not ideal but it should
+	// be fine given expected data size
+
+	for _, refOrigin := range ro {
+		// TODO: reflect refTarget.Type in comparing
+		if Address(refOrigin.Addr).Equals(Address(refTarget.Address())) {
+			origins = append(origins, refOrigin)
+		}
+
+		for _, iTarget := range refTarget.NestedTargets {
+			origins = append(origins, ro.Targeting(iTarget)...)
+		}
+	}
+
+	return origins
 }

--- a/decoder/reference_origins_test.go
+++ b/decoder/reference_origins_test.go
@@ -209,3 +209,332 @@ func TestReferenceOriginAtPos(t *testing.T) {
 		})
 	}
 }
+
+func TestCollectReferenceOrigins(t *testing.T) {
+	testCases := []struct {
+		name            string
+		cfg             string
+		expectedOrigins lang.ReferenceOrigins
+	}{
+		{
+			"no origins",
+			`attribute = "foo-bar"`,
+			lang.ReferenceOrigins{},
+		},
+		{
+			"root attribute single step",
+			`attr = onestep`,
+			lang.ReferenceOrigins{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "onestep"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 8,
+							Byte:   7,
+						},
+						End: hcl.Pos{
+							Line:   1,
+							Column: 15,
+							Byte:   14,
+						},
+					},
+				},
+			},
+		},
+		{
+			"multiple root attributes single step",
+			`attr1 = onestep
+attr2 = anotherstep
+attr3 = onestep`,
+			lang.ReferenceOrigins{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "onestep"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 9,
+							Byte:   8,
+						},
+						End: hcl.Pos{
+							Line:   1,
+							Column: 16,
+							Byte:   15,
+						},
+					},
+				},
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "anotherstep"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   2,
+							Column: 9,
+							Byte:   24,
+						},
+						End: hcl.Pos{
+							Line:   2,
+							Column: 20,
+							Byte:   35,
+						},
+					},
+				},
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "onestep"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   3,
+							Column: 9,
+							Byte:   44,
+						},
+						End: hcl.Pos{
+							Line:   3,
+							Column: 16,
+							Byte:   51,
+						},
+					},
+				},
+			},
+		},
+		{
+			"root attribute multiple origins",
+			`attr1 = "${onestep}-${onestep}-${another.foo.bar}"`,
+			lang.ReferenceOrigins{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "onestep"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 12,
+							Byte:   11,
+						},
+						End: hcl.Pos{
+							Line:   1,
+							Column: 19,
+							Byte:   18,
+						},
+					},
+				},
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "onestep"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 23,
+							Byte:   22,
+						},
+						End: hcl.Pos{
+							Line:   1,
+							Column: 30,
+							Byte:   29,
+						},
+					},
+				},
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "another"},
+						lang.AttrStep{Name: "foo"},
+						lang.AttrStep{Name: "bar"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 34,
+							Byte:   33,
+						},
+						End: hcl.Pos{
+							Line:   1,
+							Column: 49,
+							Byte:   48,
+						},
+					},
+				},
+			},
+		},
+		{
+			"root attribute multi-step",
+			`attr = one.two["key"].attr[0]`,
+			lang.ReferenceOrigins{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "one"},
+						lang.AttrStep{Name: "two"},
+						lang.IndexStep{Key: cty.StringVal("key")},
+						lang.AttrStep{Name: "attr"},
+						lang.IndexStep{Key: cty.NumberIntVal(0)},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 8,
+							Byte:   7,
+						},
+						End: hcl.Pos{
+							Line:   1,
+							Column: 30,
+							Byte:   29,
+						},
+					},
+				},
+			},
+		},
+		{
+			"attribute in block",
+			`myblock {
+  attr = onestep
+}
+`,
+			lang.ReferenceOrigins{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "onestep"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   2,
+							Column: 10,
+							Byte:   19,
+						},
+						End: hcl.Pos{
+							Line:   2,
+							Column: 17,
+							Byte:   26,
+						},
+					},
+				},
+			},
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {
+			d := NewDecoder()
+
+			f, _ := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+			err := d.LoadFile("test.tf", f)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			origins, err := d.CollectReferenceOrigins()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedOrigins, origins, ctydebug.CmpOptions); diff != "" {
+				t.Fatalf("mismatched reference origins: %s", diff)
+			}
+		})
+	}
+}
+
+func TestReferenceOriginsTargeting(t *testing.T) {
+	testCases := []struct {
+		name            string
+		allOrigins      lang.ReferenceOrigins
+		refTarget       lang.ReferenceTarget
+		expectedOrigins lang.ReferenceOrigins
+	}{
+		{
+			"no origins",
+			lang.ReferenceOrigins{},
+			lang.ReferenceTarget{
+				Addr: lang.Address{
+					lang.RootStep{Name: "test"},
+				},
+				Type: cty.String,
+			},
+			lang.ReferenceOrigins{},
+		},
+		{
+			"exact address match",
+			lang.ReferenceOrigins{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "test"},
+					},
+				},
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "test"},
+						lang.AttrStep{Name: "secondstep"},
+					},
+				},
+			},
+			lang.ReferenceTarget{
+				Addr: lang.Address{
+					lang.RootStep{Name: "test"},
+					lang.AttrStep{Name: "secondstep"},
+				},
+				Type: cty.String,
+			},
+			lang.ReferenceOrigins{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "test"},
+						lang.AttrStep{Name: "secondstep"},
+					},
+				},
+			},
+		},
+		{
+			"no match",
+			lang.ReferenceOrigins{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "test"},
+					},
+				},
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "test"},
+						lang.AttrStep{Name: "secondstep"},
+					},
+				},
+			},
+			lang.ReferenceTarget{
+				Addr: lang.Address{
+					lang.RootStep{Name: "test"},
+					lang.AttrStep{Name: "different"},
+				},
+				Type: cty.String,
+			},
+			lang.ReferenceOrigins{},
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {
+			d := NewDecoder()
+			d.SetReferenceOriginReader(func() lang.ReferenceOrigins {
+				return tc.allOrigins
+			})
+			origins, err := d.ReferenceOriginsTargeting(tc.refTarget)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedOrigins, origins, ctydebug.CmpOptions); diff != "" {
+				t.Fatalf("mismatched reference origins: %s", diff)
+			}
+		})
+	}
+}

--- a/lang/reference_origin.go
+++ b/lang/reference_origin.go
@@ -6,3 +6,25 @@ type ReferenceOrigin struct {
 	Addr  Address
 	Range hcl.Range
 }
+
+type ReferenceOrigins []ReferenceOrigin
+
+func (ro ReferenceOrigins) Copy() ReferenceOrigins {
+	if ro == nil {
+		return nil
+	}
+
+	newOrigins := make(ReferenceOrigins, len(ro))
+	for i, origin := range ro {
+		newOrigins[i] = origin.Copy()
+	}
+
+	return newOrigins
+}
+
+func (ro ReferenceOrigin) Copy() ReferenceOrigin {
+	return ReferenceOrigin{
+		Addr:  ro.Addr,
+		Range: ro.Range,
+	}
+}


### PR DESCRIPTION
TODO
 - matching targets of unknown type (e.g. where the value & type is determined from other external sources - e.g. from state in Terraform)
