### PR TITLE
Sort reference origins

### DIFF
--- a/decoder/reference_origins.go
+++ b/decoder/reference_origins.go
@@ -101,8 +101,10 @@ func (d *PathDecoder) CollectReferenceOrigins() (reference.Origins, error) {
 	}
 
 	sort.SliceStable(refOrigins, func(i, j int) bool {
-		return refOrigins[i].OriginRange().Filename <= refOrigins[j].OriginRange().Filename &&
-			refOrigins[i].OriginRange().Start.Byte < refOrigins[j].OriginRange().Start.Byte
+		if refOrigins[i].OriginRange().Filename != refOrigins[j].OriginRange().Filename {
+			return refOrigins[i].OriginRange().Filename < refOrigins[j].OriginRange().Filename
+		}
+		return refOrigins[i].OriginRange().Start.Byte < refOrigins[j].OriginRange().Start.Byte
 	})
 
 	return refOrigins, nil

--- a/decoder/reference_origins.go
+++ b/decoder/reference_origins.go
@@ -45,6 +45,16 @@ func (d *Decoder) ReferenceOriginsTargetingPos(path lang.Path, file string, pos 
 		}
 	}
 
+	sort.SliceStable(origins, func(i, j int) bool {
+		if origins[i].Path.Path != origins[j].Path.Path {
+			return origins[i].Path.Path < origins[j].Path.Path
+		}
+		if origins[i].Range.Filename != origins[j].Range.Filename {
+			return origins[i].Range.Filename < origins[j].Range.Filename
+		}
+		return origins[i].Range.Start.Byte < origins[j].Range.Start.Byte
+	})
+
 	return origins
 }
 


### PR DESCRIPTION
After running into this a couple of times [recently](https://github.com/hashicorp/hcl-lang/runs/7543556000?check_suite_focus=true), this PR now sorts the reference origins by path, filename and range.

Closes https://github.com/hashicorp/hcl-lang/issues/101