### PR TITLE
Enable hooks for dynamic completion

### DIFF
--- a/decoder/body_candidates_test.go
+++ b/decoder/body_candidates_test.go
@@ -1,6 +1,7 @@
 package decoder
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -12,6 +13,7 @@ import (
 )
 
 func TestDecoder_CandidateAtPos_incompleteAttributes(t *testing.T) {
+	ctx := context.Background()
 	bodySchema := &schema.BodySchema{
 		Blocks: map[string]*schema.BlockSchema{
 			"customblock": {
@@ -43,7 +45,7 @@ func TestDecoder_CandidateAtPos_incompleteAttributes(t *testing.T) {
 	})
 	d.maxCandidates = 1
 
-	candidates, err := d.CandidatesAtPos("test.tf", hcl.Pos{
+	candidates, err := d.CandidatesAtPos(ctx, "test.tf", hcl.Pos{
 		Line:   2,
 		Column: 7,
 		Byte:   29,
@@ -84,6 +86,7 @@ func TestDecoder_CandidateAtPos_incompleteAttributes(t *testing.T) {
 }
 
 func TestDecoder_CandidateAtPos_computedAttributes(t *testing.T) {
+	ctx := context.Background()
 	bodySchema := &schema.BodySchema{
 		Blocks: map[string]*schema.BlockSchema{
 			"customblock": {
@@ -113,7 +116,7 @@ func TestDecoder_CandidateAtPos_computedAttributes(t *testing.T) {
 		},
 	})
 
-	candidates, err := d.CandidatesAtPos("test.tf", hcl.Pos{
+	candidates, err := d.CandidatesAtPos(ctx, "test.tf", hcl.Pos{
 		Line:   2,
 		Column: 7,
 		Byte:   29,
@@ -154,6 +157,7 @@ func TestDecoder_CandidateAtPos_computedAttributes(t *testing.T) {
 }
 
 func TestDecoder_CandidateAtPos_incompleteBlocks(t *testing.T) {
+	ctx := context.Background()
 	bodySchema := &schema.BodySchema{
 		Blocks: map[string]*schema.BlockSchema{
 			"customblock": {
@@ -186,7 +190,7 @@ func TestDecoder_CandidateAtPos_incompleteBlocks(t *testing.T) {
 	})
 	d.maxCandidates = 1
 
-	candidates, err := d.CandidatesAtPos("test.tf", hcl.Pos{
+	candidates, err := d.CandidatesAtPos(ctx, "test.tf", hcl.Pos{
 		Line:   3,
 		Column: 8,
 		Byte:   42,
@@ -227,6 +231,7 @@ func TestDecoder_CandidateAtPos_incompleteBlocks(t *testing.T) {
 }
 
 func TestDecoder_CandidateAtPos_duplicateNames(t *testing.T) {
+	ctx := context.Background()
 	bodySchema := &schema.BodySchema{
 		Attributes: map[string]*schema.AttributeSchema{
 			"ingress": {
@@ -258,7 +263,7 @@ func TestDecoder_CandidateAtPos_duplicateNames(t *testing.T) {
 		},
 	})
 
-	candidates, err := d.CandidatesAtPos("test.tf", hcl.InitialPos)
+	candidates, err := d.CandidatesAtPos(ctx, "test.tf", hcl.InitialPos)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/decoder/completion_resolve.go
+++ b/decoder/completion_resolve.go
@@ -2,9 +2,16 @@ package decoder
 
 import (
 	"context"
+	"errors"
 )
 
+// ResolveCandidate tries to gather more information for a candidate,
+// by checking for a resolve hook and executing it.
 func (d *Decoder) ResolveCandidate(ctx context.Context, unresolvedCandidate UnresolvedCandidate) (*ResolvedCandidate, error) {
+	if unresolvedCandidate.ResolveHook == nil {
+		return nil, errors.New("missing resolve hook")
+	}
+
 	if resolveFunc, ok := d.ctx.CompletionResolveHooks[unresolvedCandidate.ResolveHook.Name]; ok {
 		return resolveFunc(ctx, unresolvedCandidate)
 	}

--- a/decoder/completion_resolve.go
+++ b/decoder/completion_resolve.go
@@ -1,0 +1,13 @@
+package decoder
+
+import (
+	"context"
+)
+
+func (d *Decoder) ResolveCandidate(ctx context.Context, unresolvedCandidate UnresolvedCandidate) (*ResolvedCandidate, error) {
+	if resolveFunc, ok := d.ctx.CompletionResolveHooks[unresolvedCandidate.ResolveHook.Name]; ok {
+		return resolveFunc(ctx, unresolvedCandidate)
+	}
+
+	return nil, nil
+}

--- a/decoder/completion_resolve.go
+++ b/decoder/completion_resolve.go
@@ -2,7 +2,6 @@ package decoder
 
 import (
 	"context"
-	"errors"
 )
 
 // ResolveCandidate gathers more information for a completion candidate

--- a/decoder/completion_resolve.go
+++ b/decoder/completion_resolve.go
@@ -5,11 +5,12 @@ import (
 	"errors"
 )
 
-// ResolveCandidate tries to gather more information for a candidate,
+// ResolveCandidate gathers more information for a completion candidate
 // by checking for a resolve hook and executing it.
+// This would be called as part of `completionItem/resolve` LSP method.
 func (d *Decoder) ResolveCandidate(ctx context.Context, unresolvedCandidate UnresolvedCandidate) (*ResolvedCandidate, error) {
 	if unresolvedCandidate.ResolveHook == nil {
-		return nil, errors.New("missing resolve hook")
+		return nil, nil
 	}
 
 	if resolveFunc, ok := d.ctx.CompletionResolveHooks[unresolvedCandidate.ResolveHook.Name]; ok {

--- a/decoder/context.go
+++ b/decoder/context.go
@@ -28,6 +28,7 @@ type DecoderContext struct {
 	// attribute schema, one can refer to the hooks map key to enable the hook
 	// execution on CompletionAtPos.
 	CompletionHooks CompletionFuncMap
+
 	// CompletionResolveHooks represents a map of available hooks for
 	// completion candidate resolving. One can register new hooks by adding an
 	// entry to this map. On completion candidate creation, one can specify a
@@ -48,11 +49,18 @@ func (d *Decoder) SetContext(ctx DecoderContext) {
 	d.ctx = ctx
 }
 
+// CompletionFunc is the function signature for completion hooks.
+//
+// The completion func has access to path, filename and pos via context:
+//  path, ok := decoder.PathFromContext(ctx)
+//  filename, ok := decoder.FilenameFromContext(ctx)
+//  pos, ok := decoder.PosFromContext(ctx)
 type CompletionFunc func(ctx context.Context, value cty.Value) ([]Candidate, error)
 type CompletionFuncMap map[string]CompletionFunc
 
-type CompletionResolveFuncMap map[string]CompletionResolveFunc
+// CompletionResolveFunc is the function signature for resolve hooks.
 type CompletionResolveFunc func(ctx context.Context, unresolvedCandidate UnresolvedCandidate) (*ResolvedCandidate, error)
+type CompletionResolveFuncMap map[string]CompletionResolveFunc
 
 // Candidate represents a completion candidate created and returned from a
 // completion hook.

--- a/decoder/context.go
+++ b/decoder/context.go
@@ -32,8 +32,8 @@ type DecoderContext struct {
 	// completion candidate resolving. One can register new hooks by adding an
 	// entry to this map. On completion candidate creation, one can specify a
 	// resolve hook by using the map key string. If a completion candidate has
-	// a resolve hook, ResolveCandidate will execute the hook and update the
-	// completion item.
+	// a resolve hook, ResolveCandidate will execute the hook and return
+	// additional (resolved) data for the completion item.
 	CompletionResolveHooks CompletionResolveFuncMap
 }
 

--- a/decoder/context.go
+++ b/decoder/context.go
@@ -1,6 +1,11 @@
 package decoder
 
-import "github.com/hashicorp/hcl-lang/lang"
+import (
+	"context"
+
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/zclconf/go-cty/cty"
+)
 
 // DecoderContext represents global context relevant for all possible paths
 // served by the Decoder
@@ -16,8 +21,79 @@ type DecoderContext struct {
 	// CodeLenses represents a slice of executable lenses
 	// which will be executed in the exact order they're declared
 	CodeLenses []lang.CodeLensFunc
+
+	CompletionHooks        CompletionFuncMap
+	CompletionResolveHooks CompletionResolveFuncMap
 }
 
 func (d *Decoder) SetContext(ctx DecoderContext) {
 	d.ctx = ctx
+}
+
+type CompletionFunc func(ctx context.Context, value cty.Value) ([]Candidate, error)
+type CompletionFuncMap map[string]CompletionFunc
+
+type CompletionResolveFuncMap map[string]CompletionResolveFunc
+type CompletionResolveFunc func(ctx context.Context, unresolvedCandidate UnresolvedCandidate) (*ResolvedCandidate, error)
+
+type Candidate struct {
+	// Label represents a human-readable name of the candidate
+	// if one exists (otherwise Value is used)
+	Label string
+
+	// Detail represents a human-readable string with additional
+	// information about this candidate, like symbol information.
+	Detail string
+
+	Kind lang.CandidateKind
+
+	// Description represents human-readable description
+	// of the candidate
+	Description lang.MarkupContent
+
+	// IsDeprecated indicates whether the candidate is deprecated
+	IsDeprecated bool
+
+	RawInsertText string
+
+	// ResolveHook represents a resolve hook to call
+	// and any arguments to pass to it
+	ResolveHook *lang.ResolveHook
+}
+
+type ExpressionCandidate struct {
+	// Value represents the value to be inserted
+	Value cty.Value
+
+	// Detail represents a human-readable string with additional
+	// information about this candidate, like symbol information.
+	Detail string
+
+	// Description represents human-readable description
+	// of the candidate
+	Description lang.MarkupContent
+
+	// IsDeprecated indicates whether the candidate is deprecated
+	IsDeprecated bool
+}
+
+func ExpressionCompletionCandidate(c ExpressionCandidate) Candidate {
+	return Candidate{
+		Label:         c.Value.AsString(),
+		Detail:        c.Detail,
+		Kind:          candidateKindForType(c.Value.Type()),
+		Description:   c.Description,
+		IsDeprecated:  c.IsDeprecated,
+		RawInsertText: c.Value.AsString(),
+	}
+}
+
+type UnresolvedCandidate struct {
+	ResolveHook *lang.ResolveHook
+}
+
+type ResolvedCandidate struct {
+	Description         lang.MarkupContent
+	Detail              string
+	AdditionalTextEdits []lang.TextEdit
 }

--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -41,6 +41,10 @@ func testPathDecoder(t *testing.T, pathCtx *PathContext) *PathDecoder {
 	d := NewDecoder(&testPathReader{
 		paths: dirs,
 	})
+	d.SetContext(DecoderContext{
+		CompletionHooks:        make(CompletionFuncMap),
+		CompletionResolveHooks: make(CompletionResolveFuncMap),
+	})
 
 	pathDecoder, err := d.Path(lang.Path{Path: dirPath})
 	if err != nil {

--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -41,10 +41,7 @@ func testPathDecoder(t *testing.T, pathCtx *PathContext) *PathDecoder {
 	d := NewDecoder(&testPathReader{
 		paths: dirs,
 	})
-	d.SetContext(DecoderContext{
-		CompletionHooks:        make(CompletionFuncMap),
-		CompletionResolveHooks: make(CompletionResolveFuncMap),
-	})
+	d.SetContext(NewDecoderContext())
 
 	pathDecoder, err := d.Path(lang.Path{Path: dirPath})
 	if err != nil {

--- a/decoder/expression_candidates.go
+++ b/decoder/expression_candidates.go
@@ -239,19 +239,15 @@ func (d *PathDecoder) candidatesFromHooks(ctx context.Context, attr *hclsyntax.A
 			res, _ := completionFunc(ctx, cty.StringVal(prefix))
 
 			for _, c := range res {
-				// We're adding quotes to the string here, as we're always
-				// replacing the whole edit range
-				text := fmt.Sprintf("%q", c.RawInsertText)
-
 				candidates = append(candidates, lang.Candidate{
-					Label:        text,
+					Label:        c.Label,
 					Detail:       c.Detail,
 					Description:  c.Description,
 					Kind:         c.Kind,
 					IsDeprecated: c.IsDeprecated,
 					TextEdit: lang.TextEdit{
-						NewText: text,
-						Snippet: text,
+						NewText: c.RawInsertText,
+						Snippet: c.RawInsertText,
 						Range:   editRng,
 					},
 					ResolveHook: c.ResolveHook,

--- a/decoder/expression_candidates_test.go
+++ b/decoder/expression_candidates_test.go
@@ -2779,11 +2779,11 @@ func TestDecoder_CandidateAtPos_expressions_Hooks(t *testing.T) {
 				"TestCompletionHook": func(ctx context.Context, value cty.Value) ([]Candidate, error) {
 					candidates := []Candidate{
 						{
-							Label:         "label",
+							Label:         "\"label\"",
 							Detail:        "detail",
 							Kind:          lang.StringCandidateKind,
 							Description:   lang.PlainText("description"),
-							RawInsertText: "insertText",
+							RawInsertText: "\"insertText\"",
 						},
 					}
 					return candidates, nil
@@ -2791,7 +2791,7 @@ func TestDecoder_CandidateAtPos_expressions_Hooks(t *testing.T) {
 			},
 			lang.IncompleteCandidates([]lang.Candidate{
 				{
-					Label:       "\"insertText\"",
+					Label:       "\"label\"",
 					Detail:      "detail",
 					Kind:        lang.StringCandidateKind,
 					Description: lang.PlainText("description"),
@@ -2836,11 +2836,11 @@ func TestDecoder_CandidateAtPos_expressions_Hooks(t *testing.T) {
 			},
 			lang.IncompleteCandidates([]lang.Candidate{
 				{
-					Label: "\"pa\"",
+					Label: "pa",
 					Kind:  lang.StringCandidateKind,
 					TextEdit: lang.TextEdit{
-						NewText: "\"pa\"",
-						Snippet: "\"pa\"",
+						NewText: "pa",
+						Snippet: "pa",
 						Range: hcl.Range{
 							Filename: "test.tf",
 							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
@@ -2880,11 +2880,11 @@ func TestDecoder_CandidateAtPos_expressions_Hooks(t *testing.T) {
 			},
 			lang.IncompleteCandidates([]lang.Candidate{
 				{
-					Label: "\"pa\"",
+					Label: "pa",
 					Kind:  lang.StringCandidateKind,
 					TextEdit: lang.TextEdit{
-						NewText: "\"pa\"",
-						Snippet: "\"pa\"",
+						NewText: "pa",
+						Snippet: "pa",
 						Range: hcl.Range{
 							Filename: "test.tf",
 							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
@@ -2902,6 +2902,7 @@ func TestDecoder_CandidateAtPos_expressions_Hooks(t *testing.T) {
 				Attributes: tc.attrSchema,
 			}
 
+			// We're ignoring diagnostics here, since some test cases may contain invalid HCL
 			f, _ := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
 			d := testPathDecoder(t, &PathContext{
 				Schema: bodySchema,

--- a/decoder/expression_candidates_test.go
+++ b/decoder/expression_candidates_test.go
@@ -2749,3 +2749,178 @@ variable "ccc" {}
 		t.Fatalf("unexpected candidates: %s", diff)
 	}
 }
+
+func TestDecoder_CandidateAtPos_expressions_Hooks(t *testing.T) {
+	ctx := context.Background()
+	testCases := []struct {
+		testName           string
+		attrSchema         map[string]*schema.AttributeSchema
+		cfg                string
+		pos                hcl.Pos
+		completionHooks    CompletionFuncMap
+		expectedCandidates lang.Candidates
+	}{
+		{
+			"simple hook",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Expr: schema.LiteralTypeOnly(cty.String),
+					CompletionHooks: lang.CompletionHooks{
+						{
+							Name: "TestCompletionHook",
+						},
+					},
+				},
+			},
+			`attr = 
+`,
+			hcl.Pos{Line: 1, Column: 8, Byte: 7},
+			CompletionFuncMap{
+				"TestCompletionHook": func(ctx context.Context, value cty.Value) ([]Candidate, error) {
+					candidates := []Candidate{
+						{
+							Label:         "label",
+							Detail:        "detail",
+							Kind:          lang.StringCandidateKind,
+							Description:   lang.PlainText("description"),
+							RawInsertText: "insertText",
+						},
+					}
+					return candidates, nil
+				},
+			},
+			lang.IncompleteCandidates([]lang.Candidate{
+				{
+					Label:       "\"insertText\"",
+					Detail:      "detail",
+					Kind:        lang.StringCandidateKind,
+					Description: lang.PlainText("description"),
+					TextEdit: lang.TextEdit{
+						NewText: "\"insertText\"",
+						Snippet: "\"insertText\"",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"hook with prefix",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Expr: schema.LiteralTypeOnly(cty.String),
+					CompletionHooks: lang.CompletionHooks{
+						{
+							Name: "TestCompletionHook",
+						},
+					},
+				},
+			},
+			`attr = "pa"
+`,
+			hcl.Pos{Line: 1, Column: 11, Byte: 10},
+			CompletionFuncMap{
+				"TestCompletionHook": func(ctx context.Context, value cty.Value) ([]Candidate, error) {
+					candidates := []Candidate{
+						{
+							Label:         value.AsString(),
+							Kind:          lang.StringCandidateKind,
+							RawInsertText: value.AsString(),
+						},
+					}
+					return candidates, nil
+				},
+			},
+			lang.IncompleteCandidates([]lang.Candidate{
+				{
+					Label: "\"pa\"",
+					Kind:  lang.StringCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "\"pa\"",
+						Snippet: "\"pa\"",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 12, Byte: 11},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"incomplete attr value",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Expr: schema.LiteralTypeOnly(cty.String),
+					CompletionHooks: lang.CompletionHooks{
+						{
+							Name: "TestCompletionHook",
+						},
+					},
+				},
+			},
+			`attr = "pa
+
+`,
+			hcl.Pos{Line: 1, Column: 11, Byte: 10},
+			CompletionFuncMap{
+				"TestCompletionHook": func(ctx context.Context, value cty.Value) ([]Candidate, error) {
+					candidates := []Candidate{
+						{
+							Label:         value.AsString(),
+							Kind:          lang.StringCandidateKind,
+							RawInsertText: value.AsString(),
+						},
+					}
+					return candidates, nil
+				},
+			},
+			lang.IncompleteCandidates([]lang.Candidate{
+				{
+					Label: "\"pa\"",
+					Kind:  lang.StringCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "\"pa\"",
+						Snippet: "\"pa\"",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 11, Byte: 10},
+						},
+					},
+				},
+			}),
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := &schema.BodySchema{
+				Attributes: tc.attrSchema,
+			}
+
+			f, _ := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.tf": f,
+				},
+			})
+			for n, h := range tc.completionHooks {
+				d.decoderCtx.CompletionHooks[n] = h
+			}
+
+			candidates, err := d.CandidatesAtPos(ctx, "test.tf", tc.pos)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedCandidates, candidates); diff != "" {
+				t.Fatalf("unexpected candidates: %s", diff)
+			}
+		})
+	}
+}

--- a/decoder/expression_candidates_test.go
+++ b/decoder/expression_candidates_test.go
@@ -1,6 +1,7 @@
 package decoder
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -15,6 +16,7 @@ import (
 )
 
 func TestDecoder_CandidateAtPos_expressions(t *testing.T) {
+	ctx := context.Background()
 	testCases := []struct {
 		testName           string
 		attrSchema         map[string]*schema.AttributeSchema
@@ -1518,7 +1520,7 @@ func TestDecoder_CandidateAtPos_expressions(t *testing.T) {
 				},
 			})
 
-			candidates, err := d.CandidatesAtPos("test.tf", tc.pos)
+			candidates, err := d.CandidatesAtPos(ctx, "test.tf", tc.pos)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1531,6 +1533,7 @@ func TestDecoder_CandidateAtPos_expressions(t *testing.T) {
 }
 
 func TestDecoder_CandidateAtPos_traversalExpressions(t *testing.T) {
+	ctx := context.Background()
 	testCases := []struct {
 		testName           string
 		bodySchema         *schema.BodySchema
@@ -2556,7 +2559,7 @@ another_block "meh" {
 
 			dirReader.paths[testDir].ReferenceTargets = append(dirReader.paths[testDir].ReferenceTargets, refTargets...)
 
-			candidates, err := d.CandidatesAtPos("test.tf", tc.pos)
+			candidates, err := d.CandidatesAtPos(ctx, "test.tf", tc.pos)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -2569,6 +2572,7 @@ another_block "meh" {
 }
 
 func TestDecoder_CandidateAtPos_expressions_crossFileTraversal(t *testing.T) {
+	ctx := context.Background()
 	f1, _ := hclsyntax.ParseConfig([]byte(`variable "aaa" {}
 variable "bbb" {}
 variable "ccc" {}
@@ -2685,7 +2689,7 @@ variable "ccc" {}
 
 	dirReader.paths[testDir].ReferenceTargets = refTargets
 
-	candidates, err := d.CandidatesAtPos("test2.tf", hcl.Pos{
+	candidates, err := d.CandidatesAtPos(ctx, "test2.tf", hcl.Pos{
 		Line:   1,
 		Column: 9,
 		Byte:   8,

--- a/decoder/label_candidates_test.go
+++ b/decoder/label_candidates_test.go
@@ -1,6 +1,7 @@
 package decoder
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -12,6 +13,7 @@ import (
 )
 
 func TestDecoder_CandidateAtPos_incompleteLabels(t *testing.T) {
+	ctx := context.Background()
 	bodySchema := &schema.BodySchema{
 		Blocks: map[string]*schema.BlockSchema{
 			"customblock": {
@@ -64,7 +66,7 @@ func TestDecoder_CandidateAtPos_incompleteLabels(t *testing.T) {
 	})
 	d.maxCandidates = 1
 
-	candidates, err := d.CandidatesAtPos("test.tf", hcl.Pos{
+	candidates, err := d.CandidatesAtPos(ctx, "test.tf", hcl.Pos{
 		Line:   1,
 		Column: 14,
 		Byte:   13,
@@ -104,6 +106,7 @@ func TestDecoder_CandidateAtPos_incompleteLabels(t *testing.T) {
 }
 
 func TestCandidatesAtPos_prefillRequiredFields(t *testing.T) {
+	ctx := context.Background()
 	startingConfig := "resource \"\" {\n}"
 	startingPos := hcl.Pos{
 		Line:   1,
@@ -614,7 +617,7 @@ func TestCandidatesAtPos_prefillRequiredFields(t *testing.T) {
 			d.maxCandidates = 1
 			d.PrefillRequiredFields = tt.prefill
 
-			got, err := d.CandidatesAtPos("test.tf", startingPos)
+			got, err := d.CandidatesAtPos(ctx, "test.tf", startingPos)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/lang/candidate.go
+++ b/lang/candidate.go
@@ -43,6 +43,8 @@ type Candidate struct {
 	// to reopen candidate suggestion popup after insertion
 	TriggerSuggest bool
 
+	// ResolveHook allows the async resolution of additional information
+	// for a completion candidate via ResolveCandidate.
 	ResolveHook *ResolveHook
 }
 

--- a/lang/candidate.go
+++ b/lang/candidate.go
@@ -109,3 +109,14 @@ func CompleteCandidates(list []Candidate) Candidates {
 		IsComplete: true,
 	}
 }
+
+// IncompleteCandidates creates a static list of candidates
+//
+// NewCandidates should be used at runtime instead, but IncompleteCandidates
+// provides a syntactic sugar useful in tests.
+func IncompleteCandidates(list []Candidate) Candidates {
+	return Candidates{
+		List:       list,
+		IsComplete: false,
+	}
+}

--- a/lang/candidate.go
+++ b/lang/candidate.go
@@ -43,7 +43,7 @@ type Candidate struct {
 	// to reopen candidate suggestion popup after insertion
 	TriggerSuggest bool
 
-	// ResolveHook allows the async resolution of additional information
+	// ResolveHook allows resolution of additional information
 	// for a completion candidate via ResolveCandidate.
 	ResolveHook *ResolveHook
 }

--- a/lang/candidate.go
+++ b/lang/candidate.go
@@ -42,6 +42,8 @@ type Candidate struct {
 	// TriggerSuggest allows server to instruct the client whether
 	// to reopen candidate suggestion popup after insertion
 	TriggerSuggest bool
+
+	ResolveHook *ResolveHook
 }
 
 // TextEdit represents a change (edit) of an HCL config file

--- a/lang/completion.go
+++ b/lang/completion.go
@@ -1,0 +1,22 @@
+package lang
+
+type CompletionHook struct {
+	Name string
+}
+
+type ResolveHook struct {
+	Name string `json:"resolve_hook,omitempty"`
+	Path string `json:"path,omitempty"`
+}
+
+type CompletionHooks []CompletionHook
+
+func (chs CompletionHooks) Copy() CompletionHooks {
+	if chs == nil {
+		return nil
+	}
+
+	hooksCopy := make(CompletionHooks, len(chs))
+	copy(hooksCopy, chs)
+	return hooksCopy
+}

--- a/schema/attribute_schema.go
+++ b/schema/attribute_schema.go
@@ -36,6 +36,10 @@ type AttributeSchema struct {
 	// to report for the attribute name
 	// (in addition to any modifiers of any parent blocks)
 	SemanticTokenModifiers lang.SemanticTokenModifiers
+
+	// CompletionHooks represents any hooks which provide
+	// additional completion candidates for the attribute dynamically
+	CompletionHooks lang.CompletionHooks
 }
 
 type AttributeAddrSchema struct {
@@ -110,6 +114,7 @@ func (as *AttributeSchema) Copy() *AttributeSchema {
 		Address:                as.Address.Copy(),
 		OriginForTarget:        as.OriginForTarget.Copy(),
 		SemanticTokenModifiers: as.SemanticTokenModifiers.Copy(),
+		CompletionHooks:        as.CompletionHooks.Copy(),
 	}
 
 	return newAs

--- a/schema/attribute_schema.go
+++ b/schema/attribute_schema.go
@@ -38,7 +38,9 @@ type AttributeSchema struct {
 	SemanticTokenModifiers lang.SemanticTokenModifiers
 
 	// CompletionHooks represents any hooks which provide
-	// additional completion candidates for the attribute dynamically
+	// additional completion candidates for the attribute.
+	// These are typically candidates which cannot be provided
+	// via schema and come from external APIs or other sources.
 	CompletionHooks lang.CompletionHooks
 }
 

--- a/schema/attribute_schema.go
+++ b/schema/attribute_schema.go
@@ -37,7 +37,7 @@ type AttributeSchema struct {
 	// (in addition to any modifiers of any parent blocks)
 	SemanticTokenModifiers lang.SemanticTokenModifiers
 
-	// CompletionHooks represents any hooks which provide
+	// CompletionHooks represent any hooks which provide
 	// additional completion candidates for the attribute.
 	// These are typically candidates which cannot be provided
 	// via schema and come from external APIs or other sources.

--- a/schema/body_schema.go
+++ b/schema/body_schema.go
@@ -12,8 +12,11 @@ import (
 // BodySchema describes schema of a body comprised of blocks or attributes
 // (if any), where body can be root or body of any block in the hierarchy.
 type BodySchema struct {
-	Blocks       map[string]*BlockSchema
-	Attributes   map[string]*AttributeSchema
+	Blocks     map[string]*BlockSchema
+	Attributes map[string]*AttributeSchema
+	// AnyAttribute represents an attribute where a user can pick any arbitrary
+	// name, but the attributes have the same schema
+	// e.g. `required_providers` block in Terraform
 	AnyAttribute *AttributeSchema
 	IsDeprecated bool
 	Detail       string

--- a/schema/body_schema.go
+++ b/schema/body_schema.go
@@ -14,6 +14,7 @@ import (
 type BodySchema struct {
 	Blocks     map[string]*BlockSchema
 	Attributes map[string]*AttributeSchema
+
 	// AnyAttribute represents an attribute where a user can pick any arbitrary
 	// name, but the attributes have the same schema
 	// e.g. `required_providers` block in Terraform


### PR DESCRIPTION
This PR extends the completion of attribute values by getting completion candidates from dynamically registered hooks.

If an attribute schema contains one (or multiple) completion hooks, we look in the global decoder context to see if those hooks are registered. If they are, each hook is executed and should return a list of completion candidates.

The resulting candidate always replaces the whole attribute value range (including quotes).

---

* Part of https://github.com/hashicorp/terraform-ls/issues/868