### PR TITLE
fix: filtering of self references for cross-file references

### DIFF
--- a/decoder/expression_candidates.go
+++ b/decoder/expression_candidates.go
@@ -331,7 +331,7 @@ func (d *PathDecoder) candidatesForTraversalConstraint(tc schema.TraversalExpr, 
 
 	d.pathCtx.ReferenceTargets.MatchWalk(tc, string(prefix), func(ref reference.Target) error {
 		// avoid suggesting references to block's own fields from within (for now)
-		if ref.RangePtr != nil &&
+		if ref.RangePtr != nil && outerBodyRng.Filename == ref.RangePtr.Filename &&
 			(outerBodyRng.ContainsPos(ref.RangePtr.Start) ||
 				posEqual(outerBodyRng.End, ref.RangePtr.End)) {
 			return nil


### PR DESCRIPTION
As demonstrated by the attached test this fixes a case of completion of references where we intend to filter out external self-references to the outer block itself when the completion is requested within the block. Previously we'd only be comparing the range of completion and reference, without considering the filename.

Related: https://github.com/hashicorp/terraform-ls/issues/646