### PR TITLE
Introduce LocalOrigin + PathOrigin & schema.PathTarget

### DIFF
--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -1,10 +1,8 @@
 package decoder
 
 import (
-	"context"
 	"fmt"
 
-	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -13,11 +11,6 @@ import (
 type Decoder struct {
 	ctx        DecoderContext
 	pathReader PathReader
-}
-
-type PathReader interface {
-	Paths(ctx context.Context) []lang.Path
-	PathContext(path lang.Path) (*PathContext, error)
 }
 
 // NewDecoder creates a new Decoder

--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -2,6 +2,7 @@ package decoder
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/hcl-lang/lang"
@@ -24,7 +25,11 @@ func (r *testPathReader) Paths(ctx context.Context) []lang.Path {
 }
 
 func (r *testPathReader) PathContext(path lang.Path) (*PathContext, error) {
-	return r.paths[path.Path], nil
+	if ctx, ok := r.paths[path.Path]; ok {
+		return ctx, nil
+	}
+
+	return nil, fmt.Errorf("path not found: %q", path.Path)
 }
 
 func testPathDecoder(t *testing.T, pathCtx *PathContext) *PathDecoder {

--- a/decoder/hover.go
+++ b/decoder/hover.go
@@ -594,20 +594,21 @@ func stringValFromTemplateExpr(tplExpr *hclsyntax.TemplateExpr) (cty.Value, bool
 }
 
 func (d *PathDecoder) hoverContentForTraversalExpr(traversal hcl.Traversal, tes []schema.TraversalExpr) (string, error) {
-	origin, err := reference.TraversalToOrigin(traversal, tes)
+	origin, err := reference.TraversalToLocalOrigin(traversal, tes)
 	if err != nil {
 		return "", nil
 	}
 
-	ref, ok := d.pathCtx.ReferenceTargets.FirstTargetableBy(origin)
+	targets, ok := d.pathCtx.ReferenceTargets.Match(origin.Address(), origin.OriginConstraints())
 	if !ok {
 		return "", &reference.NoTargetFound{}
 	}
 
-	return hoverContentForReferenceTarget(ref)
+	// TODO: Reflect additional found targets here?
+	return hoverContentForReferenceTarget(targets[0])
 }
 
-func hoverContentForReferenceTarget(ref *reference.Target) (string, error) {
+func hoverContentForReferenceTarget(ref reference.Target) (string, error) {
 	content := fmt.Sprintf("`%s`", ref.Addr.String())
 
 	var friendlyName string

--- a/decoder/path_reader.go
+++ b/decoder/path_reader.go
@@ -1,0 +1,27 @@
+package decoder
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/hcl-lang/lang"
+)
+
+type PathReader interface {
+	Paths(ctx context.Context) []lang.Path
+	PathContext(path lang.Path) (*PathContext, error)
+}
+
+type pathReaderKey struct{}
+
+func withPathReader(ctx context.Context, pathReader PathReader) context.Context {
+	return context.WithValue(ctx, pathReaderKey{}, pathReader)
+}
+
+func PathReaderFromContext(ctx context.Context) (PathReader, error) {
+	pathReader, ok := ctx.Value(pathReaderKey{}).(PathReader)
+	if !ok {
+		return nil, fmt.Errorf("path reader not found")
+	}
+	return pathReader, nil
+}

--- a/decoder/reference_origins.go
+++ b/decoder/reference_origins.go
@@ -77,6 +77,23 @@ func (d *PathDecoder) referenceOriginsInBody(body hcl.Body, bodySchema *schema.B
 			aSchema = bodySchema.AnyAttribute
 		}
 
+		if aSchema.OriginForTarget != nil {
+			targetAddr, ok := resolveAttributeAddress(attr, aSchema.OriginForTarget.Address)
+			if ok {
+				origins = append(origins, reference.PathOrigin{
+					Range:      attr.NameRange,
+					TargetAddr: targetAddr,
+					TargetPath: aSchema.OriginForTarget.Path,
+					Constraints: reference.OriginConstraints{
+						{
+							OfScopeId: aSchema.OriginForTarget.Constraints.ScopeId,
+							OfType:    aSchema.OriginForTarget.Constraints.Type,
+						},
+					},
+				})
+			}
+		}
+
 		origins = append(origins, d.findOriginsInExpression(attr.Expr, aSchema.Expr)...)
 	}
 

--- a/decoder/reference_origins_collect_hcl_test.go
+++ b/decoder/reference_origins_collect_hcl_test.go
@@ -46,7 +46,7 @@ func TestCollectReferenceOrigins_hcl(t *testing.T) {
 			},
 			`attr = onestep`,
 			reference.Origins{
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "onestep"},
 					},
@@ -92,7 +92,7 @@ func TestCollectReferenceOrigins_hcl(t *testing.T) {
 attr2 = anotherstep
 attr3 = onestep`,
 			reference.Origins{
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "onestep"},
 					},
@@ -111,7 +111,7 @@ attr3 = onestep`,
 						},
 					},
 				},
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "anotherstep"},
 					},
@@ -130,7 +130,7 @@ attr3 = onestep`,
 						},
 					},
 				},
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "onestep"},
 					},
@@ -164,7 +164,7 @@ attr3 = onestep`,
 			},
 			`attr1 = "${onestep}-${onestep}-${another.foo.bar}"`,
 			reference.Origins{
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "onestep"},
 					},
@@ -183,7 +183,7 @@ attr3 = onestep`,
 						},
 					},
 				},
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "onestep"},
 					},
@@ -202,7 +202,7 @@ attr3 = onestep`,
 						},
 					},
 				},
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "another"},
 						lang.AttrStep{Name: "foo"},
@@ -238,7 +238,7 @@ attr3 = onestep`,
 			},
 			`attr = one.two["key"].attr[0]`,
 			reference.Origins{
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "one"},
 						lang.AttrStep{Name: "two"},
@@ -285,7 +285,7 @@ attr3 = onestep`,
 }
 `,
 			reference.Origins{
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "onestep"},
 					},
@@ -326,7 +326,7 @@ attr3 = onestep`,
 }
 `,
 			reference.Origins{
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "onestep"},
 					},
@@ -388,7 +388,7 @@ attr3 = onestep`,
 }
 `,
 			reference.Origins{
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "var"},
 						lang.AttrStep{Name: "first"},
@@ -408,7 +408,7 @@ attr3 = onestep`,
 						},
 					},
 				},
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "var"},
 						lang.AttrStep{Name: "second"},
@@ -471,7 +471,7 @@ attr3 = onestep`,
 }
 `,
 			reference.Origins{
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "var"},
 						lang.AttrStep{Name: "first"},
@@ -539,7 +539,7 @@ set = [ var.second ]
 tuple = [ var.third ]
 `,
 			reference.Origins{
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "var"},
 						lang.AttrStep{Name: "first"},
@@ -561,7 +561,7 @@ tuple = [ var.third ]
 						{OfScopeId: lang.ScopeId("test")},
 					},
 				},
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "var"},
 						lang.AttrStep{Name: "second"},
@@ -583,7 +583,7 @@ tuple = [ var.third ]
 						{OfScopeId: lang.ScopeId("test")},
 					},
 				},
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "var"},
 						lang.AttrStep{Name: "third"},
@@ -632,7 +632,7 @@ tuple = [ var.third ]
   attr = var.first
 }`,
 			reference.Origins{
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "var"},
 						lang.AttrStep{Name: "first"},
@@ -677,7 +677,7 @@ tuple = [ var.third ]
   key = var.first
 }`,
 			reference.Origins{
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "var"},
 						lang.AttrStep{Name: "first"},
@@ -720,7 +720,7 @@ tuple = [ var.third ]
 			},
 			`tuple_cons = [ var.one ]`,
 			reference.Origins{
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "var"},
 						lang.AttrStep{Name: "one"},
@@ -784,7 +784,7 @@ obj = {
 }
 `,
 			reference.Origins{
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "var"},
 						lang.AttrStep{Name: "one"},
@@ -806,7 +806,7 @@ obj = {
 						{OfType: cty.String},
 					},
 				},
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "var"},
 						lang.AttrStep{Name: "two"},
@@ -873,7 +873,7 @@ set = [ var.two ]
 tup = [ var.three ]
 `,
 			reference.Origins{
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "var"},
 						lang.AttrStep{Name: "one"},
@@ -895,7 +895,7 @@ tup = [ var.three ]
 						{OfType: cty.String},
 					},
 				},
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "var"},
 						lang.AttrStep{Name: "two"},
@@ -917,7 +917,7 @@ tup = [ var.three ]
 						{OfType: cty.String},
 					},
 				},
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "var"},
 						lang.AttrStep{Name: "three"},

--- a/decoder/reference_origins_collect_json_test.go
+++ b/decoder/reference_origins_collect_json_test.go
@@ -46,7 +46,7 @@ func TestCollectReferenceOrigins_json(t *testing.T) {
 			},
 			`{"attr": "${onestep}"}`,
 			reference.Origins{
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "onestep"},
 					},
@@ -93,7 +93,7 @@ func TestCollectReferenceOrigins_json(t *testing.T) {
   "attr3": "${onestep}"
 }`,
 			reference.Origins{
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "onestep"},
 					},
@@ -111,7 +111,7 @@ func TestCollectReferenceOrigins_json(t *testing.T) {
 						},
 					},
 				},
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "anotherstep"},
 					},
@@ -129,7 +129,7 @@ func TestCollectReferenceOrigins_json(t *testing.T) {
 						},
 					},
 				},
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "onestep"},
 					},
@@ -162,7 +162,7 @@ func TestCollectReferenceOrigins_json(t *testing.T) {
 			},
 			`{"attr1": "${onestep}-${onestep}-${another.foo.bar}"}`,
 			reference.Origins{
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "onestep"},
 					},
@@ -180,7 +180,7 @@ func TestCollectReferenceOrigins_json(t *testing.T) {
 						},
 					},
 				},
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "onestep"},
 					},
@@ -198,7 +198,7 @@ func TestCollectReferenceOrigins_json(t *testing.T) {
 						},
 					},
 				},
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "another"},
 						lang.AttrStep{Name: "foo"},
@@ -233,7 +233,7 @@ func TestCollectReferenceOrigins_json(t *testing.T) {
 			},
 			`{"attr": "${one.two[\"key\"].attr[0]}"}`,
 			reference.Origins{
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "one"},
 						lang.AttrStep{Name: "two"},
@@ -281,7 +281,7 @@ func TestCollectReferenceOrigins_json(t *testing.T) {
 }
 `,
 			reference.Origins{
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "onestep"},
 					},
@@ -323,7 +323,7 @@ func TestCollectReferenceOrigins_json(t *testing.T) {
 }
 `,
 			reference.Origins{
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "onestep"},
 					},
@@ -388,7 +388,7 @@ func TestCollectReferenceOrigins_json(t *testing.T) {
 }
 `,
 			reference.Origins{
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "var"},
 						lang.AttrStep{Name: "first"},
@@ -407,7 +407,7 @@ func TestCollectReferenceOrigins_json(t *testing.T) {
 						},
 					},
 				},
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "var"},
 						lang.AttrStep{Name: "second"},
@@ -473,7 +473,7 @@ func TestCollectReferenceOrigins_json(t *testing.T) {
 }
 `,
 			reference.Origins{
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "var"},
 						lang.AttrStep{Name: "first"},
@@ -541,7 +541,7 @@ func TestCollectReferenceOrigins_json(t *testing.T) {
   "tuple": [ "${var.third}" ]
 }`,
 			reference.Origins{
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "var"},
 						lang.AttrStep{Name: "first"},
@@ -560,7 +560,7 @@ func TestCollectReferenceOrigins_json(t *testing.T) {
 						},
 					},
 				},
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "var"},
 						lang.AttrStep{Name: "second"},
@@ -579,7 +579,7 @@ func TestCollectReferenceOrigins_json(t *testing.T) {
 						},
 					},
 				},
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "var"},
 						lang.AttrStep{Name: "third"},
@@ -627,7 +627,7 @@ func TestCollectReferenceOrigins_json(t *testing.T) {
   }
 }`,
 			reference.Origins{
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "var"},
 						lang.AttrStep{Name: "first"},
@@ -671,7 +671,7 @@ func TestCollectReferenceOrigins_json(t *testing.T) {
   }
 }`,
 			reference.Origins{
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "var"},
 						lang.AttrStep{Name: "first"},
@@ -711,7 +711,7 @@ func TestCollectReferenceOrigins_json(t *testing.T) {
 			},
 			`{"tuple_cons": [ "${var.one}" ]}`,
 			reference.Origins{
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "var"},
 						lang.AttrStep{Name: "one"},
@@ -774,7 +774,7 @@ func TestCollectReferenceOrigins_json(t *testing.T) {
 }
 `,
 			reference.Origins{
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "var"},
 						lang.AttrStep{Name: "one"},
@@ -793,7 +793,7 @@ func TestCollectReferenceOrigins_json(t *testing.T) {
 						},
 					},
 				},
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "var"},
 						lang.AttrStep{Name: "two"},
@@ -858,7 +858,7 @@ func TestCollectReferenceOrigins_json(t *testing.T) {
   "tup": [ "${var.three}" ]
 }`,
 			reference.Origins{
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "var"},
 						lang.AttrStep{Name: "one"},
@@ -877,7 +877,7 @@ func TestCollectReferenceOrigins_json(t *testing.T) {
 						},
 					},
 				},
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "var"},
 						lang.AttrStep{Name: "two"},
@@ -896,7 +896,7 @@ func TestCollectReferenceOrigins_json(t *testing.T) {
 						},
 					},
 				},
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "var"},
 						lang.AttrStep{Name: "three"},

--- a/decoder/reference_origins_test.go
+++ b/decoder/reference_origins_test.go
@@ -110,7 +110,7 @@ func TestReferenceOriginsTargetingPos(t *testing.T) {
 				},
 			},
 			reference.Origins{
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "var"},
 						lang.AttrStep{Name: "test"},
@@ -197,7 +197,7 @@ func TestReferenceOriginsTargetingPos(t *testing.T) {
 				},
 			},
 			reference.Origins{
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "var"},
 						lang.AttrStep{Name: "test"},
@@ -293,7 +293,7 @@ func TestReferenceOriginsTargetingPos(t *testing.T) {
 				},
 			},
 			reference.Origins{
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "aws_instance"},
 						lang.AttrStep{Name: "test"},
@@ -317,7 +317,7 @@ func TestReferenceOriginsTargetingPos(t *testing.T) {
 						},
 					},
 				},
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "aws_instance"},
 						lang.AttrStep{Name: "test"},
@@ -419,7 +419,7 @@ func TestReferenceOriginsTargetingPos(t *testing.T) {
 				},
 			},
 			reference.Origins{
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "module"},
 						lang.AttrStep{Name: "test"},
@@ -443,7 +443,7 @@ func TestReferenceOriginsTargetingPos(t *testing.T) {
 						},
 					},
 				},
-				{
+				reference.LocalOrigin{
 					Addr: lang.Address{
 						lang.RootStep{Name: "module"},
 						lang.AttrStep{Name: "test"},

--- a/decoder/semantic_tokens.go
+++ b/decoder/semantic_tokens.go
@@ -147,12 +147,12 @@ func (d *PathDecoder) tokensForExpression(expr hclsyntax.Expression, constraints
 		if ok && d.pathCtx.ReferenceTargets != nil {
 			traversal := eType.AsTraversal()
 
-			origin, err := reference.TraversalToOrigin(traversal, tes)
+			origin, err := reference.TraversalToLocalOrigin(traversal, tes)
 			if err != nil {
 				return tokens
 			}
 
-			_, targetFound := d.pathCtx.ReferenceTargets.FirstTargetableBy(origin)
+			_, targetFound := d.pathCtx.ReferenceTargets.Match(origin.Address(), origin.OriginConstraints())
 			if !targetFound {
 				return tokens
 			}

--- a/lang/path.go
+++ b/lang/path.go
@@ -4,3 +4,7 @@ type Path struct {
 	Path       string
 	LanguageID string
 }
+
+func (path Path) Equals(p Path) bool {
+	return path.Path == p.Path && path.LanguageID == p.LanguageID
+}

--- a/reference/origin.go
+++ b/reference/origin.go
@@ -20,7 +20,7 @@ type Origin struct {
 
 func (ro Origin) Copy() Origin {
 	return Origin{
-		Addr:        ro.Addr,
+		Addr:        ro.Addr.Copy(),
 		Range:       ro.Range,
 		Constraints: ro.Constraints.Copy(),
 	}

--- a/reference/origin.go
+++ b/reference/origin.go
@@ -5,23 +5,12 @@ import (
 	"github.com/hashicorp/hcl/v2"
 )
 
-type Origin struct {
-	Addr  lang.Address
-	Range hcl.Range
+type originSigil struct{}
 
-	// Constraints represents any traversal expression constraints
-	// for the attribute where the origin was found.
-	//
-	// Further matching against decoded reference targets is needed
-	// for >1 constraints, which is done later at runtime as
-	// targets and origins can be decoded at different times.
-	Constraints OriginConstraints
-}
-
-func (ro Origin) Copy() Origin {
-	return Origin{
-		Addr:        ro.Addr.Copy(),
-		Range:       ro.Range,
-		Constraints: ro.Constraints.Copy(),
-	}
+type Origin interface {
+	isOriginImpl() originSigil
+	Copy() Origin
+	OriginRange() hcl.Range
+	OriginConstraints() OriginConstraints
+	Address() lang.Address
 }

--- a/reference/origin_local.go
+++ b/reference/origin_local.go
@@ -1,0 +1,48 @@
+package reference
+
+import (
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl/v2"
+)
+
+// LocalOrigin represents a resolved reference origin (traversal)
+// targeting a *local* attribute or a block within the same path
+type LocalOrigin struct {
+	// Addr describes the resolved address of the reference
+	Addr lang.Address
+
+	// Range represents the range of the traversal
+	Range hcl.Range
+
+	// Constraints represents any traversal expression constraints
+	// for the attribute where the origin was found.
+	//
+	// Further matching against decoded reference targets is needed
+	// for >1 constraints, which is done later at runtime as
+	// targets and origins can be decoded at different times.
+	Constraints OriginConstraints
+}
+
+func (lo LocalOrigin) Copy() Origin {
+	return LocalOrigin{
+		Addr:        lo.Addr.Copy(),
+		Range:       lo.Range,
+		Constraints: lo.Constraints.Copy(),
+	}
+}
+
+func (LocalOrigin) isOriginImpl() originSigil {
+	return originSigil{}
+}
+
+func (lo LocalOrigin) OriginRange() hcl.Range {
+	return lo.Range
+}
+
+func (lo LocalOrigin) OriginConstraints() OriginConstraints {
+	return lo.Constraints
+}
+
+func (lo LocalOrigin) Address() lang.Address {
+	return lo.Addr
+}

--- a/reference/origin_path.go
+++ b/reference/origin_path.go
@@ -1,0 +1,48 @@
+package reference
+
+import (
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl/v2"
+)
+
+// PathOrigin represents a resolved reference origin
+// targeting an attribute or a block in a separate path
+type PathOrigin struct {
+	// Range represents a range of a local traversal or an attribute
+	Range hcl.Range
+
+	// TargetAddr describes the address of the targeted attribute or block
+	TargetAddr lang.Address
+
+	// TargetPath represents what Path does the origin target
+	TargetPath lang.Path
+
+	// Constraints represent any constraints to use when filtering
+	// the targets within the destination Path
+	Constraints OriginConstraints
+}
+
+func (po PathOrigin) Copy() Origin {
+	return PathOrigin{
+		Range:       po.Range,
+		TargetAddr:  po.TargetAddr.Copy(),
+		TargetPath:  po.TargetPath,
+		Constraints: po.Constraints.Copy(),
+	}
+}
+
+func (PathOrigin) isOriginImpl() originSigil {
+	return originSigil{}
+}
+
+func (po PathOrigin) OriginRange() hcl.Range {
+	return po.Range
+}
+
+func (po PathOrigin) OriginConstraints() OriginConstraints {
+	return po.Constraints
+}
+
+func (po PathOrigin) Address() lang.Address {
+	return po.TargetAddr
+}

--- a/reference/target.go
+++ b/reference/target.go
@@ -98,26 +98,26 @@ func (ref Target) ConformsToType(typ cty.Type) bool {
 	return conformsToType || (typ == cty.NilType && ref.Type == cty.NilType)
 }
 
-func (target Target) IsTargetableBy(origin Origin) bool {
-	if len(target.Addr) > len(origin.Addr) {
+func (target Target) Matches(addr lang.Address, cons OriginConstraints) bool {
+	if len(target.Addr) > len(addr) {
 		return false
 	}
 
-	originAddr := origin.Addr
+	originAddr := addr
 
 	matchesCons := false
 
-	if len(origin.Constraints) == 0 && target.Type != cty.NilType {
+	if len(cons) == 0 && target.Type != cty.NilType {
 		matchesCons = true
 	}
 
-	for _, cons := range origin.Constraints {
+	for _, cons := range cons {
 		if !target.MatchesScopeId(cons.OfScopeId) {
 			continue
 		}
 
 		if target.Type == cty.DynamicPseudoType {
-			originAddr = origin.Addr.FirstSteps(uint(len(target.Addr)))
+			originAddr = addr.FirstSteps(uint(len(target.Addr)))
 			matchesCons = true
 			continue
 		}

--- a/reference/targets.go
+++ b/reference/targets.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"strings"
 
+	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
 )
@@ -100,22 +101,17 @@ func (refs Targets) containsMatch(te schema.TraversalExpr, prefix string) bool {
 	return false
 }
 
-func (refs Targets) FirstTargetableBy(origin Origin) (*Target, bool) {
-	var matchingReference *Target
+func (refs Targets) Match(addr lang.Address, cons OriginConstraints) (Targets, bool) {
+	matchingReferences := make(Targets, 0)
 
 	refs.deepWalk(func(ref Target) error {
-		if ref.IsTargetableBy(origin) {
-			matchingReference = &ref
-			return stopWalking
+		if ref.Matches(addr, cons) {
+			matchingReferences = append(matchingReferences, ref)
 		}
 		return nil
 	}, InfiniteDepth)
 
-	if matchingReference == nil {
-		return nil, false
-	}
-
-	return matchingReference, true
+	return matchingReferences, len(matchingReferences) > 0
 }
 
 func (refs Targets) OutermostInFile(file string) Targets {

--- a/reference/traversal.go
+++ b/reference/traversal.go
@@ -6,10 +6,10 @@ import (
 	"github.com/hashicorp/hcl/v2"
 )
 
-func TraversalsToOrigins(traversals []hcl.Traversal, tes schema.TraversalExprs) Origins {
+func TraversalsToLocalOrigins(traversals []hcl.Traversal, tes schema.TraversalExprs) Origins {
 	origins := make(Origins, 0)
 	for _, traversal := range traversals {
-		origin, err := TraversalToOrigin(traversal, tes)
+		origin, err := TraversalToLocalOrigin(traversal, tes)
 		if err != nil {
 			continue
 		}
@@ -19,13 +19,13 @@ func TraversalsToOrigins(traversals []hcl.Traversal, tes schema.TraversalExprs) 
 	return origins
 }
 
-func TraversalToOrigin(traversal hcl.Traversal, tes schema.TraversalExprs) (Origin, error) {
+func TraversalToLocalOrigin(traversal hcl.Traversal, tes schema.TraversalExprs) (LocalOrigin, error) {
 	addr, err := lang.TraversalToAddress(traversal)
 	if err != nil {
-		return Origin{}, err
+		return LocalOrigin{}, err
 	}
 
-	return Origin{
+	return LocalOrigin{
 		Addr:        addr,
 		Range:       traversal.SourceRange(),
 		Constraints: traversalExpressionsToOriginConstraints(tes),

--- a/reference/traversal_test.go
+++ b/reference/traversal_test.go
@@ -22,7 +22,7 @@ func TestTraversalToOrigin(t *testing.T) {
 		{
 			"one",
 			schema.TraversalExprs{},
-			Origin{
+			LocalOrigin{
 				Addr: lang.Address{
 					lang.RootStep{Name: "one"},
 				},
@@ -36,7 +36,7 @@ func TestTraversalToOrigin(t *testing.T) {
 		{
 			"first.second",
 			schema.TraversalExprs{},
-			Origin{
+			LocalOrigin{
 				Addr: lang.Address{
 					lang.RootStep{Name: "first"},
 					lang.AttrStep{Name: "second"},
@@ -51,7 +51,7 @@ func TestTraversalToOrigin(t *testing.T) {
 		{
 			"foo[2]",
 			schema.TraversalExprs{},
-			Origin{
+			LocalOrigin{
 				Addr: lang.Address{
 					lang.RootStep{Name: "foo"},
 					lang.IndexStep{Key: cty.NumberIntVal(2)},
@@ -66,7 +66,7 @@ func TestTraversalToOrigin(t *testing.T) {
 		{
 			`foo["bar"]`,
 			schema.TraversalExprs{},
-			Origin{
+			LocalOrigin{
 				Addr: lang.Address{
 					lang.RootStep{Name: "foo"},
 					lang.IndexStep{Key: cty.StringVal("bar")},
@@ -87,7 +87,7 @@ func TestTraversalToOrigin(t *testing.T) {
 				t.Fatal(diags)
 			}
 
-			origin, err := TraversalToOrigin(traversal, tc.traversalExprs)
+			origin, err := TraversalToLocalOrigin(traversal, tc.traversalExprs)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/schema/address.go
+++ b/schema/address.go
@@ -1,0 +1,48 @@
+package schema
+
+import "fmt"
+
+type Address []AddrStep
+
+func (addr Address) Copy() Address {
+	if addr == nil {
+		return nil
+	}
+
+	newAddr := make([]AddrStep, len(addr))
+	for i, step := range addr {
+		newAddr[i] = step
+	}
+	return newAddr
+}
+
+func (addr Address) AttributeValidate() error {
+	if addr == nil {
+		return nil
+	}
+
+	for i, step := range addr {
+		if _, ok := step.(LabelStep); ok {
+			return fmt.Errorf("Address[%d]: LabelStep is not valid for attribute", i)
+		}
+		if _, ok := step.(AttrValueStep); ok {
+			return fmt.Errorf("Address[%d]: AttrValueStep is not implemented for attribute", i)
+		}
+	}
+
+	return nil
+}
+
+func (addr Address) BlockValidate() error {
+	if addr == nil {
+		return nil
+	}
+
+	for i, step := range addr {
+		if _, ok := step.(AttrNameStep); ok {
+			return fmt.Errorf("Steps[%d]: AttrNameStep is not valid for block", i)
+		}
+	}
+
+	return nil
+}

--- a/schema/attribute_schema.go
+++ b/schema/attribute_schema.go
@@ -26,6 +26,11 @@ type AttributeSchema struct {
 
 	// Address describes whether and how the attribute itself is targetable
 	Address *AttributeAddrSchema
+
+	// OriginForTarget describes whether the attribute is treated
+	// as an origin for another target (e.g. module inputs,
+	// or tfvars entires in Terraform)
+	OriginForTarget *PathTarget
 }
 
 type AttributeAddrSchema struct {
@@ -74,6 +79,12 @@ func (as *AttributeSchema) Validate() error {
 		}
 	}
 
+	if as.OriginForTarget != nil {
+		if err := as.OriginForTarget.Address.AttributeValidate(); err != nil {
+			return err
+		}
+	}
+
 	return as.Expr.Validate()
 }
 
@@ -83,15 +94,16 @@ func (as *AttributeSchema) Copy() *AttributeSchema {
 	}
 
 	newAs := &AttributeSchema{
-		IsRequired:   as.IsRequired,
-		IsOptional:   as.IsOptional,
-		IsDeprecated: as.IsDeprecated,
-		IsComputed:   as.IsComputed,
-		IsSensitive:  as.IsSensitive,
-		IsDepKey:     as.IsDepKey,
-		Description:  as.Description,
-		Expr:         as.Expr.Copy(),
-		Address:      as.Address.Copy(),
+		IsRequired:      as.IsRequired,
+		IsOptional:      as.IsOptional,
+		IsDeprecated:    as.IsDeprecated,
+		IsComputed:      as.IsComputed,
+		IsSensitive:     as.IsSensitive,
+		IsDepKey:        as.IsDepKey,
+		Description:     as.Description,
+		Expr:            as.Expr.Copy(),
+		Address:         as.Address.Copy(),
+		OriginForTarget: as.OriginForTarget.Copy(),
 	}
 
 	return newAs

--- a/schema/block_schema.go
+++ b/schema/block_schema.go
@@ -31,7 +31,7 @@ type BlockSchema struct {
 }
 
 type BlockAddrSchema struct {
-	Steps []AddrStep
+	Steps Address
 
 	FriendlyName string
 	ScopeId      lang.ScopeId
@@ -82,10 +82,8 @@ type BlockAsTypeOf struct {
 }
 
 func (bas *BlockAddrSchema) Validate() error {
-	for i, step := range bas.Steps {
-		if _, ok := step.(AttrNameStep); ok {
-			return fmt.Errorf("Steps[%d]: AttrNameStep is not valid for attribute", i)
-		}
+	if err := bas.Steps.BlockValidate(); err != nil {
+		return err
 	}
 
 	if bas.InferBody && !bas.BodyAsData {
@@ -113,11 +111,7 @@ func (bas *BlockAddrSchema) Copy() *BlockAddrSchema {
 		InferBody:           bas.InferBody,
 		DependentBodyAsData: bas.DependentBodyAsData,
 		InferDependentBody:  bas.InferDependentBody,
-	}
-
-	newBas.Steps = make([]AddrStep, len(bas.Steps))
-	for i, step := range bas.Steps {
-		newBas.Steps[i] = step
+		Steps:               bas.Steps.Copy(),
 	}
 
 	return newBas

--- a/schema/block_schema_test.go
+++ b/schema/block_schema_test.go
@@ -23,7 +23,7 @@ func TestBlockSchema_Validate(t *testing.T) {
 					},
 				},
 			},
-			errors.New("Address: Steps[0]: AttrNameStep is not valid for attribute"),
+			errors.New("Address: Steps[0]: AttrNameStep is not valid for block"),
 		},
 		{
 			&BlockSchema{

--- a/schema/path_target.go
+++ b/schema/path_target.go
@@ -1,0 +1,29 @@
+package schema
+
+import (
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/zclconf/go-cty/cty"
+)
+
+type PathTarget struct {
+	Address     Address
+	Path        lang.Path
+	Constraints Constraints
+}
+
+func (pt *PathTarget) Copy() *PathTarget {
+	if pt == nil {
+		return nil
+	}
+
+	return &PathTarget{
+		Address:     pt.Address.Copy(),
+		Path:        pt.Path,
+		Constraints: pt.Constraints,
+	}
+}
+
+type Constraints struct {
+	ScopeId lang.ScopeId
+	Type    cty.Type
+}


### PR DESCRIPTION
This PR introduces a concept of a path-based origin, i.e. origin reference that is pointing to a different path, in Terraform that would be outside of a module.

In Terraform this can be represented by a module input name, pointing to the relevant variable, e.g.

```hcl
module "example" {
  source = "./module"
  foo = "bar"
}
```
where `foo` would be the `PathOrigin` and point to this block within `./module/`
```hcl
variable "foo" {
  type = string
}
```

Relatedly all the existing origins become `LocalOrigin` with all the same existing structure.

There were a few high-level API changes in that both reference-lookup-related methods were moved under `Decoder` (from `PathDecoder`) as they can now both return results outside the context of a single path and therefore also need access to other paths via the `PathReader`.

It's not the smallest PR, but also it's not as big as some other recent ones 😅  and hopefully the commit log can be helpful in walking through it.