### PR TITLE
unpublish `decoder.BlockSchemaToCandidate`

### DIFF
--- a/decoder/block_candidates.go
+++ b/decoder/block_candidates.go
@@ -12,7 +12,7 @@ import (
 // blockSchemaToCandidate generates a lang.Candidate used for auto-complete inside an editor from a BlockSchema.
 // If `prefillRequiredFields` is `false`, it returns a snippet that does not expect any prefilled fields.
 // If `prefillRequiredFields` is `true`, it returns a snippet that is compatiable with a list of prefilled fields from `generateRequiredFieldsSnippet`
-func (d *Decoder) BlockSchemaToCandidate(blockType string, block *schema.BlockSchema, rng hcl.Range) lang.Candidate {
+func (d *Decoder) blockSchemaToCandidate(blockType string, block *schema.BlockSchema, rng hcl.Range) lang.Candidate {
 	triggerSuggest := false
 	if len(block.Labels) > 0 {
 		// We make some naive assumptions here for simplicity

--- a/decoder/body_candidates.go
+++ b/decoder/body_candidates.go
@@ -72,7 +72,7 @@ func (d *Decoder) bodySchemaCandidates(body *hclsyntax.Body, schema *schema.Body
 			return candidates
 		}
 
-		candidates.List = append(candidates.List, d.BlockSchemaToCandidate(bType, block, editRng))
+		candidates.List = append(candidates.List, d.blockSchemaToCandidate(bType, block, editRng))
 		count++
 	}
 


### PR DESCRIPTION
I believe this method was made public by accident and there is no need for it to be exposed to downstream consumers.

I noticed it when reading through the generated docs at https://pkg.go.dev/github.com/hashicorp/hcl-lang@v0.0.0-20211007133712-213283ecef47/decoder#Decoder.BlockSchemaToCandidate
