### PR TITLE
fix: avoid matching duplicate ref origins

### DIFF
--- a/decoder/reference_origins.go
+++ b/decoder/reference_origins.go
@@ -137,10 +137,10 @@ func (ro ReferenceOrigins) Targeting(refTarget lang.ReferenceTarget) lang.Refere
 		if Address(refOrigin.Addr).Equals(Address(refTarget.Address())) {
 			origins = append(origins, refOrigin)
 		}
+	}
 
-		for _, iTarget := range refTarget.NestedTargets {
-			origins = append(origins, ro.Targeting(iTarget)...)
-		}
+	for _, iTarget := range refTarget.NestedTargets {
+		origins = append(origins, ro.Targeting(iTarget)...)
 	}
 
 	return origins

--- a/decoder/reference_origins_test.go
+++ b/decoder/reference_origins_test.go
@@ -520,6 +520,57 @@ func TestReferenceOriginsTargeting(t *testing.T) {
 			},
 			lang.ReferenceOrigins{},
 		},
+		{
+			"match of nested target - two matches",
+			lang.ReferenceOrigins{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "foo"},
+					},
+				},
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "test"},
+					},
+				},
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "test"},
+						lang.AttrStep{Name: "second"},
+					},
+				},
+			},
+			lang.ReferenceTarget{
+				Addr: lang.Address{
+					lang.RootStep{Name: "test"},
+				},
+				Type: cty.Object(map[string]cty.Type{
+					"second": cty.String,
+				}),
+				NestedTargets: lang.ReferenceTargets{
+					{
+						Addr: lang.Address{
+							lang.RootStep{Name: "test"},
+							lang.AttrStep{Name: "second"},
+						},
+						Type: cty.String,
+					},
+				},
+			},
+			lang.ReferenceOrigins{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "test"},
+					},
+				},
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "test"},
+						lang.AttrStep{Name: "second"},
+					},
+				},
+			},
+		},
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {


### PR DESCRIPTION
Previously when looking up origins for targets with nested targets we'd produce duplicate results due to this bug which is being patched. This probably wouldn't have any effect on the end user in most language clients (assuming they just deduplicate), but it's a bug nonetheless.