### PR TITLE
schema: Make modifiers plural in LabelSchema

### DIFF
--- a/decoder/dependent_body_test.go
+++ b/decoder/dependent_body_test.go
@@ -111,17 +111,22 @@ func TestBodySchema_DependentBodySchema_dependentAttr(t *testing.T) {
 	firstDepBody := &schema.BodySchema{
 		Attributes: map[string]*schema.AttributeSchema{
 			"backend": {
-				Expr:     schema.LiteralTypeOnly(cty.String),
-				IsDepKey: true,
+				Expr:                   schema.LiteralTypeOnly(cty.String),
+				IsDepKey:               true,
+				SemanticTokenModifiers: lang.SemanticTokenModifiers{},
 			},
 		},
 	}
 	secondDepBody := &schema.BodySchema{
 		Attributes: map[string]*schema.AttributeSchema{
-			"extra": {Expr: schema.LiteralTypeOnly(cty.Number)},
+			"extra": {
+				Expr:                   schema.LiteralTypeOnly(cty.Number),
+				SemanticTokenModifiers: lang.SemanticTokenModifiers{},
+			},
 			"backend": {
-				Expr:     schema.LiteralTypeOnly(cty.String),
-				IsDepKey: true,
+				Expr:                   schema.LiteralTypeOnly(cty.String),
+				IsDepKey:               true,
+				SemanticTokenModifiers: lang.SemanticTokenModifiers{},
 			},
 		},
 	}

--- a/decoder/semantic_tokens.go
+++ b/decoder/semantic_tokens.go
@@ -84,9 +84,7 @@ func (d *PathDecoder) tokensForBody(body *hclsyntax.Body, bodySchema *schema.Bod
 		if isDependent {
 			blockModifiers = append(blockModifiers, lang.TokenModifierDependent)
 		}
-		if blockSchema.SemanticTokenModifier != "" {
-			blockModifiers = append(blockModifiers, blockSchema.SemanticTokenModifier)
-		}
+		blockModifiers = append(blockModifiers, blockSchema.SemanticTokenModifiers...)
 
 		tokens = append(tokens, lang.SemanticToken{
 			Type:      lang.TokenBlockType,
@@ -107,9 +105,7 @@ func (d *PathDecoder) tokensForBody(body *hclsyntax.Body, bodySchema *schema.Bod
 			if labelSchema.IsDepKey {
 				labelModifiers = append(labelModifiers, lang.TokenModifierDependent)
 			}
-			if blockSchema.SemanticTokenModifier != "" {
-				labelModifiers = append(labelModifiers, blockSchema.SemanticTokenModifier)
-			}
+			labelModifiers = append(labelModifiers, blockSchema.SemanticTokenModifiers...)
 			labelModifiers = append(labelModifiers, labelSchema.SemanticTokenModifiers...)
 
 			tokens = append(tokens, lang.SemanticToken{

--- a/decoder/semantic_tokens.go
+++ b/decoder/semantic_tokens.go
@@ -56,14 +56,16 @@ func (d *PathDecoder) tokensForBody(body *hclsyntax.Body, bodySchema *schema.Bod
 			attrSchema = bodySchema.AnyAttribute
 		}
 
-		modifiers := make([]lang.SemanticTokenModifier, 0)
+		attrModifiers := make([]lang.SemanticTokenModifier, 0)
+		attrModifiers = append(attrModifiers, parentModifiers...)
 		if isDependent {
-			modifiers = append(modifiers, lang.TokenModifierDependent)
+			attrModifiers = append(attrModifiers, lang.TokenModifierDependent)
 		}
+		attrModifiers = append(attrModifiers, attrSchema.SemanticTokenModifiers...)
 
 		tokens = append(tokens, lang.SemanticToken{
 			Type:      lang.TokenAttrName,
-			Modifiers: modifiers,
+			Modifiers: attrModifiers,
 			Range:     attr.NameRange,
 		})
 

--- a/decoder/semantic_tokens.go
+++ b/decoder/semantic_tokens.go
@@ -110,9 +110,7 @@ func (d *PathDecoder) tokensForBody(body *hclsyntax.Body, bodySchema *schema.Bod
 			if blockSchema.SemanticTokenModifier != "" {
 				labelModifiers = append(labelModifiers, blockSchema.SemanticTokenModifier)
 			}
-			if labelSchema.SemanticTokenModifier != "" {
-				labelModifiers = append(labelModifiers, labelSchema.SemanticTokenModifier)
-			}
+			labelModifiers = append(labelModifiers, labelSchema.SemanticTokenModifiers...)
 
 			tokens = append(tokens, lang.SemanticToken{
 				Type:      lang.TokenBlockLabel,

--- a/decoder/semantic_tokens.go
+++ b/decoder/semantic_tokens.go
@@ -28,7 +28,7 @@ func (d *PathDecoder) SemanticTokensInFile(filename string) ([]lang.SemanticToke
 		return []lang.SemanticToken{}, nil
 	}
 
-	tokens := d.tokensForBody(body, d.pathCtx.Schema, false, []lang.SemanticTokenModifier{})
+	tokens := d.tokensForBody(body, d.pathCtx.Schema, []lang.SemanticTokenModifier{})
 
 	sort.Slice(tokens, func(i, j int) bool {
 		return tokens[i].Range.Start.Byte < tokens[j].Range.Start.Byte
@@ -37,9 +37,7 @@ func (d *PathDecoder) SemanticTokensInFile(filename string) ([]lang.SemanticToke
 	return tokens, nil
 }
 
-func (d *PathDecoder) tokensForBody(body *hclsyntax.Body, bodySchema *schema.BodySchema,
-	isDependent bool, parentModifiers []lang.SemanticTokenModifier) []lang.SemanticToken {
-
+func (d *PathDecoder) tokensForBody(body *hclsyntax.Body, bodySchema *schema.BodySchema, parentModifiers []lang.SemanticTokenModifier) []lang.SemanticToken {
 	tokens := make([]lang.SemanticToken, 0)
 
 	if bodySchema == nil {
@@ -58,9 +56,6 @@ func (d *PathDecoder) tokensForBody(body *hclsyntax.Body, bodySchema *schema.Bod
 
 		attrModifiers := make([]lang.SemanticTokenModifier, 0)
 		attrModifiers = append(attrModifiers, parentModifiers...)
-		if isDependent {
-			attrModifiers = append(attrModifiers, lang.TokenModifierDependent)
-		}
 		attrModifiers = append(attrModifiers, attrSchema.SemanticTokenModifiers...)
 
 		tokens = append(tokens, lang.SemanticToken{
@@ -82,10 +77,6 @@ func (d *PathDecoder) tokensForBody(body *hclsyntax.Body, bodySchema *schema.Bod
 
 		blockModifiers := make([]lang.SemanticTokenModifier, 0)
 		blockModifiers = append(blockModifiers, parentModifiers...)
-
-		if isDependent {
-			blockModifiers = append(blockModifiers, lang.TokenModifierDependent)
-		}
 		blockModifiers = append(blockModifiers, blockSchema.SemanticTokenModifiers...)
 
 		tokens = append(tokens, lang.SemanticToken{
@@ -104,9 +95,6 @@ func (d *PathDecoder) tokensForBody(body *hclsyntax.Body, bodySchema *schema.Bod
 
 			labelModifiers := make([]lang.SemanticTokenModifier, 0)
 			labelModifiers = append(labelModifiers, parentModifiers...)
-			if labelSchema.IsDepKey {
-				labelModifiers = append(labelModifiers, lang.TokenModifierDependent)
-			}
 			labelModifiers = append(labelModifiers, blockSchema.SemanticTokenModifiers...)
 			labelModifiers = append(labelModifiers, labelSchema.SemanticTokenModifiers...)
 
@@ -118,12 +106,12 @@ func (d *PathDecoder) tokensForBody(body *hclsyntax.Body, bodySchema *schema.Bod
 		}
 
 		if block.Body != nil {
-			tokens = append(tokens, d.tokensForBody(block.Body, blockSchema.Body, false, blockModifiers)...)
+			tokens = append(tokens, d.tokensForBody(block.Body, blockSchema.Body, blockModifiers)...)
 		}
 
 		depSchema, _, ok := NewBlockSchema(blockSchema).DependentBodySchema(block.AsHCLBlock())
 		if ok {
-			tokens = append(tokens, d.tokensForBody(block.Body, depSchema, true, []lang.SemanticTokenModifier{})...)
+			tokens = append(tokens, d.tokensForBody(block.Body, depSchema, []lang.SemanticTokenModifier{})...)
 		}
 	}
 

--- a/decoder/semantic_tokens_test.go
+++ b/decoder/semantic_tokens_test.go
@@ -540,7 +540,7 @@ func TestDecoder_SemanticTokensInFile_customModifiers(t *testing.T) {
 	bodySchema := &schema.BodySchema{
 		Blocks: map[string]*schema.BlockSchema{
 			"module": {
-				SemanticTokenModifier: lang.SemanticTokenModifier("module"),
+				SemanticTokenModifiers: lang.SemanticTokenModifiers{"module"},
 				Labels: []*schema.LabelSchema{
 					{
 						Name:                   "name",
@@ -560,7 +560,7 @@ func TestDecoder_SemanticTokensInFile_customModifiers(t *testing.T) {
 				},
 			},
 			"resource": {
-				SemanticTokenModifier: lang.SemanticTokenModifier("resource"),
+				SemanticTokenModifiers: lang.SemanticTokenModifiers{"resource"},
 				Labels: []*schema.LabelSchema{
 					{
 						Name:                   "type",
@@ -575,7 +575,7 @@ func TestDecoder_SemanticTokensInFile_customModifiers(t *testing.T) {
 				Body: &schema.BodySchema{
 					Blocks: map[string]*schema.BlockSchema{
 						"provisioner": {
-							SemanticTokenModifier: lang.SemanticTokenModifier("provisioner"),
+							SemanticTokenModifiers: lang.SemanticTokenModifiers{"provisioner"},
 							Labels: []*schema.LabelSchema{
 								{
 									Name:                   "type",

--- a/decoder/semantic_tokens_test.go
+++ b/decoder/semantic_tokens_test.go
@@ -658,8 +658,10 @@ resource "vault_auth_backend" "blah" {
 			},
 		},
 		{ // source
-			Type:      lang.TokenAttrName,
-			Modifiers: []lang.SemanticTokenModifier{},
+			Type: lang.TokenAttrName,
+			Modifiers: []lang.SemanticTokenModifier{
+				lang.SemanticTokenModifier("module"),
+			},
 			Range: hcl.Range{
 				Filename: "test.tf",
 				Start: hcl.Pos{
@@ -692,8 +694,10 @@ resource "vault_auth_backend" "blah" {
 			},
 		},
 		{ // count
-			Type:      lang.TokenAttrName,
-			Modifiers: []lang.SemanticTokenModifier{},
+			Type: lang.TokenAttrName,
+			Modifiers: []lang.SemanticTokenModifier{
+				lang.SemanticTokenModifier("module"),
+			},
 			Range: hcl.Range{
 				Filename: "test.tf",
 				Start: hcl.Pos{

--- a/decoder/semantic_tokens_test.go
+++ b/decoder/semantic_tokens_test.go
@@ -543,8 +543,8 @@ func TestDecoder_SemanticTokensInFile_customModifiers(t *testing.T) {
 				SemanticTokenModifier: lang.SemanticTokenModifier("module"),
 				Labels: []*schema.LabelSchema{
 					{
-						Name:                  "name",
-						SemanticTokenModifier: lang.SemanticTokenModifier("name"),
+						Name:                   "name",
+						SemanticTokenModifiers: lang.SemanticTokenModifiers{"name"},
 					},
 				},
 				Body: &schema.BodySchema{
@@ -563,13 +563,13 @@ func TestDecoder_SemanticTokensInFile_customModifiers(t *testing.T) {
 				SemanticTokenModifier: lang.SemanticTokenModifier("resource"),
 				Labels: []*schema.LabelSchema{
 					{
-						Name:                  "type",
-						IsDepKey:              true,
-						SemanticTokenModifier: lang.SemanticTokenModifier("type"),
+						Name:                   "type",
+						IsDepKey:               true,
+						SemanticTokenModifiers: lang.SemanticTokenModifiers{"type"},
 					},
 					{
-						Name:                  "name",
-						SemanticTokenModifier: lang.SemanticTokenModifier("name"),
+						Name:                   "name",
+						SemanticTokenModifiers: lang.SemanticTokenModifiers{"name"},
 					},
 				},
 				Body: &schema.BodySchema{
@@ -578,8 +578,8 @@ func TestDecoder_SemanticTokensInFile_customModifiers(t *testing.T) {
 							SemanticTokenModifier: lang.SemanticTokenModifier("provisioner"),
 							Labels: []*schema.LabelSchema{
 								{
-									Name:                  "type",
-									SemanticTokenModifier: lang.SemanticTokenModifier("type"),
+									Name:                   "type",
+									SemanticTokenModifiers: lang.SemanticTokenModifiers{"type"},
 								},
 							},
 						},

--- a/decoder/semantic_tokens_test.go
+++ b/decoder/semantic_tokens_test.go
@@ -106,13 +106,22 @@ func TestDecoder_SemanticTokensInFile_basic(t *testing.T) {
 						"source": {
 							Expr:         schema.LiteralTypeOnly(cty.String),
 							IsDeprecated: true,
+							SemanticTokenModifiers: lang.SemanticTokenModifiers{
+								lang.TokenModifierDependent,
+							},
 						},
 					},
 				},
 			},
 			"resource": {
 				Labels: []*schema.LabelSchema{
-					{Name: "type", IsDepKey: true},
+					{
+						Name:     "type",
+						IsDepKey: true,
+						SemanticTokenModifiers: lang.SemanticTokenModifiers{
+							lang.TokenModifierDependent,
+						},
+					},
 					{Name: "name"},
 				},
 			},
@@ -164,8 +173,10 @@ resource "vault_auth_backend" "blah" {
 			},
 		},
 		{ // source
-			Type:      lang.TokenAttrName,
-			Modifiers: []lang.SemanticTokenModifier{},
+			Type: lang.TokenAttrName,
+			Modifiers: []lang.SemanticTokenModifier{
+				lang.TokenModifierDependent,
+			},
 			Range: hcl.Range{
 				Filename: "test.tf",
 				Start: hcl.Pos{
@@ -297,7 +308,13 @@ func TestDecoder_SemanticTokensInFile_dependentSchema(t *testing.T) {
 		Blocks: map[string]*schema.BlockSchema{
 			"resource": {
 				Labels: []*schema.LabelSchema{
-					{Name: "type", IsDepKey: true},
+					{
+						Name:     "type",
+						IsDepKey: true,
+						SemanticTokenModifiers: lang.SemanticTokenModifiers{
+							lang.TokenModifierDependent,
+						},
+					},
 					{Name: "name"},
 				},
 				DependentBody: map[schema.SchemaKey]*schema.BodySchema{
@@ -457,10 +474,8 @@ resource "aws_instance" "beta" {
 			},
 		},
 		{ // instance_type
-			Type: lang.TokenAttrName,
-			Modifiers: []lang.SemanticTokenModifier{
-				lang.TokenModifierDependent,
-			},
+			Type:      lang.TokenAttrName,
+			Modifiers: []lang.SemanticTokenModifier{},
 			Range: hcl.Range{
 				Filename: "test.tf",
 				Start: hcl.Pos{
@@ -493,10 +508,8 @@ resource "aws_instance" "beta" {
 			},
 		},
 		{ // deprecated
-			Type: lang.TokenAttrName,
-			Modifiers: []lang.SemanticTokenModifier{
-				lang.TokenModifierDependent,
-			},
+			Type:      lang.TokenAttrName,
+			Modifiers: []lang.SemanticTokenModifier{},
 			Range: hcl.Range{
 				Filename: "test.tf",
 				Start: hcl.Pos{
@@ -553,8 +566,9 @@ func TestDecoder_SemanticTokensInFile_customModifiers(t *testing.T) {
 							Expr: schema.LiteralTypeOnly(cty.Number),
 						},
 						"source": {
-							Expr:         schema.LiteralTypeOnly(cty.String),
-							IsDeprecated: true,
+							Expr:                   schema.LiteralTypeOnly(cty.String),
+							IsDeprecated:           true,
+							SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent},
 						},
 					},
 				},
@@ -565,7 +579,7 @@ func TestDecoder_SemanticTokensInFile_customModifiers(t *testing.T) {
 					{
 						Name:                   "type",
 						IsDepKey:               true,
-						SemanticTokenModifiers: lang.SemanticTokenModifiers{"type"},
+						SemanticTokenModifiers: lang.SemanticTokenModifiers{"type", lang.TokenModifierDependent},
 					},
 					{
 						Name:                   "name",
@@ -661,6 +675,7 @@ resource "vault_auth_backend" "blah" {
 			Type: lang.TokenAttrName,
 			Modifiers: []lang.SemanticTokenModifier{
 				lang.SemanticTokenModifier("module"),
+				lang.TokenModifierDependent,
 			},
 			Range: hcl.Range{
 				Filename: "test.tf",
@@ -751,9 +766,9 @@ resource "vault_auth_backend" "blah" {
 		{ // vault_auth_backend
 			Type: lang.TokenBlockLabel,
 			Modifiers: []lang.SemanticTokenModifier{
-				lang.TokenModifierDependent,
 				lang.SemanticTokenModifier("resource"),
 				lang.SemanticTokenModifier("type"),
+				lang.TokenModifierDependent,
 			},
 			Range: hcl.Range{
 				Filename: "test.tf",

--- a/lang/semantic_token.go
+++ b/lang/semantic_token.go
@@ -6,7 +6,7 @@ import (
 
 type SemanticToken struct {
 	Type      SemanticTokenType
-	Modifiers []SemanticTokenModifier
+	Modifiers SemanticTokenModifiers
 	Range     hcl.Range
 }
 
@@ -48,6 +48,18 @@ var SupportedSemanticTokenTypes = SemanticTokenTypes{
 }
 
 type SemanticTokenModifier string
+
+type SemanticTokenModifiers []SemanticTokenModifier
+
+func (stm SemanticTokenModifiers) Copy() SemanticTokenModifiers {
+	if stm == nil {
+		return nil
+	}
+
+	modifiersCopy := make(SemanticTokenModifiers, len(stm))
+	copy(modifiersCopy, stm)
+	return modifiersCopy
+}
 
 const (
 	TokenModifierDependent = SemanticTokenModifier("hcl-dependent")

--- a/schema/attribute_schema.go
+++ b/schema/attribute_schema.go
@@ -31,6 +31,11 @@ type AttributeSchema struct {
 	// as an origin for another target (e.g. module inputs,
 	// or tfvars entires in Terraform)
 	OriginForTarget *PathTarget
+
+	// SemanticTokenModifiers represents the semantic token modifiers
+	// to report for the attribute name
+	// (in addition to any modifiers of any parent blocks)
+	SemanticTokenModifiers lang.SemanticTokenModifiers
 }
 
 type AttributeAddrSchema struct {
@@ -94,16 +99,17 @@ func (as *AttributeSchema) Copy() *AttributeSchema {
 	}
 
 	newAs := &AttributeSchema{
-		IsRequired:      as.IsRequired,
-		IsOptional:      as.IsOptional,
-		IsDeprecated:    as.IsDeprecated,
-		IsComputed:      as.IsComputed,
-		IsSensitive:     as.IsSensitive,
-		IsDepKey:        as.IsDepKey,
-		Description:     as.Description,
-		Expr:            as.Expr.Copy(),
-		Address:         as.Address.Copy(),
-		OriginForTarget: as.OriginForTarget.Copy(),
+		IsRequired:             as.IsRequired,
+		IsOptional:             as.IsOptional,
+		IsDeprecated:           as.IsDeprecated,
+		IsComputed:             as.IsComputed,
+		IsSensitive:            as.IsSensitive,
+		IsDepKey:               as.IsDepKey,
+		Description:            as.Description,
+		Expr:                   as.Expr.Copy(),
+		Address:                as.Address.Copy(),
+		OriginForTarget:        as.OriginForTarget.Copy(),
+		SemanticTokenModifiers: as.SemanticTokenModifiers.Copy(),
 	}
 
 	return newAs

--- a/schema/block_schema.go
+++ b/schema/block_schema.go
@@ -14,10 +14,10 @@ type BlockSchema struct {
 	Labels []*LabelSchema
 	Type   BlockType
 
-	// SemanticTokenModifier represents the semantic token modifier
+	// SemanticTokenModifiers represents the semantic token modifiers
 	// to report for the block's type and labels
 	// (in addition to any modifiers of any parent blocks)
-	SemanticTokenModifier lang.SemanticTokenModifier
+	SemanticTokenModifiers lang.SemanticTokenModifiers
 
 	// Body represents the body within block
 	// such as attributes and nested blocks
@@ -167,14 +167,14 @@ func (bs *BlockSchema) Copy() *BlockSchema {
 	}
 
 	newBs := &BlockSchema{
-		Type:                  bs.Type,
-		SemanticTokenModifier: bs.SemanticTokenModifier,
-		IsDeprecated:          bs.IsDeprecated,
-		MinItems:              bs.MinItems,
-		MaxItems:              bs.MaxItems,
-		Description:           bs.Description,
-		Body:                  bs.Body.Copy(),
-		Address:               bs.Address.Copy(),
+		Type:                   bs.Type,
+		SemanticTokenModifiers: bs.SemanticTokenModifiers.Copy(),
+		IsDeprecated:           bs.IsDeprecated,
+		MinItems:               bs.MinItems,
+		MaxItems:               bs.MaxItems,
+		Description:            bs.Description,
+		Body:                   bs.Body.Copy(),
+		Address:                bs.Address.Copy(),
 	}
 
 	if bs.Labels != nil {

--- a/schema/label_schema.go
+++ b/schema/label_schema.go
@@ -11,7 +11,7 @@ type LabelSchema struct {
 
 	// SemanticTokenModifier represents the semantic token modifier
 	// (if any) to report for the label (in addition to any block modifiers)
-	SemanticTokenModifier lang.SemanticTokenModifier
+	SemanticTokenModifiers lang.SemanticTokenModifiers
 
 	// IsDepKey describes whether to use this label as key
 	// when looking up dependent schema
@@ -33,10 +33,10 @@ func (ls *LabelSchema) Copy() *LabelSchema {
 	}
 
 	return &LabelSchema{
-		Name:                  ls.Name,
-		SemanticTokenModifier: ls.SemanticTokenModifier,
-		Completable:           ls.Completable,
-		Description:           ls.Description,
-		IsDepKey:              ls.IsDepKey,
+		Name:                   ls.Name,
+		SemanticTokenModifiers: ls.SemanticTokenModifiers.Copy(),
+		Completable:            ls.Completable,
+		Description:            ls.Description,
+		IsDepKey:               ls.IsDepKey,
 	}
 }


### PR DESCRIPTION
This is to enable https://github.com/hashicorp/terraform-schema/issues/96

---

The PR introduces a number of changes:

 - `SemanticTokenModifier` in `LabelSchema` becomes plural, allowing assignment of more than 1 modifier via schema
 - `SemanticTokenModifier` in `BlockSchema` becomes plural, allowing assignment of more than 1 modifier via schema (this actually remains unused downstream in https://github.com/hashicorp/terraform-schema/pull/100 but it's mostly just to align the API and make it more flexible 🤷🏻 
 - Introduce `SemanticTokenModifiers` to `AttrSchema` such that we can use it downstream to report dependent attributes and later for adding any more modifiers per https://github.com/hashicorp/terraform-ls/issues/835
 - Removes auto-assignment of the dependent modifier, to apply the "principle of least surprise". https://github.com/hashicorp/terraform-schema/pull/100 basically reintroduces these modifiers more explicitly - which can be verbose but I still believe explicit & verbose is better than brief and magic.