### PR TITLE
decoder: Skip unknown tuple element

### DIFF
--- a/decoder/semantic_tokens.go
+++ b/decoder/semantic_tokens.go
@@ -501,7 +501,12 @@ func tokensForTupleConsExpr(expr *hclsyntax.TupleConsExpr, exprType cty.Type) []
 			elemType = *exprType.SetElementType()
 		}
 		if exprType.IsTupleType() {
-			elemType = exprType.TupleElementType(i)
+			elTypes := exprType.TupleElementTypes()
+			if len(elTypes) < i+1 {
+				// skip unknown tuple element
+				continue
+			}
+			elemType = elTypes[i]
 		}
 
 		tokens = append(tokens, tokenForTypedExpression(e, elemType)...)

--- a/decoder/semantic_tokens_expr_test.go
+++ b/decoder/semantic_tokens_expr_test.go
@@ -1173,6 +1173,68 @@ EOT
 			},
 		},
 		{
+			"undefined tuple expression",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Expr: schema.ExprConstraints{
+						schema.TupleExpr{
+							Elems: []schema.ExprConstraints{},
+						},
+					},
+				},
+			},
+			`attr = [ "one" ]
+`,
+			[]lang.SemanticToken{
+				{ // attr
+					Type:      lang.TokenAttrName,
+					Modifiers: []lang.SemanticTokenModifier{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+							Byte:   0,
+						},
+						End: hcl.Pos{
+							Line:   1,
+							Column: 5,
+							Byte:   4,
+						},
+					},
+				},
+			},
+		},
+		{
+			"undefined tuple type",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Expr: schema.LiteralTypeOnly(cty.Tuple([]cty.Type{})),
+				},
+			},
+			`attr = [ "one" ]
+`,
+			[]lang.SemanticToken{
+				{ // attr
+					Type:      lang.TokenAttrName,
+					Modifiers: []lang.SemanticTokenModifier{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+							Byte:   0,
+						},
+						End: hcl.Pos{
+							Line:   1,
+							Column: 5,
+							Byte:   4,
+						},
+					},
+				},
+			},
+		},
+		{
 			"tuple as list",
 			map[string]*schema.AttributeSchema{
 				"attr": {


### PR DESCRIPTION
This fixes a crash that can be demonstrated by the attached test.

It was initially reported as part of https://github.com/hashicorp/vscode-terraform/issues/707#issuecomment-891008775