### PR TITLE
fix: avoid semantic token modifier inheritance for dependent bodies

### DIFF
--- a/decoder/semantic_tokens.go
+++ b/decoder/semantic_tokens.go
@@ -127,7 +127,7 @@ func (d *PathDecoder) tokensForBody(body *hclsyntax.Body, bodySchema *schema.Bod
 
 		depSchema, _, ok := NewBlockSchema(blockSchema).DependentBodySchema(block.AsHCLBlock())
 		if ok {
-			tokens = append(tokens, d.tokensForBody(block.Body, depSchema, true, blockModifiers)...)
+			tokens = append(tokens, d.tokensForBody(block.Body, depSchema, true, []lang.SemanticTokenModifier{})...)
 		}
 	}
 


### PR DESCRIPTION
Fixes #108 

## UX

Nested dependent blocks no longer inherit the top level modifiers.

### Before

<img width="262" alt="Screenshot 2022-03-21 at 16 46 33" src="https://user-images.githubusercontent.com/287584/159312468-01bc1677-3936-4ffb-9594-22722558e229.png">

### After

<img width="261" alt="Screenshot 2022-03-21 at 16 44 22" src="https://user-images.githubusercontent.com/287584/159312486-6ac92589-3132-4e84-a96f-fde0710de449.png">


The examples used a custom VS Code theme:

```json
{
  "name": "Example Theme",
  "semanticHighlighting": true,
  "semanticTokenColors": {
    "hcl-blockType.terraform-resource": {"fontStyle": "bold", "foreground": "#fff"},
    "hcl-blockType.terraform-data": {"fontStyle": "bold", "foreground": "#fff"},
    "hcl-blockType.terraform-module": {"fontStyle": "bold", "foreground": "#3d5aff"},
    "hcl-blockLabel.terraform-module.terraform-name": {"foreground": "#bac4ff"},
    "hcl-blockLabel.terraform-type": {"foreground": "#844FBA", "fontStyle": "bold"},
    "hcl-blockLabel.terraform-resource.terraform-name": {"foreground": "#a589b3"}
  }
}
```