### PR TITLE
Make sure limited label candidates are sorted

### DIFF
--- a/decoder/body_candidates.go
+++ b/decoder/body_candidates.go
@@ -77,10 +77,7 @@ func (d *Decoder) bodySchemaCandidates(body *hclsyntax.Body, schema *schema.Body
 
 	candidates.IsComplete = true
 
-	// TODO: sort by more metadata, such as IsRequired or IsDeprecated
-	sort.Slice(candidates.List, func(i, j int) bool {
-		return candidates.List[i].Label < candidates.List[j].Label
-	})
+	sort.Sort(candidates)
 
 	return candidates
 }

--- a/lang/candidate.go
+++ b/lang/candidate.go
@@ -67,6 +67,19 @@ type Candidates struct {
 	IsComplete bool
 }
 
+func (ca Candidates) Len() int {
+	return len(ca.List)
+}
+
+func (ca Candidates) Less(i, j int) bool {
+	// TODO: sort by more metadata, such as IsRequired or IsDeprecated
+	return ca.List[i].Label < ca.List[j].Label
+}
+
+func (ca Candidates) Swap(i, j int) {
+	ca.List[i], ca.List[j] = ca.List[j], ca.List[i]
+}
+
 // NewCandidates creates a new (incomplete) list of candidates
 // to be appended to.
 func NewCandidates() Candidates {


### PR DESCRIPTION
This was caught by a flaky test on `main` after merging https://github.com/hashicorp/hcl-lang/pull/85

```
=== RUN   TestDecoder_CandidateAtPos_incompleteLabels
    label_candidates_test.go:102: unexpected candidates:   lang.Candidates{
          	List: []lang.Candidate{
          		{
        - 			Label:        "first",
        + 			Label:        "second",
          			Description:  {},
          			Detail:       "",
          			IsDeprecated: false,
          			TextEdit: lang.TextEdit{
          				Range:   {Filename: "test.tf", Start: {Line: 1, Column: 14, Byte: 13}, End: {Line: 1, Column: 14, Byte: 13}},
        - 				NewText: "first",
        + 				NewText: "second",
        - 				Snippet: "first",
        + 				Snippet: "second",
          			},
          			AdditionalTextEdits: nil,
          			Kind:                s"LabelCandidateKind",
          			TriggerSuggest:      false,
          		},
          	},
          	IsComplete: false,
          }
--- FAIL: TestDecoder_CandidateAtPos_incompleteLabels (0.00s)
```

Prior to this patch we were ranging over a map which doesn't have a guaranteed order. The solution reflects what we already do for attributes and blocks - i.e. iterate over sorted keys instead of a map:

https://github.com/hashicorp/hcl-lang/blob/5f3f065c14aa2c2cabf8c4c88dd91510a9a7203c/decoder/body_candidates.go#L20-L21

https://github.com/hashicorp/hcl-lang/blob/5f3f065c14aa2c2cabf8c4c88dd91510a9a7203c/decoder/body_candidates.go#L46-L47