### PR TITLE
Update `setup-go` to obtain version via `go-version-file`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,26 +32,10 @@ jobs:
         name: Unshallow
         run: git fetch --prune --unshallow
       -
-        name: Read go version (Unix)
-        if: ${{ runner.os != 'Windows' }}
-        id: go-version-unix
-        run: |
-          content=`cat ./.go-version`
-          echo "::set-output name=content::$content"
-      -
-        name: Read go version (Windows)
-        if: ${{ runner.os == 'Windows' }}
-        id: go-version-win
-        run: |
-          $content = Get-Content .\.go-version -Raw
-          echo "::set-output name=content::$content"
-      -
         name: Set up Go
         uses: actions/setup-go@v3
         with:
-          # TODO: Replace with go-version-from-file when it is supported
-          # https://github.com/actions/setup-go/pull/62
-          go-version: ${{ steps.go-version-unix.outputs.content || steps.go-version-win.outputs.content }}
+          go-version-file: ".go-version"
       -
         name: Go mod download
         run: go mod download -x


### PR DESCRIPTION
This PR updates our workflows to make `setup-go` obtain the Go version directly from the `.go-version` file.