### PR TITLE
Implement for_each and each.* completion, hover info, and semantic tokens

### DIFF
--- a/decoder/body_candidates.go
+++ b/decoder/body_candidates.go
@@ -26,6 +26,14 @@ func (d *PathDecoder) bodySchemaCandidates(body *hclsyntax.Body, schema *schema.
 				candidates.List = append(candidates.List, attributeSchemaToCandidate("count", countAttributeSchema(), editRng))
 			}
 		}
+
+		if schema.Extensions.ForEach {
+			// check if for_each attribute is already declared, so we don't
+			// suggest a duplicate
+			if _, present := body.Attributes["for_each"]; !present {
+				candidates.List = append(candidates.List, attributeSchemaToCandidate("for_each", forEachAttributeSchema(), editRng))
+			}
+		}
 	}
 
 	if len(schema.Attributes) > 0 {

--- a/decoder/body_extensions_test.go
+++ b/decoder/body_extensions_test.go
@@ -460,6 +460,408 @@ variable "test" {
 				},
 			}),
 		},
+		{
+			"foreach attribute completion",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource": {
+						Labels: []*schema.LabelSchema{
+							{Name: "type"}, {Name: "name"},
+						},
+						Body: &schema.BodySchema{
+							Extensions: &schema.BodyExtensions{
+								ForEach: true,
+							},
+						},
+					},
+				},
+			},
+			reference.Targets{},
+			`resource "aws_instance" "foo" {
+
+}`,
+			hcl.Pos{Line: 2, Column: 1, Byte: 32},
+			lang.CompleteCandidates([]lang.Candidate{{
+				Label: "for_each",
+				Description: lang.MarkupContent{
+					Value: "A meta-argument that accepts a map or a set of strings, and creates an instance for each item in that map or set.\n\n**Note**: A given block cannot use both `count` and `for_each`.",
+					Kind:  lang.MarkdownKind,
+				},
+				Detail: "optional, map of any single type or set of string",
+				TextEdit: lang.TextEdit{
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 32},
+						End:      hcl.Pos{Line: 2, Column: 1, Byte: 32},
+					},
+					NewText: "for_each",
+					Snippet: "for_each = ",
+				},
+				Kind:           lang.AttributeCandidateKind,
+				TriggerSuggest: true,
+			},
+			}),
+		},
+		{
+			"foreach attribute completion does not complete foreach when extensions not enabled",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource": {
+						Labels: []*schema.LabelSchema{
+							{Name: "type"}, {Name: "name"},
+						},
+						Body: &schema.BodySchema{
+							Extensions: &schema.BodyExtensions{
+								ForEach: false,
+							},
+						},
+					},
+				},
+			},
+			reference.Targets{},
+			`resource "aws_instance" "foo" {
+
+}`,
+			hcl.Pos{Line: 2, Column: 1, Byte: 32},
+			lang.CompleteCandidates([]lang.Candidate{}),
+		},
+		{
+			"each.* value completion",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource": {
+						Labels: []*schema.LabelSchema{
+							{Name: "type"}, {Name: "name"},
+						},
+						Body: &schema.BodySchema{
+							Extensions: &schema.BodyExtensions{
+								ForEach: true,
+							},
+							Attributes: map[string]*schema.AttributeSchema{
+								"thing": {
+									IsOptional: true,
+									Expr: schema.ExprConstraints{
+										schema.TraversalExpr{
+											OfType: cty.String,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			reference.Targets{},
+			`resource "aws_instance" "foo" {
+for_each = {
+	a_group = "eastus"
+	another_group = "westus2"
+}
+thing = 
+}`,
+			hcl.Pos{Line: 6, Column: 8, Byte: 101},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "each.key",
+					Detail: "string",
+					Kind:   lang.TraversalCandidateKind,
+					Description: lang.MarkupContent{
+						Value: "The map key (or set member) corresponding to this instance",
+						Kind:  lang.MarkdownKind,
+					},
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 6, Column: 9, Byte: 102},
+							End:      hcl.Pos{Line: 6, Column: 9, Byte: 102},
+						},
+						NewText: "each.key",
+						Snippet: "each.key",
+					},
+				},
+				{
+					Label:  "each.value",
+					Detail: "any type",
+					Kind:   lang.TraversalCandidateKind,
+					Description: lang.MarkupContent{
+						Value: "The map value corresponding to this instance. (If a set was provided, this is the same as `each.key`.)",
+						Kind:  lang.MarkdownKind,
+					},
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 6, Column: 9, Byte: 102},
+							End:      hcl.Pos{Line: 6, Column: 9, Byte: 102},
+						},
+						NewText: "each.value",
+						Snippet: "each.value",
+					},
+				},
+			}),
+		},
+		{
+			"each.* does not complete when not needed",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource": {
+						Labels: []*schema.LabelSchema{
+							{Name: "type"}, {Name: "name"},
+						},
+						Body: &schema.BodySchema{
+							Extensions: &schema.BodyExtensions{
+								ForEach: true,
+							},
+							Attributes: map[string]*schema.AttributeSchema{
+								"thing": {
+									IsOptional: true,
+									Expr: schema.ExprConstraints{
+										schema.TraversalExpr{
+											OfType: cty.String,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			reference.Targets{},
+			`resource "aws_instance" "foo" {
+thing = 
+}`,
+			hcl.Pos{Line: 2, Column: 9, Byte: 40},
+			lang.CompleteCandidates([]lang.Candidate{}),
+		},
+		{
+			"each.* does not complete when extension not enabled",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource": {
+						Labels: []*schema.LabelSchema{
+							{Name: "type"}, {Name: "name"},
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"thing": {
+									IsOptional: true,
+									Expr: schema.ExprConstraints{
+										schema.TraversalExpr{
+											OfType: cty.Number,
+										},
+									},
+								},
+							},
+							Extensions: &schema.BodyExtensions{
+								ForEach: false,
+							},
+						},
+					},
+				},
+			},
+			reference.Targets{},
+			`resource "aws_instance" "foo" {
+	thing = 
+}`,
+			hcl.Pos{Line: 2, Column: 8, Byte: 41},
+			lang.CompleteCandidates([]lang.Candidate{}),
+		},
+		{
+			"for_each does not complete more than once",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource": {
+						Labels: []*schema.LabelSchema{
+							{Name: "type"}, {Name: "name"},
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"thing": {
+									IsOptional: true,
+									Expr: schema.ExprConstraints{
+										schema.TraversalExpr{
+											OfType: cty.Number,
+										},
+									},
+								},
+							},
+							Extensions: &schema.BodyExtensions{
+								ForEach: true,
+							},
+						},
+					},
+				},
+			},
+			reference.Targets{},
+			`resource "aws_instance" "foo" {
+for_each = {
+	a_group = "eastus"
+	another_group = "westus2"
+}
+
+}`,
+			hcl.Pos{Line: 6, Column: 1, Byte: 94},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "thing",
+					Detail: "optional, number",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 6, Column: 1, Byte: 94},
+							End:      hcl.Pos{Line: 6, Column: 1, Byte: 94},
+						},
+						NewText: "thing",
+						Snippet: "thing = ",
+					},
+					TriggerSuggest: true,
+					Kind:           lang.AttributeCandidateKind,
+				},
+			}),
+		},
+		{
+			"each.* completes when inside nested blocks",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource": {
+						Labels: []*schema.LabelSchema{
+							{Name: "type"}, {Name: "name"},
+						},
+						Body: &schema.BodySchema{
+							Extensions: &schema.BodyExtensions{
+								ForEach: true,
+							},
+							Blocks: map[string]*schema.BlockSchema{
+								"foo": {
+									Body: &schema.BodySchema{
+										Attributes: map[string]*schema.AttributeSchema{
+											"thing": {
+												IsOptional: true,
+												Expr: schema.ExprConstraints{
+													schema.TraversalExpr{
+														OfType: cty.Number,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			reference.Targets{},
+			`resource "aws_instance" "foo" {
+for_each = {
+	a_group = "eastus"
+	another_group = "westus2"
+}
+foo {
+	thing = 
+}
+}`,
+			hcl.Pos{Line: 7, Column: 11, Byte: 109},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "each.key",
+					Detail: "string",
+					Kind:   lang.TraversalCandidateKind,
+					Description: lang.MarkupContent{
+						Value: "The map key (or set member) corresponding to this instance",
+						Kind:  lang.MarkdownKind,
+					},
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 7, Column: 10, Byte: 109},
+							End:      hcl.Pos{Line: 7, Column: 10, Byte: 109},
+						},
+						NewText: "each.key",
+						Snippet: "each.key",
+					},
+				},
+				{
+					Label:  "each.value",
+					Detail: "any type",
+					Kind:   lang.TraversalCandidateKind,
+					Description: lang.MarkupContent{
+						Value: "The map value corresponding to this instance. (If a set was provided, this is the same as `each.key`.)",
+						Kind:  lang.MarkdownKind,
+					},
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 7, Column: 10, Byte: 109},
+							End:      hcl.Pos{Line: 7, Column: 10, Byte: 109},
+						},
+						NewText: "each.value",
+						Snippet: "each.value",
+					},
+				},
+			}),
+		},
+		{
+			"each.* does not complete for for_each",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource": {
+						Labels: []*schema.LabelSchema{
+							{Name: "type"}, {Name: "name"},
+						},
+						Body: &schema.BodySchema{
+							Extensions: &schema.BodyExtensions{
+								ForEach: true,
+							},
+							Attributes: map[string]*schema.AttributeSchema{
+								"thing": {
+									IsOptional: true,
+									Expr: schema.ExprConstraints{
+										schema.TraversalExpr{
+											OfType: cty.String,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			reference.Targets{},
+			`resource "aws_instance" "foo" {
+for_each = 
+}`,
+			hcl.Pos{Line: 2, Column: 12, Byte: 43},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `{ "key" = any type }`,
+					Detail: "map of any single type",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 12, Byte: 43},
+							End:      hcl.Pos{Line: 2, Column: 12, Byte: 43},
+						},
+						NewText: "{\n  \"key\" = \n}",
+						Snippet: "{\n  \"${1:key}\" = ${2}\n}",
+					},
+					Kind: lang.MapCandidateKind,
+				},
+				{
+					Label:  "[ string ]",
+					Detail: "set of string",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 12, Byte: 43},
+							End:      hcl.Pos{Line: 2, Column: 12, Byte: 43},
+						},
+						NewText: `[ "" ]`,
+						Snippet: `[ "${1:value}" ]`,
+					},
+					Kind: lang.SetCandidateKind,
+				},
+			}),
+		},
 	}
 
 	for i, tc := range testCases {

--- a/decoder/candidates.go
+++ b/decoder/candidates.go
@@ -55,12 +55,22 @@ func (d *PathDecoder) candidatesAtPos(ctx context.Context, body *hclsyntax.Body,
 				ctx = schema.WithActiveCount(ctx)
 			}
 		}
+
+		if bodySchema.Extensions.ForEach {
+			if _, present := body.Attributes["for_each"]; present {
+				// append to context we need foreach completed
+				ctx = schema.WithActiveForEach(ctx)
+			}
+		}
 	}
 
 	for _, attr := range body.Attributes {
 		if d.isPosInsideAttrExpr(attr, pos) {
 			if bodySchema.Extensions != nil && bodySchema.Extensions.Count && attr.Name == "count" {
 				return d.attrValueCandidatesAtPos(ctx, attr, countAttributeSchema(), outerBodyRng, pos)
+			}
+			if bodySchema.Extensions != nil && bodySchema.Extensions.ForEach && attr.Name == "for_each" {
+				return d.attrValueCandidatesAtPos(ctx, attr, forEachAttributeSchema(), outerBodyRng, pos)
 			}
 			if aSchema, ok := bodySchema.Attributes[attr.Name]; ok {
 				return d.attrValueCandidatesAtPos(ctx, attr, aSchema, outerBodyRng, pos)

--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -172,6 +172,20 @@ func countAttributeSchema() *schema.AttributeSchema {
 	}
 }
 
+func forEachAttributeSchema() *schema.AttributeSchema {
+	return &schema.AttributeSchema{
+		IsOptional: true,
+		Expr: schema.ExprConstraints{
+			schema.TraversalExpr{OfType: cty.Map(cty.DynamicPseudoType)},
+			schema.TraversalExpr{OfType: cty.Set(cty.String)},
+			schema.LiteralTypeExpr{Type: cty.Map(cty.DynamicPseudoType)},
+			schema.LiteralTypeExpr{Type: cty.Set(cty.String)},
+		},
+		Description: lang.Markdown("A meta-argument that accepts a map or a set of strings, and creates an instance for each item in that map or set.\n\n" +
+			"**Note**: A given block cannot use both `count` and `for_each`."),
+	}
+}
+
 func countIndexHoverData(rng hcl.Range) *lang.HoverData {
 	return &lang.HoverData{
 		Content: lang.Markdown("`count.index` _number_\n\nThe distinct index number (starting with 0) corresponding to the instance"),
@@ -189,6 +203,39 @@ func countIndexCandidate(editRng hcl.Range) lang.Candidate {
 			NewText: "count.index",
 			Snippet: "count.index",
 			Range:   editRng,
+		},
+	}
+}
+
+func foreachEachCandidate(editRng hcl.Range) []lang.Candidate {
+	return []lang.Candidate{
+		{
+			Label:  "each.key",
+			Detail: "string",
+			Description: lang.MarkupContent{
+				Value: "The map key (or set member) corresponding to this instance",
+				Kind:  lang.MarkdownKind,
+			},
+			Kind: lang.TraversalCandidateKind,
+			TextEdit: lang.TextEdit{
+				NewText: "each.key",
+				Snippet: "each.key",
+				Range:   editRng,
+			},
+		},
+		{
+			Label:  "each.value",
+			Detail: "any type",
+			Description: lang.MarkupContent{
+				Value: "The map value corresponding to this instance. (If a set was provided, this is the same as `each.key`.)",
+				Kind:  lang.MarkdownKind,
+			},
+			Kind: lang.TraversalCandidateKind,
+			TextEdit: lang.TextEdit{
+				NewText: "each.value",
+				Snippet: "each.value",
+				Range:   editRng,
+			},
 		},
 	}
 }

--- a/decoder/expression_candidates.go
+++ b/decoder/expression_candidates.go
@@ -331,6 +331,10 @@ func (d *PathDecoder) constraintToCandidates(ctx context.Context, constraint sch
 		if schema.ActiveCountFromContext(ctx) && attr.Name != "count" {
 			candidates = append(candidates, countIndexCandidate(editRng))
 		}
+		if schema.ActiveForEachFromContext(ctx) && attr.Name != "for_each" {
+			candidates = append(candidates, foreachEachCandidate(editRng)...)
+		}
+
 		candidates = append(candidates, d.candidatesForTraversalConstraint(c, outerBodyRng, prefixRng, editRng)...)
 	case schema.TupleConsExpr:
 		candidates = append(candidates, lang.Candidate{

--- a/decoder/hover.go
+++ b/decoder/hover.go
@@ -51,6 +51,10 @@ func (d *PathDecoder) hoverAtPos(ctx context.Context, body *hclsyntax.Body, body
 				ctx = schema.WithActiveCount(ctx)
 			}
 		}
+
+		if bodySchema.Extensions.ForEach {
+			ctx = schema.WithActiveForEach(ctx)
+		}
 	}
 
 	for name, attr := range body.Attributes {
@@ -58,6 +62,8 @@ func (d *PathDecoder) hoverAtPos(ctx context.Context, body *hclsyntax.Body, body
 			var aSchema *schema.AttributeSchema
 			if bodySchema.Extensions != nil && bodySchema.Extensions.Count && name == "count" {
 				aSchema = countAttributeSchema()
+			} else if bodySchema.Extensions != nil && bodySchema.Extensions.ForEach && name == "for_each" {
+				aSchema = forEachAttributeSchema()
 			} else {
 				var ok bool
 				aSchema, ok = bodySchema.Attributes[attr.Name]

--- a/schema/body_schema.go
+++ b/schema/body_schema.go
@@ -51,7 +51,8 @@ type BodySchema struct {
 }
 
 type BodyExtensions struct {
-	Count bool // count attribute + count.index refs
+	Count   bool // count attribute + count.index refs
+	ForEach bool // for_each attribute + each.* refs
 }
 
 func (be *BodyExtensions) Copy() *BodyExtensions {
@@ -60,7 +61,8 @@ func (be *BodyExtensions) Copy() *BodyExtensions {
 	}
 
 	return &BodyExtensions{
-		Count: be.Count,
+		Count:   be.Count,
+		ForEach: be.ForEach,
 	}
 }
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -22,3 +22,13 @@ func WithActiveCount(ctx context.Context) context.Context {
 func ActiveCountFromContext(ctx context.Context) bool {
 	return ctx.Value(bodyActiveCountCtxKey{}) != nil
 }
+
+type bodyActiveForEachCtxKey struct{}
+
+func WithActiveForEach(ctx context.Context) context.Context {
+	return context.WithValue(ctx, bodyActiveForEachCtxKey{}, true)
+}
+
+func ActiveForEachFromContext(ctx context.Context) bool {
+	return ctx.Value(bodyActiveForEachCtxKey{}) != nil
+}


### PR DESCRIPTION
This provides completion hints inside blocks for `for_each` and `each.*` references within `resource`, `data` and `module` blocks anywhere the `for_each` meta-argument is supported. It detects if `for_each` is used already and does not suggest duplicates and detects when it is necessary to provide `each.*` completions. This does not complete the values for `each.key` and `each.value`, e.g. `each.value.something`.

This also provides hover support for `for_each` and `each.*` references using the documentation as source.

This also provides semantic token support for `for_each` and `each.*` references.

Closes https://github.com/hashicorp/terraform-ls/issues/861
