### PR TITLE
fix: associate correct constraints with nested origins

### DIFF
--- a/decoder/expression_candidates_test.go
+++ b/decoder/expression_candidates_test.go
@@ -836,7 +836,7 @@ func TestDecoder_CandidateAtPos_expressions(t *testing.T) {
 			lang.CompleteCandidates([]lang.Candidate{
 				{
 					Label:  "attr",
-					Detail: "list",
+					Detail: "list of string",
 					TextEdit: lang.TextEdit{
 						Range: hcl.Range{
 							Filename: "test.tf",
@@ -867,7 +867,7 @@ func TestDecoder_CandidateAtPos_expressions(t *testing.T) {
 			lang.CompleteCandidates([]lang.Candidate{
 				{
 					Label:  "[ string ]",
-					Detail: "list",
+					Detail: "list of string",
 					TextEdit: lang.TextEdit{
 						Range: hcl.Range{
 							Filename: "test.tf",
@@ -959,7 +959,7 @@ func TestDecoder_CandidateAtPos_expressions(t *testing.T) {
 			lang.CompleteCandidates([]lang.Candidate{
 				{
 					Label:  "attr",
-					Detail: "set",
+					Detail: "set of string",
 					TextEdit: lang.TextEdit{
 						Range: hcl.Range{
 							Filename: "test.tf",
@@ -990,7 +990,7 @@ func TestDecoder_CandidateAtPos_expressions(t *testing.T) {
 			lang.CompleteCandidates([]lang.Candidate{
 				{
 					Label:  "[ string ]",
-					Detail: "set",
+					Detail: "set of string",
 					TextEdit: lang.TextEdit{
 						Range: hcl.Range{
 							Filename: "test.tf",

--- a/decoder/hover_expressions_test.go
+++ b/decoder/hover_expressions_test.go
@@ -344,7 +344,7 @@ _object_`),
 ]`,
 			hcl.Pos{Line: 1, Column: 3, Byte: 2},
 			&lang.HoverData{
-				Content: lang.Markdown(`**objects** _list_`),
+				Content: lang.Markdown(`**objects** _list of object_`),
 				Range: hcl.Range{
 					Filename: "test.tf",
 					Start: hcl.Pos{
@@ -976,7 +976,7 @@ _object_`),
 			`list = [ "one", "two" ]`,
 			hcl.Pos{Line: 1, Column: 8, Byte: 7},
 			&lang.HoverData{
-				Content: lang.Markdown("_list_\n\nSpecial list"),
+				Content: lang.Markdown("_list of string_\n\nSpecial list"),
 				Range: hcl.Range{
 					Filename: "test.tf",
 					Start: hcl.Pos{
@@ -1035,7 +1035,7 @@ _object_`),
 			`set = [ "one", "two" ]`,
 			hcl.Pos{Line: 1, Column: 7, Byte: 6},
 			&lang.HoverData{
-				Content: lang.Markdown("_set_\n\nSpecial set"),
+				Content: lang.Markdown("_set of string_\n\nSpecial set"),
 				Range: hcl.Range{
 					Filename: "test.tf",
 					Start: hcl.Pos{

--- a/decoder/reference_origins_test.go
+++ b/decoder/reference_origins_test.go
@@ -1063,6 +1063,203 @@ tuple = [ var.third ]
 				},
 			},
 		},
+		{
+			"origin inside object and map expression with multiple matches",
+			&schema.BodySchema{
+				Attributes: map[string]*schema.AttributeSchema{
+					"map": {
+						Expr: schema.ExprConstraints{
+							schema.TraversalExpr{OfType: cty.Map(cty.String)},
+							schema.MapExpr{
+								Elem: schema.ExprConstraints{
+									schema.TraversalExpr{OfType: cty.String},
+								},
+							},
+						},
+					},
+					"obj": {
+						Expr: schema.ExprConstraints{
+							schema.TraversalExpr{OfType: cty.Object(map[string]cty.Type{
+								"foo": cty.String,
+							})},
+							schema.ObjectExpr{
+								Attributes: schema.ObjectExprAttributes{
+									"foo": &schema.AttributeSchema{
+										Expr: schema.ExprConstraints{
+											schema.TraversalExpr{OfType: cty.String},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			`map = {
+  bar = var.one
+}
+obj = {
+  foo = var.two
+}
+`,
+			lang.ReferenceOrigins{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "one"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   2,
+							Column: 9,
+							Byte:   16,
+						},
+						End: hcl.Pos{
+							Line:   2,
+							Column: 16,
+							Byte:   23,
+						},
+					},
+					Constraints: lang.ReferenceOriginConstraints{
+						{OfType: cty.String},
+					},
+				},
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "two"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   5,
+							Column: 9,
+							Byte:   42,
+						},
+						End: hcl.Pos{
+							Line:   5,
+							Column: 16,
+							Byte:   49,
+						},
+					},
+					Constraints: lang.ReferenceOriginConstraints{
+						{OfType: cty.String},
+					},
+				},
+			},
+		},
+		{
+			"origin inside list, set and tuple expression with multiple matches",
+			&schema.BodySchema{
+				Attributes: map[string]*schema.AttributeSchema{
+					"list": {
+						Expr: schema.ExprConstraints{
+							schema.TraversalExpr{OfType: cty.List(cty.String)},
+							schema.ListExpr{
+								Elem: schema.ExprConstraints{
+									schema.TraversalExpr{OfType: cty.String},
+								},
+							},
+						},
+					},
+					"set": {
+						Expr: schema.ExprConstraints{
+							schema.TraversalExpr{OfType: cty.Set(cty.String)},
+							schema.SetExpr{
+								Elem: schema.ExprConstraints{
+									schema.TraversalExpr{OfType: cty.String},
+								},
+							},
+						},
+					},
+					"tup": {
+						Expr: schema.ExprConstraints{
+							schema.TraversalExpr{OfType: cty.Tuple([]cty.Type{cty.String})},
+							schema.TupleExpr{
+								Elems: []schema.ExprConstraints{
+									{
+										schema.TraversalExpr{OfType: cty.String},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			`list = [ var.one ]
+set = [ var.two ]
+tup = [ var.three ]
+`,
+			lang.ReferenceOrigins{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "one"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 10,
+							Byte:   9,
+						},
+						End: hcl.Pos{
+							Line:   1,
+							Column: 17,
+							Byte:   16,
+						},
+					},
+					Constraints: lang.ReferenceOriginConstraints{
+						{OfType: cty.String},
+					},
+				},
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "two"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   2,
+							Column: 9,
+							Byte:   27,
+						},
+						End: hcl.Pos{
+							Line:   2,
+							Column: 16,
+							Byte:   34,
+						},
+					},
+					Constraints: lang.ReferenceOriginConstraints{
+						{OfType: cty.String},
+					},
+				},
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "three"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   3,
+							Column: 9,
+							Byte:   45,
+						},
+						End: hcl.Pos{
+							Line:   3,
+							Column: 18,
+							Byte:   54,
+						},
+					},
+					Constraints: lang.ReferenceOriginConstraints{
+						{OfType: cty.String},
+					},
+				},
+			},
+		},
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {

--- a/schema/expressions.go
+++ b/schema/expressions.go
@@ -162,7 +162,11 @@ func (ListExpr) isExprConstraintImpl() exprConstrSigil {
 	return exprConstrSigil{}
 }
 
-func (ListExpr) FriendlyName() string {
+func (le ListExpr) FriendlyName() string {
+	elemName := le.Elem.FriendlyName()
+	if elemName != "" {
+		return fmt.Sprintf("list of %s", elemName)
+	}
 	return "list"
 }
 
@@ -186,7 +190,11 @@ func (SetExpr) isExprConstraintImpl() exprConstrSigil {
 	return exprConstrSigil{}
 }
 
-func (SetExpr) FriendlyName() string {
+func (se SetExpr) FriendlyName() string {
+	elemName := se.Elem.FriendlyName()
+	if elemName != "" {
+		return fmt.Sprintf("set of %s", elemName)
+	}
 	return "set"
 }
 
@@ -239,6 +247,10 @@ func (MapExpr) isExprConstraintImpl() exprConstrSigil {
 
 func (me MapExpr) FriendlyName() string {
 	if me.Name == "" {
+		elemName := me.Elem.FriendlyName()
+		if elemName != "" {
+			return fmt.Sprintf("map of %s", elemName)
+		}
 		return "map"
 	}
 	return me.Name


### PR DESCRIPTION
This is to address a bug reported in https://github.com/hashicorp/terraform-ls/issues/592 where origins were being associated with incorrect expression constraints (e.g. map of traversals instead of traversal).

There is still more work to do in terms of fully supporting nested expressions, but this at least covers the most common and obvious cases of list, set, tuple, map and object expressions. Remaining expression types are to be dealt with as part of https://github.com/hashicorp/terraform-ls/issues/496 (tracked there but most of the work will be done in this repo).