### PR TITLE
Expose new kind of origins

### DIFF
--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -70,9 +70,7 @@ func mergeBlockBodySchemas(block *hcl.Block, blockSchema *schema.BlockSchema) (*
 			mergedSchema.TargetableAs = append(mergedSchema.TargetableAs, tBody)
 		}
 
-		if depSchema.Targets != nil {
-			mergedSchema.Targets = depSchema.Targets.Copy()
-		}
+		mergedSchema.Targets = depSchema.Targets.Copy()
 	}
 
 	return mergedSchema, nil

--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -69,6 +69,10 @@ func mergeBlockBodySchemas(block *hcl.Block, blockSchema *schema.BlockSchema) (*
 		for _, tBody := range depSchema.TargetableAs {
 			mergedSchema.TargetableAs = append(mergedSchema.TargetableAs, tBody)
 		}
+
+		if depSchema.Targets != nil {
+			mergedSchema.Targets = depSchema.Targets.Copy()
+		}
 	}
 
 	return mergedSchema, nil

--- a/decoder/reference_origins.go
+++ b/decoder/reference_origins.go
@@ -111,6 +111,14 @@ func (d *PathDecoder) referenceOriginsInBody(body hcl.Body, bodySchema *schema.B
 			}
 		}
 
+		if aSchema.IsDepKey && bodySchema.Targets != nil {
+			origins = append(origins, reference.DirectOrigin{
+				Range:       attr.Expr.Range(),
+				TargetPath:  bodySchema.Targets.Path,
+				TargetRange: bodySchema.Targets.Range,
+			})
+		}
+
 		origins = append(origins, d.findOriginsInExpression(attr.Expr, aSchema.Expr)...)
 	}
 

--- a/decoder/reference_targets_test.go
+++ b/decoder/reference_targets_test.go
@@ -280,6 +280,49 @@ func TestReferenceTargetForOriginAtPos(t *testing.T) {
 			},
 			nil,
 		},
+		{
+			"direct origin target",
+			map[string]*PathContext{
+				dirPath: {
+					ReferenceTargets: reference.Targets{},
+					ReferenceOrigins: reference.Origins{
+						reference.DirectOrigin{
+							Range: hcl.Range{
+								Filename: "test.tf",
+								Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+								End:      hcl.Pos{Line: 1, Column: 6, Byte: 5},
+							},
+							TargetPath: lang.Path{Path: dirPath, LanguageID: "terraform"},
+							TargetRange: hcl.Range{
+								Filename: "target.tf",
+								Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+								End:      hcl.Pos{Line: 3, Column: 2, Byte: 15},
+							},
+						},
+					},
+				},
+			},
+			lang.Path{Path: dirPath},
+			"test.tf",
+			hcl.InitialPos,
+			ReferenceTargets{
+				{
+					OriginRange: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 6, Byte: 5},
+					},
+					Path: lang.Path{Path: dirPath, LanguageID: "terraform"},
+					Range: hcl.Range{
+						Filename: "target.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 3, Column: 2, Byte: 15},
+					},
+					DefRangePtr: nil,
+				},
+			},
+			nil,
+		},
 	}
 
 	for i, tc := range testCases {

--- a/reference/origin.go
+++ b/reference/origin.go
@@ -11,6 +11,10 @@ type Origin interface {
 	isOriginImpl() originSigil
 	Copy() Origin
 	OriginRange() hcl.Range
+}
+
+type MatchableOrigin interface {
+	Origin
 	OriginConstraints() OriginConstraints
 	Address() lang.Address
 }

--- a/reference/origin_direct.go
+++ b/reference/origin_direct.go
@@ -1,0 +1,35 @@
+package reference
+
+import (
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl/v2"
+)
+
+// DirectOrigin represents an origin which directly targets a file
+// and doesn't need a matching target
+type DirectOrigin struct {
+	// Range represents a range of a local traversal or an attribute
+	Range hcl.Range
+
+	// TargetPath represents what Path does the origin targets
+	TargetPath lang.Path
+
+	// TargetRange represents which file and line the origin targets
+	TargetRange hcl.Range
+}
+
+func (do DirectOrigin) Copy() Origin {
+	return DirectOrigin{
+		Range:       do.Range,
+		TargetPath:  do.TargetPath,
+		TargetRange: do.TargetRange,
+	}
+}
+
+func (DirectOrigin) isOriginImpl() originSigil {
+	return originSigil{}
+}
+
+func (do DirectOrigin) OriginRange() hcl.Range {
+	return do.Range
+}

--- a/reference/origin_direct.go
+++ b/reference/origin_direct.go
@@ -8,10 +8,10 @@ import (
 // DirectOrigin represents an origin which directly targets a file
 // and doesn't need a matching target
 type DirectOrigin struct {
-	// Range represents a range of a local traversal or an attribute
+	// Range represents a range of a local traversal, attribute, or an expression
 	Range hcl.Range
 
-	// TargetPath represents what Path does the origin targets
+	// TargetPath represents what (directory) Path does the origin targets
 	TargetPath lang.Path
 
 	// TargetRange represents which file and line the origin targets

--- a/reference/origins.go
+++ b/reference/origins.go
@@ -44,6 +44,8 @@ func (ro Origins) Match(localPath lang.Path, target Target, targetPath lang.Path
 			if origin.TargetPath.Equals(targetPath) && target.Matches(origin.Address(), origin.OriginConstraints()) {
 				origins = append(origins, refOrigin)
 			}
+		case DirectOrigin:
+			continue
 		}
 	}
 

--- a/reference/origins.go
+++ b/reference/origins.go
@@ -44,8 +44,6 @@ func (ro Origins) Match(localPath lang.Path, target Target, targetPath lang.Path
 			if origin.TargetPath.Equals(targetPath) && target.Matches(origin.Address(), origin.OriginConstraints()) {
 				origins = append(origins, refOrigin)
 			}
-		case DirectOrigin:
-			continue
 		}
 	}
 

--- a/reference/origins_test.go
+++ b/reference/origins_test.go
@@ -502,7 +502,7 @@ func TestOrigins_Match(t *testing.T) {
 			},
 		},
 		{
-			"direct origin cant be matched",
+			"direct origin cannot be matched",
 			alphaPath,
 			Origins{
 				DirectOrigin{

--- a/reference/origins_test.go
+++ b/reference/origins_test.go
@@ -501,6 +501,33 @@ func TestOrigins_Match(t *testing.T) {
 				},
 			},
 		},
+		{
+			"direct origin cant be matched",
+			alphaPath,
+			Origins{
+				DirectOrigin{
+					Range: hcl.Range{
+						Filename: "origin.tf",
+						Start:    hcl.InitialPos,
+						End:      hcl.InitialPos,
+					},
+					TargetPath: betaPath,
+					TargetRange: hcl.Range{
+						Filename: "target.tf",
+						Start:    hcl.InitialPos,
+						End:      hcl.InitialPos,
+					},
+				},
+			},
+			alphaPath,
+			Target{
+				Addr: lang.Address{
+					lang.RootStep{Name: "test"},
+				},
+				Type: cty.String,
+			},
+			Origins{},
+		},
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {

--- a/reference/targets_test.go
+++ b/reference/targets_test.go
@@ -16,7 +16,7 @@ func TestTargets_Match(t *testing.T) {
 	testCases := []struct {
 		name            string
 		targets         Targets
-		origin          Origin
+		origin          MatchableOrigin
 		expectedTargets Targets
 		expectedFound   bool
 	}{

--- a/schema/body_schema.go
+++ b/schema/body_schema.go
@@ -31,11 +31,20 @@ type BodySchema struct {
 	// TargetableAs represents how else the body may be targeted
 	// if not by its declarable attributes or blocks.
 	TargetableAs Targetables
+
+	// Targets indicates whether the something inside the body is
+	// targeting another location
+	Targets *Target
 }
 
 type DocsLink struct {
 	URL     string
 	Tooltip string
+}
+
+type Target struct {
+	Path  lang.Path
+	Range hcl.Range
 }
 
 func (*BodySchema) isSchemaImpl() schemaImplSigil {
@@ -137,6 +146,7 @@ func (bs *BodySchema) Copy() *BodySchema {
 		AnyAttribute: bs.AnyAttribute.Copy(),
 		HoverURL:     bs.HoverURL,
 		DocsLink:     bs.DocsLink.Copy(),
+		Targets:      bs.Targets.Copy(),
 	}
 
 	if bs.TargetableAs != nil {
@@ -171,5 +181,16 @@ func (dl *DocsLink) Copy() *DocsLink {
 	return &DocsLink{
 		URL:     dl.URL,
 		Tooltip: dl.Tooltip,
+	}
+}
+
+func (t *Target) Copy() *Target {
+	if t == nil {
+		return nil
+	}
+
+	return &Target{
+		Path:  t.Path,
+		Range: t.Range,
 	}
 }

--- a/schema/body_schema.go
+++ b/schema/body_schema.go
@@ -32,8 +32,8 @@ type BodySchema struct {
 	// if not by its declarable attributes or blocks.
 	TargetableAs Targetables
 
-	// Targets indicates whether the something inside the body is
-	// targeting another location
+	// Targets represents a location targeted by the body, when used as a body
+	// dependent on an attribute (e.g. Terraform module source)
 	Targets *Target
 }
 


### PR DESCRIPTION
This PR allows schemas to introduce a target for the module source attribute. We achieve this by introducing a new field `Targets` to the `BodySchema`.

Example within terraform-schema: https://github.com/hashicorp/terraform-schema/pull/101

Required for https://github.com/hashicorp/terraform-ls/issues/558