### PR TITLE
Support Dynamic block expression extensions

### DIFF
--- a/decoder/body_candidates.go
+++ b/decoder/body_candidates.go
@@ -34,6 +34,10 @@ func (d *PathDecoder) bodySchemaCandidates(body *hclsyntax.Body, schema *schema.
 				candidates.List = append(candidates.List, attributeSchemaToCandidate("for_each", forEachAttributeSchema(), editRng))
 			}
 		}
+
+		if schema.Extensions.DynamicBlocks {
+			candidates.List = append(candidates.List, d.blockSchemaToCandidate("dynamic", dynamicBlockSchema(), editRng))
+		}
 	}
 
 	if len(schema.Attributes) > 0 {

--- a/decoder/body_extensions_test.go
+++ b/decoder/body_extensions_test.go
@@ -1113,7 +1113,7 @@ resource "aws_elastic_beanstalk_environment" "example" {
 						Value: "The body of each generated block",
 						Kind:  lang.PlainTextKind,
 					},
-					Detail: "Block",
+					Detail: "Block, max: 1",
 					Kind:   lang.BlockCandidateKind,
 					TextEdit: lang.TextEdit{
 						Range: hcl.Range{

--- a/decoder/body_extensions_test.go
+++ b/decoder/body_extensions_test.go
@@ -985,3 +985,224 @@ for_each =
 		})
 	}
 }
+
+func TestCompletionAtPos_BodySchema_DynamicBlock_Extensions(t *testing.T) {
+	ctx := context.Background()
+
+	testCases := []struct {
+		testName           string
+		bodySchema         *schema.BodySchema
+		cfg                string
+		pos                hcl.Pos
+		expectedCandidates lang.Candidates
+	}{
+		{
+			"dynamic block does not complete if not enabled",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource": {
+						Labels: []*schema.LabelSchema{
+							{
+								Name: "type",
+							},
+							{
+								Name: "name",
+							},
+						},
+						Body: &schema.BodySchema{
+							Extensions: &schema.BodyExtensions{
+								DynamicBlocks: false,
+							},
+						},
+					},
+				},
+			},
+			`
+resource "aws_elastic_beanstalk_environment" "example" {
+	name = "example"
+	
+}`,
+			hcl.Pos{
+				Line:   4,
+				Column: 3,
+				Byte:   77,
+			},
+			lang.CompleteCandidates([]lang.Candidate{}),
+		},
+		{
+			"dynamic block completion",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource": {
+						Labels: []*schema.LabelSchema{
+							{Name: "type"}, {Name: "name"},
+						},
+						Body: &schema.BodySchema{
+							Extensions: &schema.BodyExtensions{
+								DynamicBlocks: true,
+							},
+						},
+					},
+				},
+			},
+			`resource "aws_elastic_beanstalk_environment" "example" {
+	name = "example"
+	
+}`,
+			hcl.Pos{
+				Line:   3,
+				Column: 3,
+				Byte:   76,
+			},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label: "dynamic",
+					Description: lang.MarkupContent{
+						Value: "A dynamic block to produce blocks dynamically by iterating over a given complex value",
+						Kind:  lang.MarkdownKind,
+					},
+					Detail: "Block, map",
+					Kind:   lang.BlockCandidateKind,
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start: hcl.Pos{
+								Line:   3,
+								Column: 3,
+								Byte:   76,
+							},
+							End: hcl.Pos{
+								Line:   3,
+								Column: 3,
+								Byte:   76,
+							},
+						},
+						NewText: "dynamic",
+						Snippet: "dynamic \"${1:name}\" {\n  ${2}\n}",
+					},
+				},
+			}),
+		},
+		{
+			"dynamic block inner completion",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource": {
+						Labels: []*schema.LabelSchema{
+							{Name: "type"}, {Name: "name"},
+						},
+						Body: &schema.BodySchema{
+							Extensions: &schema.BodyExtensions{
+								DynamicBlocks: true,
+							},
+						},
+					},
+				},
+			},
+			`resource "aws_elastic_beanstalk_environment" "example" {
+	name = "example"
+	dynamic "foo" {
+		
+	}
+}`,
+			hcl.Pos{Line: 4, Column: 5, Byte: 94},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label: "content",
+					Description: lang.MarkupContent{
+						Value: "The body of each generated block",
+						Kind:  lang.PlainTextKind,
+					},
+					Detail: "Block",
+					Kind:   lang.BlockCandidateKind,
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 4, Column: 5, Byte: 94},
+							End:      hcl.Pos{Line: 4, Column: 5, Byte: 94},
+						},
+						NewText: "content",
+						Snippet: "content {\n  ${1}\n}",
+					},
+				},
+				{
+					Label: "for_each",
+					Description: lang.MarkupContent{
+						Value: "A meta-argument that accepts a map or a set of strings, and creates an instance for each item in that map or set.\n\n**Note**: A given block cannot use both `count` and `for_each`.",
+						Kind:  lang.MarkdownKind,
+					},
+					Detail:         "required, map of any single type or set of string",
+					Kind:           lang.AttributeCandidateKind,
+					TriggerSuggest: true,
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 4, Column: 5, Byte: 94},
+							End:      hcl.Pos{Line: 4, Column: 5, Byte: 94},
+						},
+						NewText: "for_each",
+						Snippet: "for_each = ",
+					},
+				},
+				{
+					Label: "iterator",
+					Description: lang.MarkupContent{
+						Value: "The name of a temporary variable that represents the current element of the complex value. Defaults to the label of the dynamic block.",
+						Kind:  lang.MarkdownKind,
+					},
+					Detail: "optional, string",
+					Kind:   lang.AttributeCandidateKind,
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 4, Column: 5, Byte: 94},
+							End:      hcl.Pos{Line: 4, Column: 5, Byte: 94},
+						},
+						NewText: "iterator",
+						Snippet: `iterator = "${1:value}"`,
+					},
+				},
+				{
+					Label: "labels",
+					Description: lang.MarkupContent{
+						Value: "A list of strings that specifies the block labels, in order, to use for each generated block.",
+						Kind:  lang.MarkdownKind,
+					},
+					Detail: "optional, list of string",
+					Kind:   lang.AttributeCandidateKind,
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 4, Column: 5, Byte: 94},
+							End:      hcl.Pos{Line: 4, Column: 5, Byte: 94},
+						},
+						NewText: "labels",
+						Snippet: "labels = [\n  ${0}\n]",
+					},
+				},
+			}),
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+			f, _ := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+
+			d := testPathDecoder(t, &PathContext{
+				Schema: tc.bodySchema,
+				Files: map[string]*hcl.File{
+					"test.tf": f,
+				},
+			})
+
+			candidates, err := d.CandidatesAtPos(ctx, "test.tf", tc.pos)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedCandidates, candidates); diff != "" {
+				t.Fatalf("unexpected candidates: %s", diff)
+			}
+		})
+	}
+}

--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -238,6 +238,7 @@ func dynamicBlockSchema() *schema.BlockSchema {
 			Blocks: map[string]*schema.BlockSchema{
 				"content": {
 					Description: lang.PlainText("The body of each generated block"),
+					MaxItems:    1,
 				},
 			},
 		},

--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -195,6 +195,55 @@ func forEachAttributeSchema() *schema.AttributeSchema {
 	}
 }
 
+func dynamicBlockSchema() *schema.BlockSchema {
+	return &schema.BlockSchema{
+		Description: lang.Markdown("A dynamic block to produce blocks dynamically by iterating over a given complex value"),
+		Type:        schema.BlockTypeMap,
+		Labels: []*schema.LabelSchema{
+			{Name: "name"},
+		},
+		Body: &schema.BodySchema{
+			Attributes: map[string]*schema.AttributeSchema{
+				"for_each": {
+					Expr: schema.ExprConstraints{
+						schema.TraversalExpr{OfType: cty.Map(cty.DynamicPseudoType)},
+						schema.TraversalExpr{OfType: cty.Set(cty.String)},
+						schema.LiteralTypeExpr{Type: cty.Map(cty.DynamicPseudoType)},
+						schema.LiteralTypeExpr{Type: cty.Set(cty.String)},
+					},
+					IsRequired: true,
+					Description: lang.Markdown("A meta-argument that accepts a map or a set of strings, and creates an instance for each item in that map or set.\n\n" +
+						"**Note**: A given block cannot use both `count` and `for_each`."),
+				},
+				"iterator": {
+					Expr:       schema.LiteralTypeOnly(cty.String),
+					IsOptional: true,
+					Description: lang.Markdown("The name of a temporary variable that represents the current " +
+						"element of the complex value. Defaults to the label of the dynamic block."),
+				},
+				"labels": {
+					Expr: schema.ExprConstraints{
+						schema.ListExpr{
+							Elem: schema.ExprConstraints{
+								schema.LiteralTypeExpr{Type: cty.String},
+								schema.TraversalExpr{OfType: cty.String},
+							},
+						},
+					},
+					IsOptional: true,
+					Description: lang.Markdown("A list of strings that specifies the block labels, " +
+						"in order, to use for each generated block."),
+				},
+			},
+			Blocks: map[string]*schema.BlockSchema{
+				"content": {
+					Description: lang.PlainText("The body of each generated block"),
+				},
+			},
+		},
+	}
+}
+
 func countIndexHoverData(rng hcl.Range) *lang.HoverData {
 	return &lang.HoverData{
 		Content: lang.Markdown("`count.index` _number_\n\nThe distinct index number (starting with 0) corresponding to the instance"),

--- a/schema/body_schema.go
+++ b/schema/body_schema.go
@@ -51,8 +51,9 @@ type BodySchema struct {
 }
 
 type BodyExtensions struct {
-	Count   bool // count attribute + count.index refs
-	ForEach bool // for_each attribute + each.* refs
+	Count         bool // count attribute + count.index refs
+	ForEach       bool // for_each attribute + each.* refs
+	DynamicBlocks bool // dynamic "block-name" w/ content & for_each inside
 }
 
 func (be *BodyExtensions) Copy() *BodyExtensions {
@@ -61,8 +62,9 @@ func (be *BodyExtensions) Copy() *BodyExtensions {
 	}
 
 	return &BodyExtensions{
-		Count:   be.Count,
-		ForEach: be.ForEach,
+		Count:         be.Count,
+		ForEach:       be.ForEach,
+		DynamicBlocks: be.DynamicBlocks,
 	}
 }
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -32,3 +32,13 @@ func WithActiveForEach(ctx context.Context) context.Context {
 func ActiveForEachFromContext(ctx context.Context) bool {
 	return ctx.Value(bodyActiveForEachCtxKey{}) != nil
 }
+
+type bodyActiveDynamicBlockCtxKey struct{}
+
+func WithActiveDynamicBlock(ctx context.Context) context.Context {
+	return context.WithValue(ctx, bodyActiveDynamicBlockCtxKey{}, true)
+}
+
+func ActiveActiveDynamicBlockFromContext(ctx context.Context) bool {
+	return ctx.Value(bodyActiveDynamicBlockCtxKey{}) != nil
+}


### PR DESCRIPTION
Adds support for completion of dynamic blocks in resource, data, provider and provisioner blocks.

This does not provide completion for the label for a given dynamic block, which will be provided in a future set of work.

Partially implements https://github.com/hashicorp/terraform-ls/issues/530