### PR TITLE
Reflect dependent schemas when collecting ref origins

### DIFF
--- a/decoder/reference_origins.go
+++ b/decoder/reference_origins.go
@@ -108,7 +108,11 @@ func (d *Decoder) referenceOriginsInBody(body *hclsyntax.Body, bodySchema *schem
 				// skip unknown blocks
 				continue
 			}
-			origins = append(origins, d.referenceOriginsInBody(block.Body, bSchema.Body)...)
+			mergedSchema, err := mergeBlockBodySchemas(block, bSchema)
+			if err != nil {
+				continue
+			}
+			origins = append(origins, d.referenceOriginsInBody(block.Body, mergedSchema)...)
 		}
 	}
 

--- a/decoder/reference_origins_test.go
+++ b/decoder/reference_origins_test.go
@@ -534,6 +534,149 @@ attr3 = onestep`,
 				},
 			},
 		},
+		{
+			"origins within block with matching dependent body",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"myblock": {
+						Labels: []*schema.LabelSchema{
+							{Name: "type", IsDepKey: true},
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"static": {
+									Expr: schema.ExprConstraints{
+										schema.TraversalExpr{},
+									},
+								},
+							},
+						},
+						DependentBody: map[schema.SchemaKey]*schema.BodySchema{
+							schema.NewSchemaKey(schema.DependencyKeys{
+								Labels: []schema.LabelDependent{
+									{Index: 0, Value: "special"},
+								},
+							}): {
+								Attributes: map[string]*schema.AttributeSchema{
+									"dep_attr": {
+										Expr: schema.ExprConstraints{
+											schema.TraversalExpr{},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			`myblock "special" {
+  static = var.first
+  dep_attr = var.second
+}
+`,
+			lang.ReferenceOrigins{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "first"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   2,
+							Column: 12,
+							Byte:   31,
+						},
+						End: hcl.Pos{
+							Line:   2,
+							Column: 21,
+							Byte:   40,
+						},
+					},
+				},
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "second"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   3,
+							Column: 14,
+							Byte:   54,
+						},
+						End: hcl.Pos{
+							Line:   3,
+							Column: 24,
+							Byte:   64,
+						},
+					},
+				},
+			},
+		},
+		{
+			"origins within block with mismatching dependent body",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"myblock": {
+						Labels: []*schema.LabelSchema{
+							{Name: "type", IsDepKey: true},
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"static": {
+									Expr: schema.ExprConstraints{
+										schema.TraversalExpr{},
+									},
+								},
+							},
+						},
+						DependentBody: map[schema.SchemaKey]*schema.BodySchema{
+							schema.NewSchemaKey(schema.DependencyKeys{
+								Labels: []schema.LabelDependent{
+									{Index: 0, Value: "special"},
+								},
+							}): {
+								Attributes: map[string]*schema.AttributeSchema{
+									"dep_attr": {
+										Expr: schema.ExprConstraints{
+											schema.TraversalExpr{},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			`myblock "different" {
+  static = var.first
+  dep_attr = var.second
+}
+`,
+			lang.ReferenceOrigins{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "first"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   2,
+							Column: 12,
+							Byte:   33,
+						},
+						End: hcl.Pos{
+							Line:   2,
+							Column: 21,
+							Byte:   42,
+						},
+					},
+				},
+			},
+		},
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {

--- a/decoder/reference_targets.go
+++ b/decoder/reference_targets.go
@@ -282,6 +282,8 @@ func (d *Decoder) decodeReferenceTargetsForBody(body *hclsyntax.Body, bodySchema
 			continue
 		}
 
+		// TODO: Support dependent schemas
+
 		iRefs := d.decodeReferenceTargetsForBody(block.Body, bSchema.Body)
 		refs = append(refs, iRefs...)
 


### PR DESCRIPTION
This was mostly an oversight in the initial implementation, discovered as part of https://github.com/hashicorp/terraform-ls/issues/585

The same problem still exists for reference targets, but dependent schema in Terraform's context AFAICT doesn't contain custom addresses at this point, so this is currently not a priority - but I left a TODO there.