### PR TITLE
fix: avoid circular references to complex attribute types

### DIFF
--- a/decoder/reference_targets.go
+++ b/decoder/reference_targets.go
@@ -369,7 +369,7 @@ func decodeReferenceTargetsForComplexTypeExpr(addr lang.Address, expr hclsyntax.
 	case *hclsyntax.TupleConsExpr:
 		if t.IsListType() {
 			for i, item := range e.Exprs {
-				elemAddr := append(addr, lang.IndexStep{Key: cty.NumberIntVal(int64(i))})
+				elemAddr := append(addr.Copy(), lang.IndexStep{Key: cty.NumberIntVal(int64(i))})
 				elemType := t.ElementType()
 
 				ref := lang.ReferenceTarget{
@@ -399,7 +399,7 @@ func decodeReferenceTargetsForComplexTypeExpr(addr lang.Address, expr hclsyntax.
 				if !ok {
 					continue
 				}
-				attrAddr := append(addr, lang.AttrStep{Name: key.AsString()})
+				attrAddr := append(addr.Copy(), lang.AttrStep{Name: key.AsString()})
 				rng := hcl.RangeBetween(item.KeyExpr.Range(), item.ValueExpr.Range())
 
 				ref := lang.ReferenceTarget{
@@ -430,7 +430,7 @@ func decodeReferenceTargetsForComplexTypeExpr(addr lang.Address, expr hclsyntax.
 				}
 				elemType := *elemTypePtr
 
-				elemAddr := append(addr, lang.IndexStep{Key: key})
+				elemAddr := append(addr.Copy(), lang.IndexStep{Key: key})
 				rng := hcl.RangeBetween(item.KeyExpr.Range(), item.ValueExpr.Range())
 
 				ref := lang.ReferenceTarget{
@@ -698,9 +698,7 @@ func (d *Decoder) collectInferredReferenceTargetsForBody(addr lang.Address, scop
 			continue
 		}
 
-		attrAddr := make(lang.Address, len(addr))
-		copy(attrAddr, addr)
-		attrAddr = append(attrAddr, lang.AttrStep{Name: name})
+		attrAddr := append(addr.Copy(), lang.AttrStep{Name: name})
 
 		ref := lang.ReferenceTarget{
 			Addr:        attrAddr,

--- a/decoder/reference_targets.go
+++ b/decoder/reference_targets.go
@@ -380,7 +380,7 @@ func decodeReferenceTargetsForComplexTypeExpr(addr lang.Address, expr hclsyntax.
 				}
 				if !elemType.IsPrimitiveType() {
 					ref.NestedTargets = make(lang.ReferenceTargets, 0)
-					ref.NestedTargets = append(refs, decodeReferenceTargetsForComplexTypeExpr(elemAddr, item, elemType, scopeId)...)
+					ref.NestedTargets = append(ref.NestedTargets, decodeReferenceTargetsForComplexTypeExpr(elemAddr, item, elemType, scopeId)...)
 				}
 
 				refs = append(refs, ref)
@@ -410,7 +410,7 @@ func decodeReferenceTargetsForComplexTypeExpr(addr lang.Address, expr hclsyntax.
 				}
 				if !attrType.IsPrimitiveType() {
 					ref.NestedTargets = make(lang.ReferenceTargets, 0)
-					ref.NestedTargets = append(refs, decodeReferenceTargetsForComplexTypeExpr(attrAddr, item.ValueExpr, attrType, scopeId)...)
+					ref.NestedTargets = append(ref.NestedTargets, decodeReferenceTargetsForComplexTypeExpr(attrAddr, item.ValueExpr, attrType, scopeId)...)
 				}
 
 				refs = append(refs, ref)
@@ -441,7 +441,7 @@ func decodeReferenceTargetsForComplexTypeExpr(addr lang.Address, expr hclsyntax.
 				}
 				if !elemType.IsPrimitiveType() {
 					ref.NestedTargets = make(lang.ReferenceTargets, 0)
-					ref.NestedTargets = append(refs, decodeReferenceTargetsForComplexTypeExpr(elemAddr, item.ValueExpr, elemType, scopeId)...)
+					ref.NestedTargets = append(ref.NestedTargets, decodeReferenceTargetsForComplexTypeExpr(elemAddr, item.ValueExpr, elemType, scopeId)...)
 				}
 
 				refs = append(refs, ref)

--- a/decoder/reference_targets_test.go
+++ b/decoder/reference_targets_test.go
@@ -3121,6 +3121,283 @@ provider "test" {
 				},
 			},
 		},
+		{
+			// repro case for https://github.com/hashicorp/terraform-ls/issues/573
+			"nested complex objects",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"locals": {
+						Body: &schema.BodySchema{
+							AnyAttribute: &schema.AttributeSchema{
+								Address: &schema.AttributeAddrSchema{
+									Steps: []schema.AddrStep{
+										schema.StaticStep{Name: "local"},
+										schema.AttrNameStep{},
+									},
+									ScopeId:    lang.ScopeId("local"),
+									AsExprType: true,
+								},
+								Expr: schema.ExprConstraints{
+									schema.TraversalExpr{OfType: cty.DynamicPseudoType},
+									schema.LiteralTypeExpr{Type: cty.DynamicPseudoType},
+								},
+							},
+						},
+					},
+				},
+			},
+			`locals {
+  top_obj = {
+    first = {
+      attr = "val"
+    }
+    second = {
+      attr = "val"
+    }
+    third = {
+      attr = "val"
+    }
+    fourth = {
+      attr = "val"
+    }
+  }
+}
+`,
+			lang.ReferenceTargets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "top_obj"},
+					},
+					Type: cty.Object(map[string]cty.Type{
+						"first": cty.Object(map[string]cty.Type{
+							"attr": cty.String,
+						}),
+						"second": cty.Object(map[string]cty.Type{
+							"attr": cty.String,
+						}),
+						"third": cty.Object(map[string]cty.Type{
+							"attr": cty.String,
+						}),
+						"fourth": cty.Object(map[string]cty.Type{
+							"attr": cty.String,
+						}),
+					}),
+					ScopeId: lang.ScopeId("local"),
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   2,
+							Column: 3,
+							Byte:   11,
+						},
+						End: hcl.Pos{
+							Line:   15,
+							Column: 4,
+							Byte:   184,
+						},
+					},
+					NestedTargets: lang.ReferenceTargets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "local"},
+								lang.AttrStep{Name: "top_obj"},
+								lang.AttrStep{Name: "first"},
+							},
+							Type: cty.Object(map[string]cty.Type{
+								"attr": cty.String,
+							}),
+							ScopeId: lang.ScopeId("local"),
+							RangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start: hcl.Pos{
+									Line:   3,
+									Column: 5,
+									Byte:   27,
+								},
+								End: hcl.Pos{
+									Line:   5,
+									Column: 6,
+									Byte:   61,
+								},
+							},
+							NestedTargets: lang.ReferenceTargets{
+								{
+									Addr: lang.Address{
+										lang.RootStep{Name: "local"},
+										lang.AttrStep{Name: "top_obj"},
+										lang.AttrStep{Name: "first"},
+										lang.AttrStep{Name: "attr"},
+									},
+									Type:    cty.String,
+									ScopeId: lang.ScopeId("local"),
+									RangePtr: &hcl.Range{
+										Filename: "test.tf",
+										Start: hcl.Pos{
+											Line:   4,
+											Column: 7,
+											Byte:   43,
+										},
+										End: hcl.Pos{
+											Line:   4,
+											Column: 19,
+											Byte:   55,
+										},
+									},
+								},
+							},
+						},
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "local"},
+								lang.AttrStep{Name: "top_obj"},
+								lang.AttrStep{Name: "second"},
+							},
+							Type: cty.Object(map[string]cty.Type{
+								"attr": cty.String,
+							}),
+							ScopeId: lang.ScopeId("local"),
+							RangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start: hcl.Pos{
+									Line:   6,
+									Column: 5,
+									Byte:   66,
+								},
+								End: hcl.Pos{
+									Line:   8,
+									Column: 6,
+									Byte:   101,
+								},
+							},
+							NestedTargets: lang.ReferenceTargets{
+								{
+									Addr: lang.Address{
+										lang.RootStep{Name: "local"},
+										lang.AttrStep{Name: "top_obj"},
+										lang.AttrStep{Name: "second"},
+										lang.AttrStep{Name: "attr"},
+									},
+									Type:    cty.String,
+									ScopeId: lang.ScopeId("local"),
+									RangePtr: &hcl.Range{
+										Filename: "test.tf",
+										Start: hcl.Pos{
+											Line:   7,
+											Column: 7,
+											Byte:   83,
+										},
+										End: hcl.Pos{
+											Line:   7,
+											Column: 19,
+											Byte:   95,
+										},
+									},
+								},
+							},
+						},
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "local"},
+								lang.AttrStep{Name: "top_obj"},
+								lang.AttrStep{Name: "third"},
+							},
+							Type: cty.Object(map[string]cty.Type{
+								"attr": cty.String,
+							}),
+							ScopeId: lang.ScopeId("local"),
+							RangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start: hcl.Pos{
+									Line:   9,
+									Column: 5,
+									Byte:   106,
+								},
+								End: hcl.Pos{
+									Line:   11,
+									Column: 6,
+									Byte:   140,
+								},
+							},
+							NestedTargets: lang.ReferenceTargets{
+								{
+									Addr: lang.Address{
+										lang.RootStep{Name: "local"},
+										lang.AttrStep{Name: "top_obj"},
+										lang.AttrStep{Name: "third"},
+										lang.AttrStep{Name: "attr"},
+									},
+									Type:    cty.String,
+									ScopeId: lang.ScopeId("local"),
+									RangePtr: &hcl.Range{
+										Filename: "test.tf",
+										Start: hcl.Pos{
+											Line:   10,
+											Column: 7,
+											Byte:   122,
+										},
+										End: hcl.Pos{
+											Line:   10,
+											Column: 19,
+											Byte:   134,
+										},
+									},
+								},
+							},
+						},
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "local"},
+								lang.AttrStep{Name: "top_obj"},
+								lang.AttrStep{Name: "fourth"},
+							},
+							Type: cty.Object(map[string]cty.Type{
+								"attr": cty.String,
+							}),
+							ScopeId: lang.ScopeId("local"),
+							RangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start: hcl.Pos{
+									Line:   12,
+									Column: 5,
+									Byte:   145,
+								},
+								End: hcl.Pos{
+									Line:   14,
+									Column: 6,
+									Byte:   180,
+								},
+							},
+							NestedTargets: lang.ReferenceTargets{
+								{
+									Addr: lang.Address{
+										lang.RootStep{Name: "local"},
+										lang.AttrStep{Name: "top_obj"},
+										lang.AttrStep{Name: "fourth"},
+										lang.AttrStep{Name: "attr"},
+									},
+									Type:    cty.String,
+									ScopeId: lang.ScopeId("local"),
+									RangePtr: &hcl.Range{
+										Filename: "test.tf",
+										Start: hcl.Pos{
+											Line:   13,
+											Column: 7,
+											Byte:   162,
+										},
+										End: hcl.Pos{
+											Line:   13,
+											Column: 19,
+											Byte:   174,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for i, tc := range testCases {

--- a/lang/address_steps.go
+++ b/lang/address_steps.go
@@ -20,12 +20,18 @@ func (a Address) Marshal() ([]byte, error) {
 	return []byte(a.String()), nil
 }
 
-func (r Address) String() string {
+func (a Address) String() string {
 	addr := ""
-	for _, s := range r {
+	for _, s := range a {
 		addr += s.String()
 	}
 	return addr
+}
+
+func (a Address) Copy() Address {
+	addrCopy := make(Address, len(a))
+	copy(addrCopy, a)
+	return addrCopy
 }
 
 type RootStep struct {


### PR DESCRIPTION
Parsing the following config would lead to the creation of circular references, which then cause a loop while copying the references in LS:

```hcl
locals {
  top_obj = {
    first = {
      attr = "val"
    }
    second = {
      attr = "val"
    }
    third = {
      attr = "val"
    }
    fourth = {
      attr = "val"
    }
  }
}
```