### PR TITLE
Add `SortText` and respect `maxCandidates` for hook completion

### DIFF
--- a/decoder/context.go
+++ b/decoder/context.go
@@ -90,6 +90,10 @@ type Candidate struct {
 	// ResolveHook represents a resolve hook to call
 	// and any arguments to pass to it
 	ResolveHook *lang.ResolveHook
+
+	// SortText is an optional string that will be used when comparing this
+	// candidate with other candidates
+	SortText string
 }
 
 // ExpressionCandidate is a simplified version of Candidate and the preferred

--- a/decoder/context.go
+++ b/decoder/context.go
@@ -51,10 +51,12 @@ func (d *Decoder) SetContext(ctx DecoderContext) {
 
 // CompletionFunc is the function signature for completion hooks.
 //
-// The completion func has access to path, filename and pos via context:
+// The completion func has access to path, filename, pos and maximum
+// candidate count via context:
 //  path, ok := decoder.PathFromContext(ctx)
 //  filename, ok := decoder.FilenameFromContext(ctx)
 //  pos, ok := decoder.PosFromContext(ctx)
+//  maxCandidates, ok := decoder.MaxCandidatesFromContext(ctx)
 type CompletionFunc func(ctx context.Context, value cty.Value) ([]Candidate, error)
 type CompletionFuncMap map[string]CompletionFunc
 

--- a/decoder/expression_candidates.go
+++ b/decoder/expression_candidates.go
@@ -251,6 +251,7 @@ func (d *PathDecoder) candidatesFromHooks(ctx context.Context, attr *hclsyntax.A
 						Range:   editRng,
 					},
 					ResolveHook: c.ResolveHook,
+					SortText:    c.SortText,
 				})
 			}
 

--- a/decoder/expression_candidates.go
+++ b/decoder/expression_candidates.go
@@ -195,8 +195,8 @@ func FilenameFromContext(ctx context.Context) (string, bool) {
 type maxCandidatesKey struct{}
 
 func MaxCandidatesFromContext(ctx context.Context) (uint, bool) {
-	f, ok := ctx.Value(maxCandidatesKey{}).(uint)
-	return f, ok
+	mc, ok := ctx.Value(maxCandidatesKey{}).(uint)
+	return mc, ok
 }
 
 func isEmptyExpr(expr hclsyntax.Expression) bool {

--- a/decoder/expression_candidates.go
+++ b/decoder/expression_candidates.go
@@ -25,12 +25,18 @@ func (d *PathDecoder) attrValueCandidatesAtPos(ctx context.Context, attr *hclsyn
 		candidates.List = append(candidates.List, d.candidatesFromHooks(ctx, attr, schema, outerBodyRng, pos)...)
 	}
 
-	if len(constraints) > 0 {
+	count := len(candidates.List)
+	if len(constraints) > 0 && uint(count) < d.maxCandidates {
 		prefixRng := editRng
 		prefixRng.End = pos
 
 		for _, c := range constraints {
+			if uint(count) >= d.maxCandidates {
+				return candidates, nil
+			}
+
 			candidates.List = append(candidates.List, d.constraintToCandidates(c, outerBodyRng, prefixRng, editRng)...)
+			count++
 		}
 	}
 
@@ -186,6 +192,13 @@ func FilenameFromContext(ctx context.Context) (string, bool) {
 	return f, ok
 }
 
+type maxCandidatesKey struct{}
+
+func MaxCandidatesFromContext(ctx context.Context) (uint, bool) {
+	f, ok := ctx.Value(maxCandidatesKey{}).(uint)
+	return f, ok
+}
+
 func isEmptyExpr(expr hclsyntax.Expression) bool {
 	l, ok := expr.(*hclsyntax.LiteralValueExpr)
 	if !ok {
@@ -233,12 +246,18 @@ func (d *PathDecoder) candidatesFromHooks(ctx context.Context, attr *hclsyntax.A
 	ctx = context.WithValue(ctx, pathKey{}, d.path)
 	ctx = context.WithValue(ctx, filenameKey{}, attr.Expr.Range().Filename)
 	ctx = context.WithValue(ctx, posKey{}, pos)
+	ctx = context.WithValue(ctx, maxCandidatesKey{}, d.maxCandidates)
 
+	count := 0
 	for _, hook := range schema.CompletionHooks {
 		if completionFunc, ok := d.decoderCtx.CompletionHooks[hook.Name]; ok {
 			res, _ := completionFunc(ctx, cty.StringVal(prefix))
 
 			for _, c := range res {
+				if uint(count) >= d.maxCandidates {
+					return candidates
+				}
+
 				candidates = append(candidates, lang.Candidate{
 					Label:        c.Label,
 					Detail:       c.Detail,
@@ -253,6 +272,7 @@ func (d *PathDecoder) candidatesFromHooks(ctx context.Context, attr *hclsyntax.A
 					ResolveHook: c.ResolveHook,
 					SortText:    c.SortText,
 				})
+				count++
 			}
 
 		}

--- a/lang/candidate.go
+++ b/lang/candidate.go
@@ -46,6 +46,10 @@ type Candidate struct {
 	// ResolveHook allows resolution of additional information
 	// for a completion candidate via ResolveCandidate.
 	ResolveHook *ResolveHook
+
+	// SortText is an optional string that will be used when comparing this
+	// candidate with other candidates
+	SortText string
 }
 
 // TextEdit represents a change (edit) of an HCL config file


### PR DESCRIPTION
This PR adds the `SortText` field to completion candidates and only allows `maxCandidates` (100 for now) to be returned on attribute expression completion.

We stop adding candidates and executing hooks once the limit is reached. A better way might be to allow each hook to contribute to the list of completion candidates.