### PR TITLE
ci: Use latest versions of (Windows/macOS/Ubuntu)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-18.04
-          - windows-2019
-          - macos-10.15
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
     steps:
       -
         name: Checkout


### PR DESCRIPTION
There is no reason to be pinning to a particular OS version at this point. We expect the library to follow compatibility promises of the Go version declared in `go.mod` as per convention

https://github.com/hashicorp/hcl-lang/blob/a8fdffa641ca3a26e87177fda91beb0bf327d6b0/go.mod#L3

Also FWIW the library is considered experimental for any compatibility promises (at this point) anyway.