### PR TITLE
decoder: fix completion & hover for `count` extension value

### DIFF
--- a/decoder/body_candidates.go
+++ b/decoder/body_candidates.go
@@ -23,7 +23,7 @@ func (d *PathDecoder) bodySchemaCandidates(body *hclsyntax.Body, schema *schema.
 			// check if count attribute is already declared, so we don't
 			// suggest a duplicate
 			if _, ok := body.Attributes["count"]; !ok {
-				candidates.List = append(candidates.List, countAttributeCandidate(editRng))
+				candidates.List = append(candidates.List, attributeSchemaToCandidate("count", countAttributeSchema(), editRng))
 			}
 		}
 	}

--- a/decoder/body_extensions_test.go
+++ b/decoder/body_extensions_test.go
@@ -6,12 +6,13 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/reference"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
-	"github.com/zclconf/go-cty/cty"
 )
 
 func TestCompletionAtPos_BodySchema_Extensions(t *testing.T) {

--- a/decoder/body_extensions_test.go
+++ b/decoder/body_extensions_test.go
@@ -60,23 +60,28 @@ func TestCompletionAtPos_BodySchema_Extensions(t *testing.T) {
 					Label: "count",
 					Description: lang.MarkupContent{
 						Value: "The distinct index number (starting with 0) corresponding to the instance",
-						Kind:  lang.PlainTextKind,
+						Kind:  lang.MarkdownKind,
 					},
 					Detail: "optional, number",
-					TextEdit: lang.TextEdit{Range: hcl.Range{
-						Filename: "test.tf",
-						Start: hcl.Pos{
-							Line:   2,
-							Column: 1,
-							Byte:   32,
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start: hcl.Pos{
+								Line:   2,
+								Column: 1,
+								Byte:   32,
+							},
+							End: hcl.Pos{
+								Line:   2,
+								Column: 1,
+								Byte:   32,
+							},
 						},
-						End: hcl.Pos{
-							Line:   2,
-							Column: 1,
-							Byte:   32,
-						},
-					}, NewText: "count", Snippet: "count = ${1:1}"},
-					Kind: lang.AttributeCandidateKind,
+						NewText: "count",
+						Snippet: "count = ",
+					},
+					TriggerSuggest: true,
+					Kind:           lang.AttributeCandidateKind,
 				},
 			}),
 		},

--- a/decoder/candidates.go
+++ b/decoder/candidates.go
@@ -59,6 +59,9 @@ func (d *PathDecoder) candidatesAtPos(ctx context.Context, body *hclsyntax.Body,
 
 	for _, attr := range body.Attributes {
 		if d.isPosInsideAttrExpr(attr, pos) {
+			if bodySchema.Extensions != nil && bodySchema.Extensions.Count && attr.Name == "count" {
+				return d.attrValueCandidatesAtPos(ctx, attr, countAttributeSchema(), outerBodyRng, pos)
+			}
 			if aSchema, ok := bodySchema.Attributes[attr.Name]; ok {
 				return d.attrValueCandidatesAtPos(ctx, attr, aSchema, outerBodyRng, pos)
 			}

--- a/decoder/candidates_test.go
+++ b/decoder/candidates_test.go
@@ -1575,10 +1575,12 @@ func TestDecoder_CandidatesAtPos_incompleteLabel(t *testing.T) {
 	resourceSchema := &schema.BlockSchema{
 		Labels: resourceLabelSchema,
 		Body: &schema.BodySchema{
-			Extensions: &schema.BodyExtensions{
-				Count: true,
+			Attributes: map[string]*schema.AttributeSchema{
+				"foo": {
+					IsOptional: true,
+					Expr:       schema.LiteralTypeOnly(cty.String),
+				},
 			},
-			Attributes: map[string]*schema.AttributeSchema{},
 		},
 		DependentBody: map[schema.SchemaKey]*schema.BodySchema{
 			schema.NewSchemaKey(schema.DependencyKeys{
@@ -1633,26 +1635,22 @@ res
 			"new block or attribute inside a block",
 			`
 resource "any" "ref" {
-  co
+  fo
 }
 `,
 			hcl.Pos{Line: 3, Column: 5, Byte: 28},
 			lang.CompleteCandidates([]lang.Candidate{
 				{
-					Label: "count",
-					Description: lang.MarkupContent{
-						Value: "The distinct index number (starting with 0) corresponding to the instance",
-						Kind:  lang.PlainTextKind,
-					},
-					Detail: "optional, number",
+					Label:  "foo",
+					Detail: "optional, string",
 					TextEdit: lang.TextEdit{
 						Range: hcl.Range{
 							Filename: "test.tf",
 							Start:    hcl.Pos{Line: 3, Column: 3, Byte: 26},
 							End:      hcl.Pos{Line: 3, Column: 5, Byte: 28},
 						},
-						NewText: "count",
-						Snippet: "count = ${1:1}",
+						NewText: "foo",
+						Snippet: `foo = "${1:value}"`,
 					},
 					Kind: lang.AttributeCandidateKind,
 				},

--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
 )
 
 type Decoder struct {
@@ -171,6 +172,17 @@ func countAttributeCandidate(editRng hcl.Range) lang.Candidate {
 			Snippet: "count = ${1:1}",
 			Range:   editRng,
 		},
+	}
+}
+
+func countAttributeSchema() *schema.AttributeSchema {
+	return &schema.AttributeSchema{
+		IsOptional: true,
+		Expr: schema.ExprConstraints{
+			schema.TraversalExpr{OfType: cty.Number},
+			schema.LiteralTypeExpr{Type: cty.Number},
+		},
+		Description: lang.Markdown("The distinct index number (starting with 0) corresponding to the instance"),
 	}
 }
 

--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -161,20 +161,6 @@ func stringPos(pos hcl.Pos) string {
 	return fmt.Sprintf("%d,%d", pos.Line, pos.Column)
 }
 
-func countAttributeCandidate(editRng hcl.Range) lang.Candidate {
-	return lang.Candidate{
-		Label:       "count",
-		Detail:      "optional, number",
-		Description: lang.PlainText("The distinct index number (starting with 0) corresponding to the instance"),
-		Kind:        lang.AttributeCandidateKind,
-		TextEdit: lang.TextEdit{
-			NewText: "count",
-			Snippet: "count = ${1:1}",
-			Range:   editRng,
-		},
-	}
-}
-
 func countAttributeSchema() *schema.AttributeSchema {
 	return &schema.AttributeSchema{
 		IsOptional: true,

--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -172,6 +172,13 @@ func countAttributeSchema() *schema.AttributeSchema {
 	}
 }
 
+func countIndexHoverData(rng hcl.Range) *lang.HoverData {
+	return &lang.HoverData{
+		Content: lang.Markdown("`count.index` _number_\n\nThe distinct index number (starting with 0) corresponding to the instance"),
+		Range:   rng,
+	}
+}
+
 func countIndexCandidate(editRng hcl.Range) lang.Candidate {
 	return lang.Candidate{
 		Label:       "count.index",
@@ -183,15 +190,5 @@ func countIndexCandidate(editRng hcl.Range) lang.Candidate {
 			Snippet: "count.index",
 			Range:   editRng,
 		},
-	}
-}
-
-func countAttributeHoverData(editRng hcl.Range) *lang.HoverData {
-	return &lang.HoverData{
-		Content: lang.MarkupContent{
-			Kind:  lang.MarkdownKind,
-			Value: "**count** _optional, number_\n\nThe distinct index number (starting with 0) corresponding to the instance",
-		},
-		Range: editRng,
 	}
 }

--- a/decoder/hover_test.go
+++ b/decoder/hover_test.go
@@ -973,6 +973,78 @@ func TestDecoder_HoverAtPos_extension(t *testing.T) {
 				},
 			},
 		},
+		{
+			"count.index reference",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"myblock": {
+						Labels: []*schema.LabelSchema{
+							{Name: "type", IsDepKey: true},
+							{Name: "name"},
+						},
+						Body: &schema.BodySchema{
+							Extensions: &schema.BodyExtensions{
+								Count: true,
+							},
+							Attributes: map[string]*schema.AttributeSchema{
+								"foo": {
+									IsOptional: true,
+									Expr: schema.ExprConstraints{
+										schema.TraversalExpr{OfType: cty.Number},
+										schema.LiteralTypeExpr{Type: cty.Number},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			`myblock "foo" "bar" {
+  count = 1
+  foo   = count.index
+}
+`,
+			hcl.Pos{Line: 3, Column: 15, Byte: 48},
+			&lang.HoverData{
+				Content: lang.Markdown("`count.index` _number_\n\nThe distinct index number (starting with 0) corresponding to the instance"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 3, Column: 11, Byte: 44},
+					End:      hcl.Pos{Line: 3, Column: 22, Byte: 55},
+				},
+			},
+		},
+		{
+			"count attribute value",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"myblock": {
+						Labels: []*schema.LabelSchema{
+							{Name: "type", IsDepKey: true},
+							{Name: "name"},
+						},
+						Body: &schema.BodySchema{
+							Extensions: &schema.BodyExtensions{
+								Count: true,
+							},
+						},
+					},
+				},
+			},
+			`myblock "foo" "bar" {
+  count = 3
+}
+`,
+			hcl.Pos{Line: 2, Column: 11, Byte: 32},
+			&lang.HoverData{
+				Content: lang.Markdown("`3` _number_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 2, Column: 11, Byte: 32},
+					End:      hcl.Pos{Line: 2, Column: 12, Byte: 33},
+				},
+			},
+		},
 	}
 
 	for i, tc := range testCases {


### PR DESCRIPTION
I'd love to attach some screenshots before & after, but all usage of the extensions currently involves `DependentBody` which itself has some bugs, which are being fixed as part of https://github.com/hashicorp/hcl-lang/pull/142/commits/32e493e09ce61eca33e4fa2176e943ac599a9015 in https://github.com/hashicorp/hcl-lang/pull/142

So failing & passing tests will hopefully suffice.