### PR TITLE
BodySchema: Introduce TargetableAs

### DIFF
--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -185,6 +185,9 @@ func mergeBlockBodySchemas(block *hclsyntax.Block, blockSchema *schema.BlockSche
 	if mergedSchema.Blocks == nil {
 		mergedSchema.Blocks = make(map[string]*schema.BlockSchema, 0)
 	}
+	if mergedSchema.TargetableAs == nil {
+		mergedSchema.TargetableAs = make([]*schema.Targetable, 0)
+	}
 
 	depSchema, _, ok := NewBlockSchema(blockSchema).DependentBodySchema(block)
 	if ok {
@@ -203,6 +206,9 @@ func mergeBlockBodySchemas(block *hclsyntax.Block, blockSchema *schema.BlockSche
 				// Skip duplicate block type
 				continue
 			}
+		}
+		for _, tBody := range depSchema.TargetableAs {
+			mergedSchema.TargetableAs = append(mergedSchema.TargetableAs, tBody)
 		}
 	}
 

--- a/schema/body_schema.go
+++ b/schema/body_schema.go
@@ -26,6 +26,10 @@ type BodySchema struct {
 	// but often will match.
 	HoverURL string
 
+	// TargetableAs represents how else the body may be targeted
+	// if not by its declarable attributes or blocks.
+	TargetableAs []*Targetable
+
 	// TODO: Functions
 }
 
@@ -87,6 +91,13 @@ func (bs *BodySchema) Copy() *BodySchema {
 		AnyAttribute: bs.AnyAttribute.Copy(),
 		HoverURL:     bs.HoverURL,
 		DocsLink:     bs.DocsLink.Copy(),
+	}
+
+	if bs.TargetableAs != nil {
+		newBs.TargetableAs = make([]*Targetable, len(bs.TargetableAs))
+		for id, target := range bs.TargetableAs {
+			newBs.TargetableAs[id] = target.Copy()
+		}
 	}
 
 	if bs.Attributes != nil {

--- a/schema/targetable.go
+++ b/schema/targetable.go
@@ -1,0 +1,106 @@
+package schema
+
+import (
+	"sort"
+
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/zclconf/go-cty/cty"
+)
+
+type Targetable struct {
+	Address      lang.Address
+	ScopeId      lang.ScopeId
+	AsType       cty.Type
+	IsSensitive  bool
+	FriendlyName string
+	Description  lang.MarkupContent
+
+	NestedTargetables []*Targetable
+}
+
+func (tb *Targetable) Copy() *Targetable {
+	newTb := &Targetable{
+		Address:      tb.Address,
+		ScopeId:      tb.ScopeId,
+		AsType:       tb.AsType,
+		IsSensitive:  tb.IsSensitive,
+		FriendlyName: tb.FriendlyName,
+		Description:  tb.Description,
+	}
+
+	if tb.NestedTargetables != nil {
+		for i, ntb := range tb.NestedTargetables {
+			newTb.NestedTargetables[i] = ntb.NestedTargetables[i].Copy()
+		}
+	}
+
+	return newTb
+}
+
+func NestedTargetablesForValue(address lang.Address, scopeId lang.ScopeId, val cty.Value) []*Targetable {
+	if val.IsNull() {
+		return nil
+	}
+	typ := val.Type()
+
+	if typ.IsPrimitiveType() || typ == cty.DynamicPseudoType {
+		return nil
+	}
+
+	if typ.IsSetType() {
+		// set elements are not addressable
+		return nil
+	}
+
+	nestedTargetables := make([]*Targetable, 0)
+
+	if typ.IsObjectType() {
+		for key := range typ.AttributeTypes() {
+			elAddr := address.Copy()
+			elAddr = append(elAddr, lang.AttrStep{Name: key})
+
+			nestedTargetables = append(nestedTargetables,
+				targetableForValue(elAddr, scopeId, val.GetAttr(key)))
+		}
+	}
+
+	if typ.IsMapType() {
+		for key, val := range val.AsValueMap() {
+			elAddr := address.Copy()
+			elAddr = append(elAddr, lang.IndexStep{Key: cty.StringVal(key)})
+
+			nestedTargetables = append(nestedTargetables,
+				targetableForValue(elAddr, scopeId, val))
+		}
+	}
+
+	if typ.IsListType() || typ.IsTupleType() {
+		for i, val := range val.AsValueSlice() {
+			elAddr := address.Copy()
+			elAddr = append(elAddr, lang.IndexStep{Key: cty.NumberIntVal(int64(i))})
+
+			nestedTargetables = append(nestedTargetables,
+				targetableForValue(elAddr, scopeId, val))
+		}
+	}
+
+	sort.SliceStable(nestedTargetables, func(i, j int) bool {
+		return nestedTargetables[i].Address.String() < nestedTargetables[j].Address.String()
+	})
+
+	return nestedTargetables
+}
+
+func targetableForValue(addr lang.Address, scopeId lang.ScopeId, val cty.Value) *Targetable {
+	typ := cty.DynamicPseudoType
+	if !val.IsNull() {
+		typ = val.Type()
+	}
+
+	return &Targetable{
+		Address:           addr,
+		ScopeId:           scopeId,
+		AsType:            typ,
+		NestedTargetables: NestedTargetablesForValue(addr, scopeId, val),
+	}
+}

--- a/schema/targetable_test.go
+++ b/schema/targetable_test.go
@@ -1,0 +1,148 @@
+package schema
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/zclconf/go-cty-debug/ctydebug"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestNestedTargetablesForValue(t *testing.T) {
+	testCases := []struct {
+		name                string
+		addr                lang.Address
+		scopeId             lang.ScopeId
+		val                 cty.Value
+		expectedTargetables []*Targetable
+	}{
+		{
+			"primitive type",
+			lang.Address{
+				lang.RootStep{Name: "foo"},
+			},
+			lang.ScopeId("test"),
+			cty.StringVal("test"),
+			nil,
+		},
+		{
+			"set type",
+			lang.Address{
+				lang.RootStep{Name: "foo"},
+			},
+			lang.ScopeId("test"),
+			cty.SetVal([]cty.Value{
+				cty.StringVal("test"),
+			}),
+			nil,
+		},
+		{
+			"list type",
+			lang.Address{
+				lang.RootStep{Name: "foo"},
+			},
+			lang.ScopeId("test"),
+			cty.ListVal([]cty.Value{
+				cty.StringVal("test"),
+			}),
+			[]*Targetable{
+				{
+					Address: lang.Address{
+						lang.RootStep{Name: "foo"},
+						lang.IndexStep{Key: cty.NumberIntVal(0)},
+					},
+					ScopeId: lang.ScopeId("test"),
+					AsType:  cty.String,
+				},
+			},
+		},
+		{
+			"tuple type",
+			lang.Address{
+				lang.RootStep{Name: "foo"},
+			},
+			lang.ScopeId("test"),
+			cty.TupleVal([]cty.Value{
+				cty.StringVal("test"),
+			}),
+			[]*Targetable{
+				{
+					Address: lang.Address{
+						lang.RootStep{Name: "foo"},
+						lang.IndexStep{Key: cty.NumberIntVal(0)},
+					},
+					ScopeId: lang.ScopeId("test"),
+					AsType:  cty.String,
+				},
+			},
+		},
+		{
+			"object type",
+			lang.Address{
+				lang.RootStep{Name: "foo"},
+			},
+			lang.ScopeId("test"),
+			cty.ObjectVal(map[string]cty.Value{
+				"attr1": cty.StringVal("test1"),
+				"attr2": cty.StringVal("test2"),
+				"attr3": cty.StringVal("test3"),
+			}),
+			[]*Targetable{
+				{
+					Address: lang.Address{
+						lang.RootStep{Name: "foo"},
+						lang.AttrStep{Name: "attr1"},
+					},
+					ScopeId: lang.ScopeId("test"),
+					AsType:  cty.String,
+				},
+				{
+					Address: lang.Address{
+						lang.RootStep{Name: "foo"},
+						lang.AttrStep{Name: "attr2"},
+					},
+					ScopeId: lang.ScopeId("test"),
+					AsType:  cty.String,
+				},
+				{
+					Address: lang.Address{
+						lang.RootStep{Name: "foo"},
+						lang.AttrStep{Name: "attr3"},
+					},
+					ScopeId: lang.ScopeId("test"),
+					AsType:  cty.String,
+				},
+			},
+		},
+		{
+			"map type",
+			lang.Address{
+				lang.RootStep{Name: "foo"},
+			},
+			lang.ScopeId("test"),
+			cty.MapVal(map[string]cty.Value{
+				"key": cty.StringVal("test"),
+			}),
+			[]*Targetable{
+				{
+					Address: lang.Address{
+						lang.RootStep{Name: "foo"},
+						lang.IndexStep{Key: cty.StringVal("key")},
+					},
+					ScopeId: lang.ScopeId("test"),
+					AsType:  cty.String,
+				},
+			},
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {
+			targetables := NestedTargetablesForValue(tc.addr, tc.scopeId, tc.val)
+			if diff := cmp.Diff(tc.expectedTargetables, targetables, ctydebug.CmpOptions); diff != "" {
+				t.Fatalf("mismatch of targetables: %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is to aid with expressing Terraform module output references.

For example a module block such as

```hcl
module "example" {
  source = "./submodule"
}
```
can be targeted as `module.example.foo`, assuming there is `foo` output declared within `./submodule`:

```hcl
output "foo" {
  value = "..."
}
```

It is not possible to express this as computed-only attributes because module inputs and outputs can have same names, so there would be potential for conflict.