### PR TITLE
ci: reduce min threshold for k8s-metrics-server benchmark

### DIFF
--- a/decoder/candidates.go
+++ b/decoder/candidates.go
@@ -13,7 +13,7 @@ import (
 //
 // Schema is required in order to return any candidates and method will return
 // error if there isn't one.
-func (d *PathDecoder) CandidatesAtPos(filename string, pos hcl.Pos) (lang.Candidates, error) {
+func (d *PathDecoder) CandidatesAtPos(ctx context.Context, filename string, pos hcl.Pos) (lang.Candidates, error) {
 	f, err := d.fileByName(filename)
 	if err != nil {
 		return lang.ZeroCandidates(), err

--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -1,16 +1,50 @@
 package decoder
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
 )
 
 type Decoder struct {
 	ctx        DecoderContext
 	pathReader PathReader
+
+	CompletionHooks        map[string]CompletionFunc
+	CompletionResolveHooks map[string]CompletionResolveFunc
+}
+
+// TODO: We need context of other fields, like "source" for completing "version"
+type CompletionFunc func(ctx context.Context, value cty.Value) ([]Candidate, error)
+
+type CompletionResolveFunc func(ctx context.Context, candidate lang.Candidate, meta interface{}) (ResolvedCandidate, error)
+
+type Candidate struct {
+	// Value represents the value to be inserted
+	Value cty.Value
+
+	// Label represents a human-readable name of the candidate
+	// if one exists (otherwise Value is used)
+	Label string
+
+	// Description represents human-readable description
+	// of the candidate
+	Description lang.MarkupContent
+
+	// IsDeprecated indicates whether the candidate is deprecated
+	IsDeprecated bool
+
+	// ResolveHookMeta is arbitrary data to pass to the resolve the candidate
+	ResolveHookMeta interface{}
+}
+
+type ResolvedCandidate struct {
+	Description lang.MarkupContent
 }
 
 // NewDecoder creates a new Decoder

--- a/schema/attribute_schema.go
+++ b/schema/attribute_schema.go
@@ -20,6 +20,10 @@ type AttributeSchema struct {
 	// expressions are expected for the attribute
 	Expr ExprConstraints
 
+	// CompletionHookNames represents names of hooks which provide
+	// additional completion items for the attribute dynamically
+	CompletionHookNames []string
+
 	// IsDepKey describes whether to use this attribute (and its value)
 	// as key when looking up dependent schema
 	IsDepKey bool


### PR DESCRIPTION
This is to address the following nightly failure:

https://github.com/hashicorp/terraform-ls/runs/5983427527?check_suite_focus=true#step:9:1

```json
{
  "Status": "fail",
  "Diffs": [
    {
      "Status": "fail",
      "Package": "github.com/hashicorp/terraform-ls/internal/langserver/handlers",
      "Benchmark": "BenchmarkInitializeFolder_basic/k8s-metrics-server-2",
      "Value": 1057.225971
    }
  ],
  "Thresholds": {
    "Min": 1060,
    "Max": 2800
  }
}
```