### PR TITLE
Reflect that ref origins have multiple constraints

### DIFF
--- a/decoder/expression_candidates.go
+++ b/decoder/expression_candidates.go
@@ -48,9 +48,9 @@ func constraintsAtPos(expr hcl.Expression, constraints ExprConstraints, pos hcl.
 		if ok {
 			matchedConstraints = append(matchedConstraints, ke)
 		}
-		te, ok := constraints.TraversalExpr()
+		tes, ok := constraints.TraversalExprs()
 		if ok {
-			matchedConstraints = append(matchedConstraints, te)
+			matchedConstraints = append(matchedConstraints, tes.AsConstraints()...)
 		}
 
 		if len(matchedConstraints) > 0 {

--- a/decoder/expression_constraints.go
+++ b/decoder/expression_constraints.go
@@ -29,13 +29,15 @@ func (ec ExprConstraints) KeywordExpr() (schema.KeywordExpr, bool) {
 	return schema.KeywordExpr{}, false
 }
 
-func (ec ExprConstraints) TraversalExpr() (schema.TraversalExpr, bool) {
+func (ec ExprConstraints) TraversalExprs() (schema.TraversalExprs, bool) {
+	tes := make([]schema.TraversalExpr, 0)
 	for _, c := range ec {
 		if te, ok := c.(schema.TraversalExpr); ok {
-			return te, ok
+			tes = append(tes, te)
 		}
 	}
-	return schema.TraversalExpr{}, false
+
+	return tes, len(tes) > 0
 }
 
 func (ec ExprConstraints) MapExpr() (schema.MapExpr, bool) {

--- a/decoder/hover.go
+++ b/decoder/hover.go
@@ -234,9 +234,9 @@ func (d *Decoder) hoverDataForExpr(expr hcl.Expression, constraints ExprConstrai
 			}, nil
 		}
 
-		te, ok := constraints.TraversalExpr()
+		tes, ok := constraints.TraversalExprs()
 		if ok {
-			content, err := d.hoverContentForTraversalExpr(e.AsTraversal(), te)
+			content, err := d.hoverContentForTraversalExpr(e.AsTraversal(), tes)
 			if err != nil {
 				return nil, err
 			}
@@ -595,14 +595,14 @@ func stringValFromTemplateExpr(tplExpr *hclsyntax.TemplateExpr) (cty.Value, bool
 	return cty.StringVal(value), true
 }
 
-func (d *Decoder) hoverContentForTraversalExpr(traversal hcl.Traversal, te schema.TraversalExpr) (string, error) {
+func (d *Decoder) hoverContentForTraversalExpr(traversal hcl.Traversal, tes []schema.TraversalExpr) (string, error) {
 	if d.refTargetReader == nil {
 		return "", &NoRefTargetFound{}
 	}
 
 	allTargets := ReferenceTargets(d.refTargetReader())
 
-	origin, err := TraversalToReferenceOrigin(traversal, te)
+	origin, err := TraversalToReferenceOrigin(traversal, tes)
 	if err != nil {
 		return "", nil
 	}

--- a/decoder/reference_targets_test.go
+++ b/decoder/reference_targets_test.go
@@ -4623,6 +4623,7 @@ func TestReferenceTargetForOrigin(t *testing.T) {
 					lang.RootStep{Name: "var"},
 					lang.AttrStep{Name: "test"},
 				},
+				Constraints: lang.ReferenceOriginConstraints{{}},
 			},
 			&lang.ReferenceTarget{
 				Addr: lang.Address{
@@ -4661,7 +4662,9 @@ func TestReferenceTargetForOrigin(t *testing.T) {
 					lang.RootStep{Name: "var"},
 					lang.AttrStep{Name: "test"},
 				},
-				OfType: cty.Bool,
+				Constraints: lang.ReferenceOriginConstraints{
+					{OfType: cty.Bool},
+				},
 			},
 			&lang.ReferenceTarget{
 				Addr: lang.Address{
@@ -4695,6 +4698,7 @@ func TestReferenceTargetForOrigin(t *testing.T) {
 					lang.AttrStep{Name: "foo"},
 					lang.AttrStep{Name: "bar"},
 				},
+				Constraints: lang.ReferenceOriginConstraints{{}},
 			},
 			&lang.ReferenceTarget{
 				Addr: lang.Address{
@@ -4739,6 +4743,9 @@ func TestReferenceTargetForOrigin(t *testing.T) {
 					lang.RootStep{Name: "var"},
 					lang.AttrStep{Name: "foo"},
 					lang.AttrStep{Name: "bar"},
+				},
+				Constraints: lang.ReferenceOriginConstraints{
+					{OfType: cty.String},
 				},
 			},
 			&lang.ReferenceTarget{

--- a/decoder/semantic_tokens.go
+++ b/decoder/semantic_tokens.go
@@ -142,12 +142,12 @@ func (d *Decoder) tokensForExpression(expr hclsyntax.Expression, constraints Exp
 			}
 		}
 
-		te, ok := constraints.TraversalExpr()
+		tes, ok := constraints.TraversalExprs()
 		if ok && d.refTargetReader != nil {
 			refs := ReferenceTargets(d.refTargetReader())
 			traversal := eType.AsTraversal()
 
-			origin, err := TraversalToReferenceOrigin(traversal, te)
+			origin, err := TraversalToReferenceOrigin(traversal, tes)
 			if err != nil {
 				return tokens
 			}

--- a/lang/reference_origin.go
+++ b/lang/reference_origin.go
@@ -9,8 +9,13 @@ type ReferenceOrigin struct {
 	Addr  Address
 	Range hcl.Range
 
-	OfScopeId ScopeId
-	OfType    cty.Type
+	// Constraints represents any traversal expression constraints
+	// for the attribute where the origin was found.
+	//
+	// Further matching against decoded reference targets is needed
+	// for >1 constraints, which is done later at runtime as
+	// targets and origins can be decoded at different times.
+	Constraints ReferenceOriginConstraints
 }
 
 type ReferenceOrigins []ReferenceOrigin
@@ -30,9 +35,28 @@ func (ro ReferenceOrigins) Copy() ReferenceOrigins {
 
 func (ro ReferenceOrigin) Copy() ReferenceOrigin {
 	return ReferenceOrigin{
-		Addr:      ro.Addr,
-		Range:     ro.Range,
-		OfScopeId: ro.OfScopeId,
-		OfType:    ro.OfType,
+		Addr:        ro.Addr,
+		Range:       ro.Range,
+		Constraints: ro.Constraints.Copy(),
 	}
+}
+
+type ReferenceOriginConstraint struct {
+	OfScopeId ScopeId
+	OfType    cty.Type
+}
+
+type ReferenceOriginConstraints []ReferenceOriginConstraint
+
+func (roc ReferenceOriginConstraints) Copy() ReferenceOriginConstraints {
+	if roc == nil {
+		return nil
+	}
+
+	cons := make(ReferenceOriginConstraints, 0)
+	for _, oc := range roc {
+		cons = append(cons, oc)
+	}
+
+	return cons
 }

--- a/schema/expressions.go
+++ b/schema/expressions.go
@@ -334,6 +334,19 @@ type TraversalExpr struct {
 	Address *TraversalAddrSchema
 }
 
+type TraversalExprs []TraversalExpr
+
+func (tes TraversalExprs) AsConstraints() ExprConstraints {
+	if tes == nil {
+		return nil
+	}
+	ec := make(ExprConstraints, 0)
+	for _, te := range tes {
+		ec = append(ec, te)
+	}
+	return ec
+}
+
 type TraversalAddrSchema struct {
 	ScopeId lang.ScopeId
 }


### PR DESCRIPTION
We collect origins and targets in parallel (not sequentially) and we cannot know which constraint would match the target if the origin has multiple constraints - such as in Terraform `resource` blocks have `depends_on` which may contain multiple `schema.TraversalExpr` with different `ScopeId`s.

Matching of the scope needs to be done only against decoded targets, not sooner.
