### PR TITLE
decoder: prefer attribute over block in case of duplicate name

### DIFF
--- a/decoder/body_candidates.go
+++ b/decoder/body_candidates.go
@@ -47,6 +47,20 @@ func (d *Decoder) bodySchemaCandidates(body *hclsyntax.Body, schema *schema.Body
 	for _, bType := range blockTypes {
 		block := schema.Blocks[bType]
 
+		// In Terraform duplicates should never occur when providers
+		// use the official plugin SDK, except when a field uses
+		// SchemaConfigMode to turn blocks into attributes
+		// for backwards compatibility reasons.
+		//
+		// Decoder allows duplicates but they should be avoided if possible.
+		//
+		// Here we prefer attribute completion in case of a duplicate
+		// to mimic how Terraform Core treats duplicate list(object)
+		// and set(object) attributes.
+		if _, ok := schema.Attributes[bType]; ok {
+			continue
+		}
+
 		if !isBlockDeclarable(body, bType, block) {
 			continue
 		}


### PR DESCRIPTION
This is to compliment https://github.com/hashicorp/terraform-schema/pull/69 by avoiding to complete a block if there's an attribute of the same name.
