### PR TITLE
Add support for `SignatureAtPos`

### DIFF
--- a/decoder/signature.go
+++ b/decoder/signature.go
@@ -1,0 +1,123 @@
+package decoder
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+// SignatureAtPos returns a function signature for the given pos if pos
+// is inside a FunctionCallExpr
+func (d *PathDecoder) SignatureAtPos(filename string, pos hcl.Pos) (*lang.FunctionSignature, error) {
+	file, err := d.fileByName(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := d.bodyForFileAndPos(filename, file, pos)
+	if err != nil {
+		return nil, err
+	}
+
+	var signature *lang.FunctionSignature
+	hclsyntax.VisitAll(body, func(node hclsyntax.Node) hcl.Diagnostics {
+		if !node.Range().ContainsPos(pos) {
+			return nil // Node not under cursor
+		}
+
+		fNode, isFunc := node.(*hclsyntax.FunctionCallExpr)
+		if !isFunc {
+			return nil // No function call expression
+		}
+
+		f, ok := d.pathCtx.Functions[fNode.Name]
+		if !ok {
+			return nil // Unknown function
+		}
+
+		if len(f.Params) == 0 && f.VarParam == nil {
+			signature = &lang.FunctionSignature{
+				Name:        fmt.Sprintf("%s(%s) %s", fNode.Name, f.ParameterSignature(), f.ReturnType.FriendlyName()),
+				Description: lang.Markdown(f.Description),
+			}
+
+			return nil // Function accepts no parameters, return early
+		}
+
+		pRange := hcl.RangeBetween(fNode.OpenParenRange, fNode.CloseParenRange)
+		if !pRange.ContainsPos(pos) {
+			return nil // Not inside parenthesis
+		}
+
+		activePar := 0 // default to first parameter
+		foundActivePar := false
+		lastArgEndPos := fNode.OpenParenRange.Start
+		lastArgIdx := 0
+		for i, v := range fNode.Args {
+			// We overshot the argument and stop
+			if v.Range().Start.Byte > pos.Byte {
+				break
+			}
+			if v.Range().ContainsPos(pos) || v.Range().End.Byte == pos.Byte {
+				activePar = i
+				foundActivePar = true
+				break
+			}
+			lastArgEndPos = v.Range().End
+			lastArgIdx = i
+		}
+
+		if !foundActivePar {
+			recoveredBytes := recoverLeftBytes(file.Bytes, pos, func(byteOffset int, r rune) bool {
+				return r == ',' && byteOffset > lastArgEndPos.Byte
+			})
+			trimmedBytes := bytes.TrimRight(recoveredBytes, " \t\n")
+			if string(trimmedBytes) == "," {
+				activePar = lastArgIdx + 1
+			}
+		}
+
+		paramsLen := len(f.Params)
+		if f.VarParam != nil {
+			paramsLen += 1
+		}
+
+		if activePar >= paramsLen && f.VarParam == nil {
+			return nil // too many arguments passed to the function
+		}
+
+		if activePar >= paramsLen {
+			// there are multiple variadic arguments passed, so
+			// we want to highlight the variadic parameter in the
+			// function signature
+			activePar = paramsLen - 1
+		}
+
+		parameters := make([]lang.FunctionParameter, 0, paramsLen)
+		for _, p := range f.Params {
+			parameters = append(parameters, lang.FunctionParameter{
+				Name:        p.Name,
+				Description: lang.Markdown(p.Description),
+			})
+		}
+		if f.VarParam != nil {
+			parameters = append(parameters, lang.FunctionParameter{
+				Name:        f.VarParam.Name,
+				Description: lang.Markdown(f.VarParam.Description),
+			})
+		}
+		signature = &lang.FunctionSignature{
+			Name:            fmt.Sprintf("%s(%s) %s", fNode.Name, f.ParameterSignature(), f.ReturnType.FriendlyName()),
+			Description:     lang.Markdown(f.Description),
+			Parameters:      parameters,
+			ActiveParameter: uint32(activePar),
+		}
+
+		return nil // We don't want to add any diagnostics
+	})
+
+	return signature, nil
+}

--- a/decoder/signature_test.go
+++ b/decoder/signature_test.go
@@ -175,7 +175,7 @@ func TestSignatureAtPos(t *testing.T) {
 			`x = foo("a", )`,
 			hcl.Pos{Line: 1, Column: 12, Byte: 13},
 			&lang.FunctionSignature{
-				Name:        "foo(input string, ...vinput number) string",
+				Name:        "foo(input string, …vinput number) string",
 				Description: lang.Markdown("`foo` description"),
 				Parameters: []lang.FunctionParameter{
 					{
@@ -213,7 +213,7 @@ func TestSignatureAtPos(t *testing.T) {
 			`x = foo("a", 1, 2, )`,
 			hcl.Pos{Line: 1, Column: 18, Byte: 19},
 			&lang.FunctionSignature{
-				Name:        "foo(input string, ...vinput number) string",
+				Name:        "foo(input string, …vinput number) string",
 				Description: lang.Markdown("`foo` description"),
 				Parameters: []lang.FunctionParameter{
 					{
@@ -353,7 +353,7 @@ func TestSignatureAtPos(t *testing.T) {
 			`x = foo(1, 2, 3, )`,
 			hcl.Pos{Line: 1, Column: 16, Byte: 17},
 			&lang.FunctionSignature{
-				Name:        "foo(...vinput number) string",
+				Name:        "foo(…vinput number) string",
 				Description: lang.Markdown("`foo` description"),
 				Parameters: []lang.FunctionParameter{
 					{
@@ -379,7 +379,7 @@ func TestSignatureAtPos(t *testing.T) {
 			`x = concat([],)`,
 			hcl.Pos{Line: 1, Column: 13, Byte: 14},
 			&lang.FunctionSignature{
-				Name:        "concat(...seqs dynamic) dynamic",
+				Name:        "concat(…seqs dynamic) dynamic",
 				Description: lang.Markdown("`concat` description"),
 				Parameters: []lang.FunctionParameter{
 					{

--- a/decoder/signature_test.go
+++ b/decoder/signature_test.go
@@ -1,0 +1,495 @@
+package decoder
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+)
+
+func TestSignatureAtPos(t *testing.T) {
+	testCases := []struct {
+		testName          string
+		functions         map[string]schema.FunctionSignature
+		cfg               string
+		pos               hcl.Pos
+		expectedSignature *lang.FunctionSignature
+	}{
+		{
+			"no function call expr",
+			map[string]schema.FunctionSignature{},
+			`x = "hello"`,
+			hcl.Pos{Line: 1, Column: 3, Byte: 4},
+			nil,
+		},
+		{
+			"unknown function",
+			map[string]schema.FunctionSignature{},
+			`x = foo()`,
+			hcl.Pos{Line: 1, Column: 7, Byte: 8},
+			nil,
+		},
+		{
+			"no description",
+			map[string]schema.FunctionSignature{
+				"foo": {
+					ReturnType: cty.String,
+				},
+			},
+			`x = foo()`,
+			hcl.Pos{Line: 1, Column: 7, Byte: 8},
+			&lang.FunctionSignature{
+				Name:        "foo() string",
+				Description: lang.Markdown(""),
+			},
+		},
+		{
+			"no parameter, no var param",
+			map[string]schema.FunctionSignature{
+				"foo": {
+					ReturnType:  cty.String,
+					Description: "`foo` description",
+				},
+			},
+			`x = foo()`,
+			hcl.Pos{Line: 1, Column: 7, Byte: 8},
+			&lang.FunctionSignature{
+				Name:        "foo() string",
+				Description: lang.Markdown("`foo` description"),
+			},
+		},
+		{
+			"one parameter, pos not inside parenthesis",
+			map[string]schema.FunctionSignature{
+				"foo": {
+					Params: []function.Parameter{
+						{
+							Name:        "input",
+							Type:        cty.String,
+							Description: "`input` description",
+						},
+					},
+					ReturnType:  cty.String,
+					Description: "`foo` description.",
+				},
+			},
+			`x = foo()`,
+			hcl.Pos{Line: 1, Column: 5, Byte: 6},
+			nil,
+		},
+		{
+			"one parameter, empty first parameter",
+			map[string]schema.FunctionSignature{
+				"foo": {
+					Params: []function.Parameter{
+						{
+							Name:        "input",
+							Type:        cty.String,
+							Description: "`input` description",
+						},
+					},
+					ReturnType:  cty.String,
+					Description: "`foo` description",
+				},
+			},
+			`x = foo()`,
+			hcl.Pos{Line: 1, Column: 7, Byte: 8},
+			&lang.FunctionSignature{
+				Name:        "foo(input string) string",
+				Description: lang.Markdown("`foo` description"),
+				Parameters: []lang.FunctionParameter{
+					{
+						Name:        "input",
+						Description: lang.Markdown("`input` description"),
+					},
+				},
+				ActiveParameter: 0,
+			},
+		},
+		{
+			"two parameters, empty second parameter",
+			map[string]schema.FunctionSignature{
+				"foo": {
+					Params: []function.Parameter{
+						{
+							Name:        "input",
+							Type:        cty.String,
+							Description: "`input` description",
+						},
+						{
+							Name:        "input2",
+							Type:        cty.Number,
+							Description: "`input2` description",
+						},
+					},
+					ReturnType:  cty.String,
+					Description: "`foo` description",
+				},
+			},
+			`x = foo("a", )`,
+			hcl.Pos{Line: 1, Column: 12, Byte: 13},
+			&lang.FunctionSignature{
+				Name:        "foo(input string, input2 number) string",
+				Description: lang.Markdown("`foo` description"),
+				Parameters: []lang.FunctionParameter{
+					{
+						Name:        "input",
+						Description: lang.Markdown("`input` description"),
+					},
+					{
+						Name:        "input2",
+						Description: lang.Markdown("`input2` description"),
+					},
+				},
+				ActiveParameter: 1,
+			},
+		},
+		{
+			"one parameter, one variadic, empty variadic",
+			map[string]schema.FunctionSignature{
+				"foo": {
+					Params: []function.Parameter{
+						{
+							Name:        "input",
+							Type:        cty.String,
+							Description: "`input` description",
+						},
+					},
+					VarParam: &function.Parameter{
+						Name:        "vinput",
+						Type:        cty.Number,
+						Description: "`vinput` description",
+					},
+					ReturnType:  cty.String,
+					Description: "`foo` description",
+				},
+			},
+			`x = foo("a", )`,
+			hcl.Pos{Line: 1, Column: 12, Byte: 13},
+			&lang.FunctionSignature{
+				Name:        "foo(input string, ...vinput number) string",
+				Description: lang.Markdown("`foo` description"),
+				Parameters: []lang.FunctionParameter{
+					{
+						Name:        "input",
+						Description: lang.Markdown("`input` description"),
+					},
+					{
+						Name:        "vinput",
+						Description: lang.Markdown("`vinput` description"),
+					},
+				},
+				ActiveParameter: 1,
+			},
+		},
+		{
+			"one parameter, one variadic, some variadic",
+			map[string]schema.FunctionSignature{
+				"foo": {
+					Params: []function.Parameter{
+						{
+							Name:        "input",
+							Type:        cty.String,
+							Description: "`input` description",
+						},
+					},
+					VarParam: &function.Parameter{
+						Name:        "vinput",
+						Type:        cty.Number,
+						Description: "`vinput` description",
+					},
+					ReturnType:  cty.String,
+					Description: "`foo` description",
+				},
+			},
+			`x = foo("a", 1, 2, )`,
+			hcl.Pos{Line: 1, Column: 18, Byte: 19},
+			&lang.FunctionSignature{
+				Name:        "foo(input string, ...vinput number) string",
+				Description: lang.Markdown("`foo` description"),
+				Parameters: []lang.FunctionParameter{
+					{
+						Name:        "input",
+						Description: lang.Markdown("`input` description"),
+					},
+					{
+						Name:        "vinput",
+						Description: lang.Markdown("`vinput` description"),
+					},
+				},
+				ActiveParameter: 1,
+			},
+		},
+		{
+			"two complex parameters, empty second parameter",
+			map[string]schema.FunctionSignature{
+				"foo": {
+					Params: []function.Parameter{
+						{
+							Name:        "input",
+							Type:        cty.List(cty.String),
+							Description: "`input` description",
+						},
+						{
+							Name:        "input2",
+							Type:        cty.List(cty.Number),
+							Description: "`input2` description",
+						},
+					},
+					ReturnType:  cty.Map(cty.Number),
+					Description: "`foo` description",
+				},
+			},
+			`x = foo(["a", "b"], )`,
+			hcl.Pos{Line: 1, Column: 19, Byte: 20},
+			&lang.FunctionSignature{
+				Name:        "foo(input list of string, input2 list of number) map of number",
+				Description: lang.Markdown("`foo` description"),
+				Parameters: []lang.FunctionParameter{
+					{
+						Name:        "input",
+						Description: lang.Markdown("`input` description"),
+					},
+					{
+						Name:        "input2",
+						Description: lang.Markdown("`input2` description"),
+					},
+				},
+				ActiveParameter: 1,
+			},
+		},
+		{
+			"three parameters, filling middle parameter",
+			map[string]schema.FunctionSignature{
+				"foo": {
+					Params: []function.Parameter{
+						{
+							Name:        "input",
+							Type:        cty.String,
+							Description: "`input` description",
+						},
+						{
+							Name:        "input2",
+							Type:        cty.Number,
+							Description: "`input2` description",
+						},
+						{
+							Name:        "input3",
+							Type:        cty.Bool,
+							Description: "`input3` description",
+						},
+					},
+					ReturnType:  cty.String,
+					Description: "`foo` description",
+				},
+			},
+			`x = foo("a",  , false)`,
+			hcl.Pos{Line: 1, Column: 12, Byte: 13},
+			&lang.FunctionSignature{
+				Name:        "foo(input string, input2 number, input3 bool) string",
+				Description: lang.Markdown("`foo` description"),
+				Parameters: []lang.FunctionParameter{
+					{
+						Name:        "input",
+						Description: lang.Markdown("`input` description"),
+					},
+					{
+						Name:        "input2",
+						Description: lang.Markdown("`input2` description"),
+					},
+					{
+						Name:        "input3",
+						Description: lang.Markdown("`input3` description"),
+					},
+				},
+				ActiveParameter: 1,
+			},
+		},
+		{
+			"two parameters, adding a third",
+			map[string]schema.FunctionSignature{
+				"foo": {
+					Params: []function.Parameter{
+						{
+							Name:        "foo",
+							Type:        cty.String,
+							Description: "`foo` description",
+						},
+						{
+							Name:        "foo2",
+							Type:        cty.Number,
+							Description: "`foo2` description",
+						},
+					},
+					ReturnType:  cty.String,
+					Description: "`foo` description",
+				},
+			},
+			`x = foo("a", "b", )`,
+			hcl.Pos{Line: 1, Column: 17, Byte: 18},
+			nil,
+		},
+		{
+			"no parameter, one variadic, some variadic",
+			map[string]schema.FunctionSignature{
+				"foo": {
+					VarParam: &function.Parameter{
+						Name:        "vinput",
+						Type:        cty.Number,
+						Description: "`vinput` description",
+					},
+					ReturnType:  cty.String,
+					Description: "`foo` description",
+				},
+			},
+			`x = foo(1, 2, 3, )`,
+			hcl.Pos{Line: 1, Column: 16, Byte: 17},
+			&lang.FunctionSignature{
+				Name:        "foo(...vinput number) string",
+				Description: lang.Markdown("`foo` description"),
+				Parameters: []lang.FunctionParameter{
+					{
+						Name:        "vinput",
+						Description: lang.Markdown("`vinput` description"),
+					},
+				},
+				ActiveParameter: 0,
+			},
+		},
+		{
+			"no parameter, one variadic, second arg",
+			map[string]schema.FunctionSignature{
+				"concat": {
+					VarParam: &function.Parameter{
+						Name: "seqs",
+						Type: cty.DynamicPseudoType,
+					},
+					ReturnType:  cty.DynamicPseudoType,
+					Description: "`concat` description",
+				},
+			},
+			`x = concat([],)`,
+			hcl.Pos{Line: 1, Column: 13, Byte: 14},
+			&lang.FunctionSignature{
+				Name:        "concat(...seqs dynamic) dynamic",
+				Description: lang.Markdown("`concat` description"),
+				Parameters: []lang.FunctionParameter{
+					{
+						Name:        "seqs",
+						Description: lang.Markdown(""),
+					},
+				},
+				ActiveParameter: 0,
+			},
+		},
+		{
+			"multi-line two complex parameters, empty first parameter",
+			map[string]schema.FunctionSignature{
+				"foo": {
+					Params: []function.Parameter{
+						{
+							Name:        "input",
+							Type:        cty.List(cty.String),
+							Description: "`input` description",
+						},
+						{
+							Name:        "input2",
+							Type:        cty.List(cty.Number),
+							Description: "`input2` description",
+						},
+					},
+					ReturnType:  cty.Map(cty.Number),
+					Description: "`foo` description",
+				},
+			},
+			`x = foo(
+  
+)`,
+			hcl.Pos{Line: 2, Column: 1, Byte: 11},
+			&lang.FunctionSignature{
+				Name:        "foo(input list of string, input2 list of number) map of number",
+				Description: lang.Markdown("`foo` description"),
+				Parameters: []lang.FunctionParameter{
+					{
+						Name:        "input",
+						Description: lang.Markdown("`input` description"),
+					},
+					{
+						Name:        "input2",
+						Description: lang.Markdown("`input2` description"),
+					},
+				},
+				ActiveParameter: 0,
+			},
+		},
+		{
+			"multi-line two complex parameters, empty second parameter",
+			map[string]schema.FunctionSignature{
+				"foo": {
+					Params: []function.Parameter{
+						{
+							Name:        "input",
+							Type:        cty.List(cty.String),
+							Description: "`input` description",
+						},
+						{
+							Name:        "input2",
+							Type:        cty.List(cty.Number),
+							Description: "`input2` description",
+						},
+					},
+					ReturnType:  cty.Map(cty.Number),
+					Description: "`foo` description",
+				},
+			},
+			`x = foo(
+  ["a", "b"],
+  
+)`,
+			hcl.Pos{Line: 3, Column: 1, Byte: 25},
+			&lang.FunctionSignature{
+				Name:        "foo(input list of string, input2 list of number) map of number",
+				Description: lang.Markdown("`foo` description"),
+				Parameters: []lang.FunctionParameter{
+					{
+						Name:        "input",
+						Description: lang.Markdown("`input` description"),
+					},
+					{
+						Name:        "input2",
+						Description: lang.Markdown("`input2` description"),
+					},
+				},
+				ActiveParameter: 1,
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%2d-%s", i, tc.testName), func(t *testing.T) {
+			f, _ := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+			d := testPathDecoder(t, &PathContext{
+				Files: map[string]*hcl.File{
+					"test.tf": f,
+				},
+				Functions: tc.functions,
+			})
+
+			signature, err := d.SignatureAtPos("test.tf", tc.pos)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedSignature, signature); diff != "" {
+				t.Fatalf("unexpected signature: %s", diff)
+			}
+		})
+	}
+
+}

--- a/lang/signature.go
+++ b/lang/signature.go
@@ -1,0 +1,24 @@
+package lang
+
+type FunctionSignature struct {
+	Name string
+
+	// Description is an optional human-readable description
+	// of the function.
+	Description MarkupContent
+
+	// Parameters is an ordered list of the function's parameters.
+	Parameters []FunctionParameter
+
+	// ActiveParameter is an index marking the parameter a user is currently
+	// editing. It should lie inside the range of Parameters.
+	ActiveParameter uint32
+}
+
+type FunctionParameter struct {
+	Name string
+
+	// Description is an optional human-readable description
+	// of the parameter.
+	Description MarkupContent
+}

--- a/schema/signature.go
+++ b/schema/signature.go
@@ -1,6 +1,9 @@
 package schema
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/function"
 )
@@ -21,4 +24,43 @@ type FunctionSignature struct {
 	// VarParam describes the function's variadic
 	// parameter if it is supported.
 	VarParam *function.Parameter
+}
+
+// ParameterNames returns a list of all parameter names of a function.
+func (fs FunctionSignature) ParameterNames() []string {
+	paramsLen := len(fs.Params)
+	if fs.VarParam != nil {
+		paramsLen += 1
+	}
+	names := make([]string, 0, paramsLen)
+
+	for _, p := range fs.Params {
+		names = append(names, p.Name)
+	}
+	if fs.VarParam != nil {
+		names = append(names, "..."+fs.VarParam.Name)
+	}
+
+	return names
+}
+
+// ParameterSignature returns a string containing all function parameters
+// with their respective types.
+//
+// Useful for displaying as part of a function signature.
+func (fs FunctionSignature) ParameterSignature() string {
+	paramsLen := len(fs.Params)
+	if fs.VarParam != nil {
+		paramsLen += 1
+	}
+	names := make([]string, 0, paramsLen)
+
+	for _, p := range fs.Params {
+		names = append(names, fmt.Sprintf("%s %s", p.Name, p.Type.FriendlyName()))
+	}
+	if fs.VarParam != nil {
+		names = append(names, fmt.Sprintf("...%s %s", fs.VarParam.Name, fs.VarParam.Type.FriendlyName()))
+	}
+
+	return strings.Join(names, ", ")
 }

--- a/schema/signature.go
+++ b/schema/signature.go
@@ -1,9 +1,6 @@
 package schema
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/function"
 )
@@ -24,43 +21,4 @@ type FunctionSignature struct {
 	// VarParam describes the function's variadic
 	// parameter if it is supported.
 	VarParam *function.Parameter
-}
-
-// ParameterNames returns a list of all parameter names of a function.
-func (fs FunctionSignature) ParameterNames() []string {
-	paramsLen := len(fs.Params)
-	if fs.VarParam != nil {
-		paramsLen += 1
-	}
-	names := make([]string, 0, paramsLen)
-
-	for _, p := range fs.Params {
-		names = append(names, p.Name)
-	}
-	if fs.VarParam != nil {
-		names = append(names, "..."+fs.VarParam.Name)
-	}
-
-	return names
-}
-
-// ParameterSignature returns a string containing all function parameters
-// with their respective types.
-//
-// Useful for displaying as part of a function signature.
-func (fs FunctionSignature) ParameterSignature() string {
-	paramsLen := len(fs.Params)
-	if fs.VarParam != nil {
-		paramsLen += 1
-	}
-	names := make([]string, 0, paramsLen)
-
-	for _, p := range fs.Params {
-		names = append(names, fmt.Sprintf("%s %s", p.Name, p.Type.FriendlyName()))
-	}
-	if fs.VarParam != nil {
-		names = append(names, fmt.Sprintf("...%s %s", fs.VarParam.Name, fs.VarParam.Type.FriendlyName()))
-	}
-
-	return strings.Join(names, ", ")
 }


### PR DESCRIPTION
This PR adds the `SignatureAtPos` method to enable support for signature help. Function signatures must be present in the path context for it to work. We added the function signatures to terraform-schema in https://github.com/hashicorp/terraform-schema/pull/145. 

If you want to try it, there is a draft PR in terraform-ls, tying it all together: https://github.com/hashicorp/terraform-ls/pull/1077

## UX
Nested function calls with variadic parameters
![2023-03-14 14 06 18](https://user-images.githubusercontent.com/45985/225013332-86c54478-7991-48cd-a7ce-c84531b7c1fe.gif)

Functions without any arguments
![2023-03-14 14 07 34](https://user-images.githubusercontent.com/45985/225013436-e26d0ed9-cf07-4ec8-8741-a95e38b0cf22.gif)

No signature help, if passing too many arguments
![2023-03-14 14 08 07](https://user-images.githubusercontent.com/45985/225013546-31316481-b565-4111-a608-b14f73bc3d1f.gif)

Multiline function calls
![2023-03-14 14 17 06](https://user-images.githubusercontent.com/45985/225013592-78569251-60e4-46ae-85bd-5828c1cd9f6d.gif)


---

* Part of https://github.com/hashicorp/terraform-ls/issues/37