### PR TITLE
Support for local references

### DIFF
--- a/decoder/body_extensions_test.go
+++ b/decoder/body_extensions_test.go
@@ -60,7 +60,7 @@ func TestCompletionAtPos_BodySchema_Extensions(t *testing.T) {
 				{
 					Label: "count",
 					Description: lang.MarkupContent{
-						Value: "The distinct index number (starting with 0) corresponding to the instance",
+						Value: "Total number of instances of this block",
 						Kind:  lang.MarkdownKind,
 					},
 					Detail: "optional, number",
@@ -136,7 +136,7 @@ func TestCompletionAtPos_BodySchema_Extensions(t *testing.T) {
 				{
 					Label: "count",
 					Description: lang.MarkupContent{
-						Value: "The distinct index number (starting with 0) corresponding to the instance",
+						Value: "Total number of instances of this block",
 						Kind:  lang.MarkdownKind,
 					},
 					Detail: "optional, number",
@@ -289,7 +289,16 @@ func TestCompletionAtPos_BodySchema_Extensions(t *testing.T) {
 					},
 				},
 			},
-			reference.Targets{},
+			reference.Targets{
+				{
+					LocalAddr: lang.Address{
+						lang.RootStep{Name: "count"},
+						lang.AttrStep{Name: "index"},
+					},
+					Type:        cty.Number,
+					Description: lang.PlainText("The distinct index number (starting with 0) corresponding to the instance"),
+				},
+			},
 			`resource "aws_instance" "foo" {
 	count = 4
 	cpu_count =
@@ -440,7 +449,42 @@ func TestCompletionAtPos_BodySchema_Extensions(t *testing.T) {
 					},
 				},
 			},
-			reference.Targets{},
+			reference.Targets{
+				{
+					LocalAddr: lang.Address{
+						lang.RootStep{Name: "count"},
+						lang.AttrStep{Name: "index"},
+					},
+					Type:        cty.Number,
+					Description: lang.PlainText("The distinct index number (starting with 0) corresponding to the instance"),
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   2,
+							Column: 3,
+							Byte:   34,
+						},
+						End: hcl.Pos{
+							Line:   2,
+							Column: 12,
+							Byte:   43,
+						},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   2,
+							Column: 3,
+							Byte:   34,
+						},
+						End: hcl.Pos{
+							Line:   2,
+							Column: 8,
+							Byte:   39,
+						},
+					},
+				},
+			},
 			`resource "aws_instance" "foo" {
   count = 4
   foo {

--- a/decoder/body_extensions_test.go
+++ b/decoder/body_extensions_test.go
@@ -693,7 +693,42 @@ variable "test" {
 					},
 				},
 			},
-			reference.Targets{},
+			reference.Targets{
+				{
+					LocalAddr: lang.Address{
+						lang.RootStep{Name: "each"},
+					},
+					Type: cty.Object(map[string]cty.Type{
+						"key":   cty.String,
+						"value": cty.DynamicPseudoType,
+					}),
+					Description: lang.Markdown("Each element the given map or set"),
+					RangePtr:    nil,
+					DefRangePtr: nil,
+					NestedTargets: reference.Targets{
+						{
+							LocalAddr: lang.Address{
+								lang.RootStep{Name: "each"},
+								lang.AttrStep{Name: "key"},
+							},
+							Type:        cty.String,
+							Description: lang.Markdown("The map key (or set member) corresponding to this instance"),
+							RangePtr:    nil,
+							DefRangePtr: nil,
+						},
+						{
+							LocalAddr: lang.Address{
+								lang.RootStep{Name: "each"},
+								lang.AttrStep{Name: "value"},
+							},
+							Type:        cty.DynamicPseudoType,
+							Description: lang.Markdown("The map value corresponding to this instance. (If a set was provided, this is the same as `each.key`.)"),
+							RangePtr:    nil,
+							DefRangePtr: nil,
+						},
+					},
+				},
+			},
 			`resource "aws_instance" "foo" {
 for_each = {
 	a_group = "eastus"
@@ -701,8 +736,26 @@ for_each = {
 }
 thing = 
 }`,
-			hcl.Pos{Line: 6, Column: 8, Byte: 101},
+			hcl.Pos{Line: 6, Column: 9, Byte: 102},
 			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "each",
+					Detail: "object",
+					Kind:   lang.TraversalCandidateKind,
+					Description: lang.MarkupContent{
+						Value: "Each element the given map or set",
+						Kind:  lang.MarkdownKind,
+					},
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 6, Column: 9, Byte: 102},
+							End:      hcl.Pos{Line: 6, Column: 9, Byte: 102},
+						},
+						NewText: "each",
+						Snippet: "each",
+					},
+				},
 				{
 					Label:  "each.key",
 					Detail: "string",
@@ -723,7 +776,7 @@ thing =
 				},
 				{
 					Label:  "each.value",
-					Detail: "any type",
+					Detail: "dynamic",
 					Kind:   lang.TraversalCandidateKind,
 					Description: lang.MarkupContent{
 						Value: "The map value corresponding to this instance. (If a set was provided, this is the same as `each.key`.)",
@@ -880,7 +933,7 @@ for_each = {
 												IsOptional: true,
 												Expr: schema.ExprConstraints{
 													schema.TraversalExpr{
-														OfType: cty.Number,
+														OfType: cty.DynamicPseudoType,
 													},
 												},
 											},
@@ -892,7 +945,42 @@ for_each = {
 					},
 				},
 			},
-			reference.Targets{},
+			reference.Targets{
+				{
+					LocalAddr: lang.Address{
+						lang.RootStep{Name: "each"},
+					},
+					Type: cty.Object(map[string]cty.Type{
+						"key":   cty.String,
+						"value": cty.DynamicPseudoType,
+					}),
+					Description: lang.Markdown("Each element the given map or set"),
+					RangePtr:    nil,
+					DefRangePtr: nil,
+					NestedTargets: reference.Targets{
+						{
+							LocalAddr: lang.Address{
+								lang.RootStep{Name: "each"},
+								lang.AttrStep{Name: "key"},
+							},
+							Type:        cty.String,
+							Description: lang.Markdown("The map key (or set member) corresponding to this instance"),
+							RangePtr:    nil,
+							DefRangePtr: nil,
+						},
+						{
+							LocalAddr: lang.Address{
+								lang.RootStep{Name: "each"},
+								lang.AttrStep{Name: "value"},
+							},
+							Type:        cty.DynamicPseudoType,
+							Description: lang.Markdown("The map value corresponding to this instance. (If a set was provided, this is the same as `each.key`.)"),
+							RangePtr:    nil,
+							DefRangePtr: nil,
+						},
+					},
+				},
+			},
 			`resource "aws_instance" "foo" {
 for_each = {
 	a_group = "eastus"
@@ -904,6 +992,24 @@ foo {
 }`,
 			hcl.Pos{Line: 7, Column: 11, Byte: 109},
 			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "each",
+					Detail: "object",
+					Kind:   lang.TraversalCandidateKind,
+					Description: lang.MarkupContent{
+						Value: "Each element the given map or set",
+						Kind:  lang.MarkdownKind,
+					},
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 7, Column: 10, Byte: 109},
+							End:      hcl.Pos{Line: 7, Column: 10, Byte: 109},
+						},
+						NewText: "each",
+						Snippet: "each",
+					},
+				},
 				{
 					Label:  "each.key",
 					Detail: "string",
@@ -924,7 +1030,7 @@ foo {
 				},
 				{
 					Label:  "each.value",
-					Detail: "any type",
+					Detail: "dynamic",
 					Kind:   lang.TraversalCandidateKind,
 					Description: lang.MarkupContent{
 						Value: "The map value corresponding to this instance. (If a set was provided, this is the same as `each.key`.)",

--- a/decoder/body_extensions_test.go
+++ b/decoder/body_extensions_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 )
 
-func TestCompletionAtPos_BodySchema_Extensions(t *testing.T) {
+func TestCompletionAtPos_BodySchema_Extensions_Count(t *testing.T) {
 	ctx := context.Background()
 
 	testCases := []struct {
@@ -297,16 +297,42 @@ func TestCompletionAtPos_BodySchema_Extensions(t *testing.T) {
 					},
 					Type:        cty.Number,
 					Description: lang.PlainText("The distinct index number (starting with 0) corresponding to the instance"),
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   2,
+							Column: 3,
+							Byte:   34,
+						},
+						End: hcl.Pos{
+							Line:   2,
+							Column: 12,
+							Byte:   43,
+						},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   2,
+							Column: 3,
+							Byte:   34,
+						},
+						End: hcl.Pos{
+							Line:   2,
+							Column: 8,
+							Byte:   39,
+						},
+					},
 				},
 			},
 			`resource "aws_instance" "foo" {
-	count = 4
-	cpu_count =
+  count = 4
+  cpu_count = 
 }`,
 			hcl.Pos{
 				Line:   3,
-				Column: 14,
-				Byte:   55,
+				Column: 15,
+				Byte:   57,
 			},
 			lang.CompleteCandidates([]lang.Candidate{
 				{
@@ -321,13 +347,13 @@ func TestCompletionAtPos_BodySchema_Extensions(t *testing.T) {
 							Filename: "test.tf",
 							Start: hcl.Pos{
 								Line:   3,
-								Column: 13,
-								Byte:   55,
+								Column: 15,
+								Byte:   58,
 							},
 							End: hcl.Pos{
 								Line:   3,
-								Column: 13,
-								Byte:   55,
+								Column: 15,
+								Byte:   58,
 							},
 						},
 						NewText: "count.index",
@@ -602,6 +628,43 @@ variable "test" {
 				},
 			}),
 		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+			f, _ := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+
+			d := testPathDecoder(t, &PathContext{
+				Schema: tc.bodySchema,
+				Files: map[string]*hcl.File{
+					"test.tf": f,
+				},
+				ReferenceTargets: tc.referenceTargets,
+			})
+
+			candidates, err := d.CandidatesAtPos(ctx, "test.tf", tc.pos)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedCandidates, candidates); diff != "" {
+				t.Fatalf("unexpected candidates: %s", diff)
+			}
+		})
+	}
+}
+
+func TestCompletionAtPos_BodySchema_Extensions_ForEach(t *testing.T) {
+	ctx := context.Background()
+
+	testCases := []struct {
+		testName           string
+		bodySchema         *schema.BodySchema
+		referenceTargets   reference.Targets
+		cfg                string
+		pos                hcl.Pos
+		expectedCandidates lang.Candidates
+	}{
 		{
 			"foreach attribute completion",
 			&schema.BodySchema{
@@ -703,8 +766,16 @@ variable "test" {
 						"value": cty.DynamicPseudoType,
 					}),
 					Description: lang.Markdown("Each element the given map or set"),
-					RangePtr:    nil,
-					DefRangePtr: nil,
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 32},
+						End:      hcl.Pos{Line: 5, Column: 2, Byte: 93},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 32},
+						End:      hcl.Pos{Line: 2, Column: 9, Byte: 40},
+					},
 					NestedTargets: reference.Targets{
 						{
 							LocalAddr: lang.Address{
@@ -713,8 +784,16 @@ variable "test" {
 							},
 							Type:        cty.String,
 							Description: lang.Markdown("The map key (or set member) corresponding to this instance"),
-							RangePtr:    nil,
-							DefRangePtr: nil,
+							RangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start:    hcl.Pos{Line: 2, Column: 1, Byte: 32},
+								End:      hcl.Pos{Line: 5, Column: 2, Byte: 93},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start:    hcl.Pos{Line: 2, Column: 1, Byte: 32},
+								End:      hcl.Pos{Line: 2, Column: 9, Byte: 40},
+							},
 						},
 						{
 							LocalAddr: lang.Address{
@@ -723,8 +802,16 @@ variable "test" {
 							},
 							Type:        cty.DynamicPseudoType,
 							Description: lang.Markdown("The map value corresponding to this instance. (If a set was provided, this is the same as `each.key`.)"),
-							RangePtr:    nil,
-							DefRangePtr: nil,
+							RangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start:    hcl.Pos{Line: 2, Column: 1, Byte: 32},
+								End:      hcl.Pos{Line: 5, Column: 2, Byte: 93},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start:    hcl.Pos{Line: 2, Column: 1, Byte: 32},
+								End:      hcl.Pos{Line: 2, Column: 9, Byte: 40},
+							},
 						},
 					},
 				},
@@ -955,8 +1042,16 @@ for_each = {
 						"value": cty.DynamicPseudoType,
 					}),
 					Description: lang.Markdown("Each element the given map or set"),
-					RangePtr:    nil,
-					DefRangePtr: nil,
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 32},
+						End:      hcl.Pos{Line: 5, Column: 2, Byte: 93},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 32},
+						End:      hcl.Pos{Line: 2, Column: 9, Byte: 40},
+					},
 					NestedTargets: reference.Targets{
 						{
 							LocalAddr: lang.Address{
@@ -965,8 +1060,16 @@ for_each = {
 							},
 							Type:        cty.String,
 							Description: lang.Markdown("The map key (or set member) corresponding to this instance"),
-							RangePtr:    nil,
-							DefRangePtr: nil,
+							RangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start:    hcl.Pos{Line: 2, Column: 1, Byte: 32},
+								End:      hcl.Pos{Line: 5, Column: 2, Byte: 93},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start:    hcl.Pos{Line: 2, Column: 1, Byte: 32},
+								End:      hcl.Pos{Line: 2, Column: 9, Byte: 40},
+							},
 						},
 						{
 							LocalAddr: lang.Address{
@@ -975,8 +1078,16 @@ for_each = {
 							},
 							Type:        cty.DynamicPseudoType,
 							Description: lang.Markdown("The map value corresponding to this instance. (If a set was provided, this is the same as `each.key`.)"),
-							RangePtr:    nil,
-							DefRangePtr: nil,
+							RangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start:    hcl.Pos{Line: 2, Column: 1, Byte: 32},
+								End:      hcl.Pos{Line: 5, Column: 2, Byte: 93},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start:    hcl.Pos{Line: 2, Column: 1, Byte: 32},
+								End:      hcl.Pos{Line: 2, Column: 9, Byte: 40},
+							},
 						},
 					},
 				},
@@ -1136,7 +1247,526 @@ for_each =
 	}
 }
 
-func TestCompletionAtPos_BodySchema_DynamicBlock_Extensions(t *testing.T) {
+func TestCompletionAtPos_BodySchema_Extensions_SelfRef(t *testing.T) {
+	ctx := context.Background()
+
+	testCases := []struct {
+		testName           string
+		bodySchema         *schema.BodySchema
+		cfg                string
+		pos                hcl.Pos
+		expectedCandidates lang.Candidates
+	}{
+		// nested block
+		{
+			"target self addr enabled but no extension enabled",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource": {
+						Labels: []*schema.LabelSchema{
+							{
+								Name:        "type",
+								IsDepKey:    true,
+								Completable: true,
+							},
+							{Name: "name"},
+						},
+						Body: schema.NewBodySchema(),
+						DependentBody: map[schema.SchemaKey]*schema.BodySchema{
+							schema.NewSchemaKey(schema.DependencyKeys{
+								Labels: []schema.LabelDependent{
+									{
+										Index: 0,
+										Value: "aws_instance",
+									},
+								},
+							}): {
+								Attributes: map[string]*schema.AttributeSchema{
+									"cpu_count": {
+										IsOptional: true,
+										Expr: schema.ExprConstraints{
+											schema.TraversalExpr{
+												OfType: cty.Number,
+											},
+											schema.LiteralTypeExpr{
+												Type: cty.Number,
+											},
+										},
+									},
+									"fox": {
+										IsOptional: true,
+										Expr: schema.ExprConstraints{
+											schema.TraversalExpr{
+												OfType: cty.Number,
+											},
+											schema.LiteralTypeExpr{
+												Type: cty.Number,
+											},
+										},
+									},
+								},
+							},
+						},
+						Address: &schema.BlockAddrSchema{
+							DependentBodyAsData:  true,
+							InferDependentBody:   true,
+							DependentBodySelfRef: true,
+							Steps: []schema.AddrStep{
+								schema.LabelStep{Index: 0},
+								schema.LabelStep{Index: 1},
+							},
+						},
+					},
+				},
+			},
+			`resource "aws_instance" "foo" {
+  cpu_count = 4
+  fox =
+}`,
+			hcl.Pos{Line: 3, Column: 8, Byte: 55},
+			lang.CompleteCandidates([]lang.Candidate{}),
+		},
+		{
+			"target self addr enabled and extension enabled",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource": {
+						Labels: []*schema.LabelSchema{
+							{
+								Name:        "type",
+								IsDepKey:    true,
+								Completable: true,
+							},
+							{Name: "name"},
+						},
+						Body: &schema.BodySchema{
+							Extensions: &schema.BodyExtensions{
+								SelfRefs: true,
+							},
+						},
+						DependentBody: map[schema.SchemaKey]*schema.BodySchema{
+							schema.NewSchemaKey(schema.DependencyKeys{
+								Labels: []schema.LabelDependent{
+									{
+										Index: 0,
+										Value: "aws_instance",
+									},
+								},
+							}): {
+								Attributes: map[string]*schema.AttributeSchema{
+									"cpu_count": {
+										IsOptional: true,
+										Expr: schema.ExprConstraints{
+											schema.TraversalExpr{
+												OfType: cty.Number,
+											},
+											schema.LiteralTypeExpr{
+												Type: cty.Number,
+											},
+										},
+									},
+									"fox": {
+										IsOptional: true,
+										Expr: schema.ExprConstraints{
+											schema.TraversalExpr{
+												OfType: cty.Number,
+											},
+											schema.LiteralTypeExpr{
+												Type: cty.Number,
+											},
+										},
+									},
+								},
+							},
+						},
+						Address: &schema.BlockAddrSchema{
+							DependentBodyAsData:  true,
+							InferDependentBody:   true,
+							DependentBodySelfRef: true,
+							Steps: []schema.AddrStep{
+								schema.LabelStep{Index: 0},
+								schema.LabelStep{Index: 1},
+							},
+						},
+					},
+				},
+			},
+			`resource "aws_instance" "foo" {
+  cpu_count = 4
+  fox =
+}`,
+			hcl.Pos{Line: 3, Column: 8, Byte: 55},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "self",
+					Detail: "object",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 3, Column: 8, Byte: 55},
+							End:      hcl.Pos{Line: 3, Column: 8, Byte: 55},
+						},
+
+						NewText: "self",
+						Snippet: "self",
+					},
+					Kind: lang.TraversalCandidateKind,
+				},
+			}),
+		},
+		{
+			"target self addr disabled and extension enabled",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource": {
+						Labels: []*schema.LabelSchema{
+							{
+								Name:        "type",
+								IsDepKey:    true,
+								Completable: true,
+							},
+							{Name: "name"},
+						},
+						Body: &schema.BodySchema{
+							Extensions: &schema.BodyExtensions{
+								SelfRefs: true,
+							},
+						},
+						DependentBody: map[schema.SchemaKey]*schema.BodySchema{
+							schema.NewSchemaKey(schema.DependencyKeys{
+								Labels: []schema.LabelDependent{
+									{
+										Index: 0,
+										Value: "aws_instance",
+									},
+								},
+							}): {
+								Attributes: map[string]*schema.AttributeSchema{
+									"cpu_count": {
+										IsOptional: true,
+										Expr: schema.ExprConstraints{
+											schema.TraversalExpr{
+												OfType: cty.Number,
+											},
+											schema.LiteralTypeExpr{
+												Type: cty.Number,
+											},
+										},
+									},
+									"fox": {
+										IsOptional: true,
+										Expr: schema.ExprConstraints{
+											schema.TraversalExpr{
+												OfType: cty.Number,
+											},
+											schema.LiteralTypeExpr{
+												Type: cty.Number,
+											},
+										},
+									},
+								},
+							},
+						},
+						Address: &schema.BlockAddrSchema{
+							DependentBodyAsData: true,
+							InferDependentBody:  true,
+							Steps: []schema.AddrStep{
+								schema.LabelStep{Index: 0},
+								schema.LabelStep{Index: 1},
+							},
+						},
+					},
+				},
+			},
+			`resource "aws_instance" "foo" {
+  cpu_count = 4
+  fox =
+}`,
+			hcl.Pos{Line: 3, Column: 8, Byte: 55},
+			lang.CompleteCandidates([]lang.Candidate{}),
+		},
+		{
+			"no cyclical completion (attr = self.attr)",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource": {
+						Labels: []*schema.LabelSchema{
+							{
+								Name:        "type",
+								IsDepKey:    true,
+								Completable: true,
+							},
+							{Name: "name"},
+						},
+						Body: &schema.BodySchema{
+							Extensions: &schema.BodyExtensions{
+								SelfRefs: true,
+							},
+						},
+						DependentBody: map[schema.SchemaKey]*schema.BodySchema{
+							schema.NewSchemaKey(schema.DependencyKeys{
+								Labels: []schema.LabelDependent{
+									{
+										Index: 0,
+										Value: "aws_instance",
+									},
+								},
+							}): {
+								Attributes: map[string]*schema.AttributeSchema{
+									"cpu_count": {
+										IsOptional: true,
+										Expr: schema.ExprConstraints{
+											schema.TraversalExpr{
+												OfType: cty.Number,
+											},
+											schema.LiteralTypeExpr{
+												Type: cty.Number,
+											},
+										},
+									},
+								},
+							},
+						},
+						Address: &schema.BlockAddrSchema{
+							DependentBodyAsData:  true,
+							InferDependentBody:   true,
+							DependentBodySelfRef: true,
+							Steps: []schema.AddrStep{
+								schema.LabelStep{Index: 0},
+								schema.LabelStep{Index: 1},
+							},
+						},
+					},
+				},
+			},
+			`resource "aws_instance" "foo" {
+  cpu_count = 
+}`,
+			hcl.Pos{Line: 2, Column: 15, Byte: 46},
+			lang.CompleteCandidates([]lang.Candidate{}),
+		},
+		{
+			"completion with prefix",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource": {
+						Labels: []*schema.LabelSchema{
+							{
+								Name:        "type",
+								IsDepKey:    true,
+								Completable: true,
+							},
+							{Name: "name"},
+						},
+						Body: &schema.BodySchema{
+							Extensions: &schema.BodyExtensions{
+								SelfRefs: true,
+							},
+						},
+						DependentBody: map[schema.SchemaKey]*schema.BodySchema{
+							schema.NewSchemaKey(schema.DependencyKeys{
+								Labels: []schema.LabelDependent{
+									{
+										Index: 0,
+										Value: "aws_instance",
+									},
+								},
+							}): {
+								Attributes: map[string]*schema.AttributeSchema{
+									"cpu_count": {
+										IsOptional: true,
+										Expr: schema.ExprConstraints{
+											schema.TraversalExpr{
+												OfType: cty.Number,
+											},
+											schema.LiteralTypeExpr{
+												Type: cty.Number,
+											},
+										},
+									},
+									"fox": {
+										IsOptional: true,
+										Expr: schema.ExprConstraints{
+											schema.TraversalExpr{
+												OfType: cty.Number,
+											},
+											schema.LiteralTypeExpr{
+												Type: cty.Number,
+											},
+										},
+									},
+								},
+							},
+						},
+						Address: &schema.BlockAddrSchema{
+							DependentBodyAsData:  true,
+							InferDependentBody:   true,
+							DependentBodySelfRef: true,
+							Steps: []schema.AddrStep{
+								schema.LabelStep{Index: 0},
+								schema.LabelStep{Index: 1},
+							},
+						},
+					},
+				},
+			},
+			`resource "aws_instance" "foo" {
+  cpu_count = 4
+  fox = self.
+}`,
+			hcl.Pos{Line: 3, Column: 14, Byte: 61},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "self.cpu_count",
+					Detail: "number",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 3, Column: 9, Byte: 56},
+							End:      hcl.Pos{Line: 3, Column: 14, Byte: 61},
+						},
+						NewText: "self.cpu_count",
+						Snippet: "self.cpu_count",
+					},
+					Kind: lang.TraversalCandidateKind,
+				},
+			}),
+		},
+		{
+			"target self addr enabled and extension enabled within a block",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource": {
+						Labels: []*schema.LabelSchema{
+							{
+								Name:        "type",
+								IsDepKey:    true,
+								Completable: true,
+							},
+							{Name: "name"},
+						},
+						Body: &schema.BodySchema{
+							Blocks: map[string]*schema.BlockSchema{
+								"animal": {
+									Body: &schema.BodySchema{
+										Extensions: &schema.BodyExtensions{
+											SelfRefs: true,
+										},
+										Attributes: map[string]*schema.AttributeSchema{
+											"fox": {
+												IsOptional: true,
+												Expr: schema.ExprConstraints{
+													schema.TraversalExpr{
+														OfType: cty.Number,
+													},
+													schema.LiteralTypeExpr{
+														Type: cty.Number,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						DependentBody: map[schema.SchemaKey]*schema.BodySchema{
+							schema.NewSchemaKey(schema.DependencyKeys{
+								Labels: []schema.LabelDependent{
+									{
+										Index: 0,
+										Value: "aws_instance",
+									},
+								},
+							}): {
+								Attributes: map[string]*schema.AttributeSchema{
+									"cpu_count": {
+										IsOptional: true,
+										Expr: schema.ExprConstraints{
+											schema.TraversalExpr{
+												OfType: cty.Number,
+											},
+											schema.LiteralTypeExpr{
+												Type: cty.Number,
+											},
+										},
+									},
+								},
+							},
+						},
+						Address: &schema.BlockAddrSchema{
+							DependentBodyAsData:  true,
+							InferDependentBody:   true,
+							DependentBodySelfRef: true,
+							Steps: []schema.AddrStep{
+								schema.LabelStep{Index: 0},
+								schema.LabelStep{Index: 1},
+							},
+						},
+					},
+				},
+			},
+			`resource "aws_instance" "foo" {
+  cpu_count = 4
+  animal {
+    fox =
+  }
+}`,
+			hcl.Pos{Line: 4, Column: 10, Byte: 68},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "self",
+					Detail: "object",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 4, Column: 10, Byte: 68},
+							End:      hcl.Pos{Line: 4, Column: 10, Byte: 68},
+						},
+
+						NewText: "self",
+						Snippet: "self",
+					},
+					Kind: lang.TraversalCandidateKind,
+				},
+			}),
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+			f, _ := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+
+			d := testPathDecoder(t, &PathContext{
+				Schema: tc.bodySchema,
+				Files: map[string]*hcl.File{
+					"test.tf": f,
+				},
+			})
+			targets, err := d.CollectReferenceTargets()
+			if err != nil {
+				t.Fatal(err)
+			}
+			d = testPathDecoder(t, &PathContext{
+				Schema: tc.bodySchema,
+				Files: map[string]*hcl.File{
+					"test.tf": f,
+				},
+				ReferenceTargets: targets,
+			})
+
+			candidates, err := d.CandidatesAtPos(ctx, "test.tf", tc.pos)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedCandidates, candidates); diff != "" {
+				t.Fatalf("unexpected candidates: %s", diff)
+			}
+		})
+	}
+}
+
+func TestCompletionAtPos_BodySchema_Extensions_DynamicBlock(t *testing.T) {
 	ctx := context.Background()
 
 	testCases := []struct {

--- a/decoder/body_extensions_test.go
+++ b/decoder/body_extensions_test.go
@@ -760,12 +760,10 @@ func TestCompletionAtPos_BodySchema_Extensions_ForEach(t *testing.T) {
 				{
 					LocalAddr: lang.Address{
 						lang.RootStep{Name: "each"},
+						lang.AttrStep{Name: "key"},
 					},
-					Type: cty.Object(map[string]cty.Type{
-						"key":   cty.String,
-						"value": cty.DynamicPseudoType,
-					}),
-					Description: lang.Markdown("Each element the given map or set"),
+					Type:        cty.String,
+					Description: lang.Markdown("The map key (or set member) corresponding to this instance"),
 					RangePtr: &hcl.Range{
 						Filename: "test.tf",
 						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 32},
@@ -776,43 +774,23 @@ func TestCompletionAtPos_BodySchema_Extensions_ForEach(t *testing.T) {
 						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 32},
 						End:      hcl.Pos{Line: 2, Column: 9, Byte: 40},
 					},
-					NestedTargets: reference.Targets{
-						{
-							LocalAddr: lang.Address{
-								lang.RootStep{Name: "each"},
-								lang.AttrStep{Name: "key"},
-							},
-							Type:        cty.String,
-							Description: lang.Markdown("The map key (or set member) corresponding to this instance"),
-							RangePtr: &hcl.Range{
-								Filename: "test.tf",
-								Start:    hcl.Pos{Line: 2, Column: 1, Byte: 32},
-								End:      hcl.Pos{Line: 5, Column: 2, Byte: 93},
-							},
-							DefRangePtr: &hcl.Range{
-								Filename: "test.tf",
-								Start:    hcl.Pos{Line: 2, Column: 1, Byte: 32},
-								End:      hcl.Pos{Line: 2, Column: 9, Byte: 40},
-							},
-						},
-						{
-							LocalAddr: lang.Address{
-								lang.RootStep{Name: "each"},
-								lang.AttrStep{Name: "value"},
-							},
-							Type:        cty.DynamicPseudoType,
-							Description: lang.Markdown("The map value corresponding to this instance. (If a set was provided, this is the same as `each.key`.)"),
-							RangePtr: &hcl.Range{
-								Filename: "test.tf",
-								Start:    hcl.Pos{Line: 2, Column: 1, Byte: 32},
-								End:      hcl.Pos{Line: 5, Column: 2, Byte: 93},
-							},
-							DefRangePtr: &hcl.Range{
-								Filename: "test.tf",
-								Start:    hcl.Pos{Line: 2, Column: 1, Byte: 32},
-								End:      hcl.Pos{Line: 2, Column: 9, Byte: 40},
-							},
-						},
+				},
+				{
+					LocalAddr: lang.Address{
+						lang.RootStep{Name: "each"},
+						lang.AttrStep{Name: "value"},
+					},
+					Type:        cty.DynamicPseudoType,
+					Description: lang.Markdown("The map value corresponding to this instance. (If a set was provided, this is the same as `each.key`.)"),
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 32},
+						End:      hcl.Pos{Line: 5, Column: 2, Byte: 93},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 32},
+						End:      hcl.Pos{Line: 2, Column: 9, Byte: 40},
 					},
 				},
 			},
@@ -825,24 +803,6 @@ thing =
 }`,
 			hcl.Pos{Line: 6, Column: 9, Byte: 102},
 			lang.CompleteCandidates([]lang.Candidate{
-				{
-					Label:  "each",
-					Detail: "object",
-					Kind:   lang.TraversalCandidateKind,
-					Description: lang.MarkupContent{
-						Value: "Each element the given map or set",
-						Kind:  lang.MarkdownKind,
-					},
-					TextEdit: lang.TextEdit{
-						Range: hcl.Range{
-							Filename: "test.tf",
-							Start:    hcl.Pos{Line: 6, Column: 9, Byte: 102},
-							End:      hcl.Pos{Line: 6, Column: 9, Byte: 102},
-						},
-						NewText: "each",
-						Snippet: "each",
-					},
-				},
 				{
 					Label:  "each.key",
 					Detail: "string",
@@ -1036,12 +996,10 @@ for_each = {
 				{
 					LocalAddr: lang.Address{
 						lang.RootStep{Name: "each"},
+						lang.AttrStep{Name: "key"},
 					},
-					Type: cty.Object(map[string]cty.Type{
-						"key":   cty.String,
-						"value": cty.DynamicPseudoType,
-					}),
-					Description: lang.Markdown("Each element the given map or set"),
+					Type:        cty.String,
+					Description: lang.Markdown("The map key (or set member) corresponding to this instance"),
 					RangePtr: &hcl.Range{
 						Filename: "test.tf",
 						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 32},
@@ -1052,43 +1010,23 @@ for_each = {
 						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 32},
 						End:      hcl.Pos{Line: 2, Column: 9, Byte: 40},
 					},
-					NestedTargets: reference.Targets{
-						{
-							LocalAddr: lang.Address{
-								lang.RootStep{Name: "each"},
-								lang.AttrStep{Name: "key"},
-							},
-							Type:        cty.String,
-							Description: lang.Markdown("The map key (or set member) corresponding to this instance"),
-							RangePtr: &hcl.Range{
-								Filename: "test.tf",
-								Start:    hcl.Pos{Line: 2, Column: 1, Byte: 32},
-								End:      hcl.Pos{Line: 5, Column: 2, Byte: 93},
-							},
-							DefRangePtr: &hcl.Range{
-								Filename: "test.tf",
-								Start:    hcl.Pos{Line: 2, Column: 1, Byte: 32},
-								End:      hcl.Pos{Line: 2, Column: 9, Byte: 40},
-							},
-						},
-						{
-							LocalAddr: lang.Address{
-								lang.RootStep{Name: "each"},
-								lang.AttrStep{Name: "value"},
-							},
-							Type:        cty.DynamicPseudoType,
-							Description: lang.Markdown("The map value corresponding to this instance. (If a set was provided, this is the same as `each.key`.)"),
-							RangePtr: &hcl.Range{
-								Filename: "test.tf",
-								Start:    hcl.Pos{Line: 2, Column: 1, Byte: 32},
-								End:      hcl.Pos{Line: 5, Column: 2, Byte: 93},
-							},
-							DefRangePtr: &hcl.Range{
-								Filename: "test.tf",
-								Start:    hcl.Pos{Line: 2, Column: 1, Byte: 32},
-								End:      hcl.Pos{Line: 2, Column: 9, Byte: 40},
-							},
-						},
+				},
+				{
+					LocalAddr: lang.Address{
+						lang.RootStep{Name: "each"},
+						lang.AttrStep{Name: "value"},
+					},
+					Type:        cty.DynamicPseudoType,
+					Description: lang.Markdown("The map value corresponding to this instance. (If a set was provided, this is the same as `each.key`.)"),
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 32},
+						End:      hcl.Pos{Line: 5, Column: 2, Byte: 93},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 32},
+						End:      hcl.Pos{Line: 2, Column: 9, Byte: 40},
 					},
 				},
 			},
@@ -1103,24 +1041,6 @@ foo {
 }`,
 			hcl.Pos{Line: 7, Column: 11, Byte: 109},
 			lang.CompleteCandidates([]lang.Candidate{
-				{
-					Label:  "each",
-					Detail: "object",
-					Kind:   lang.TraversalCandidateKind,
-					Description: lang.MarkupContent{
-						Value: "Each element the given map or set",
-						Kind:  lang.MarkdownKind,
-					},
-					TextEdit: lang.TextEdit{
-						Range: hcl.Range{
-							Filename: "test.tf",
-							Start:    hcl.Pos{Line: 7, Column: 10, Byte: 109},
-							End:      hcl.Pos{Line: 7, Column: 10, Byte: 109},
-						},
-						NewText: "each",
-						Snippet: "each",
-					},
-				},
 				{
 					Label:  "each.key",
 					Detail: "string",

--- a/decoder/body_extensions_test.go
+++ b/decoder/body_extensions_test.go
@@ -628,6 +628,60 @@ variable "test" {
 				},
 			}),
 		},
+		{
+			"cyclical count = count.index completion",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource": {
+						Labels: []*schema.LabelSchema{
+							{
+								Name: "type",
+							},
+							{
+								Name: "name",
+							},
+						},
+						Body: &schema.BodySchema{
+							Extensions: &schema.BodyExtensions{
+								Count: true,
+							},
+						},
+					},
+				},
+			},
+			reference.Targets{
+				{
+					LocalAddr: lang.Address{
+						lang.RootStep{Name: "count"},
+						lang.AttrStep{Name: "index"},
+					},
+					Type: cty.Number,
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   2,
+							Column: 3,
+							Byte:   34,
+						},
+						End: hcl.Pos{
+							Line:   2,
+							Column: 10,
+							Byte:   41,
+						},
+					},
+				},
+			},
+			`resource "aws_instance" "foo" {
+  count = 
+}
+`,
+			hcl.Pos{
+				Line:   2,
+				Column: 11,
+				Byte:   42,
+			},
+			lang.CompleteCandidates([]lang.Candidate{}),
+		},
 	}
 
 	for i, tc := range testCases {

--- a/decoder/candidates.go
+++ b/decoder/candidates.go
@@ -70,6 +70,9 @@ func (d *PathDecoder) candidatesAtPos(ctx context.Context, body *hclsyntax.Body,
 
 	for _, attr := range body.Attributes {
 		if d.isPosInsideAttrExpr(attr, pos) {
+			if bodySchema.Extensions != nil && bodySchema.Extensions.SelfRefs {
+				ctx = schema.WithActiveSelfRefs(ctx)
+			}
 			if bodySchema.Extensions != nil && bodySchema.Extensions.Count && attr.Name == "count" {
 				return d.attrValueCandidatesAtPos(ctx, attr, countAttributeSchema(), outerBodyRng, pos)
 			}

--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -104,6 +104,7 @@ type blockContent struct {
 type bodyContent struct {
 	Attributes hcl.Attributes
 	Blocks     []*blockContent
+	RangePtr   *hcl.Range
 }
 
 // decodeBody produces content of either HCL or JSON body
@@ -130,6 +131,8 @@ func decodeBody(body hcl.Body, bodySchema *schema.BodySchema) bodyContent {
 				Range: block.Range(),
 			})
 		}
+
+		content.RangePtr = hclBody.Range().Ptr()
 
 		return content
 	}

--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -263,49 +263,29 @@ func countIndexReferenceTarget(attr *hcl.Attribute, bodyRange hcl.Range) referen
 	}
 }
 
-func foreachEachCandidate(editRng hcl.Range) []lang.Candidate {
-	return []lang.Candidate{
+func forEachReferenceTargets(attr *hcl.Attribute, bodyRange hcl.Range) reference.Targets {
+	return reference.Targets{
 		{
-			Label:  "each.key",
-			Detail: "string",
-			Description: lang.MarkupContent{
-				Value: "The map key (or set member) corresponding to this instance",
-				Kind:  lang.MarkdownKind,
+			LocalAddr: lang.Address{
+				lang.RootStep{Name: "each"},
+				lang.AttrStep{Name: "key"},
 			},
-			Kind: lang.TraversalCandidateKind,
-			TextEdit: lang.TextEdit{
-				NewText: "each.key",
-				Snippet: "each.key",
-				Range:   editRng,
-			},
+			TargetableFromRangePtr: bodyRange.Ptr(),
+			Type:                   cty.String,
+			Description:            lang.Markdown("The map key (or set member) corresponding to this instance"),
+			RangePtr:               attr.Range.Ptr(),
+			DefRangePtr:            attr.NameRange.Ptr(),
 		},
 		{
-			Label:  "each.value",
-			Detail: "any type",
-			Description: lang.MarkupContent{
-				Value: "The map value corresponding to this instance. (If a set was provided, this is the same as `each.key`.)",
-				Kind:  lang.MarkdownKind,
+			LocalAddr: lang.Address{
+				lang.RootStep{Name: "each"},
+				lang.AttrStep{Name: "value"},
 			},
-			Kind: lang.TraversalCandidateKind,
-			TextEdit: lang.TextEdit{
-				NewText: "each.value",
-				Snippet: "each.value",
-				Range:   editRng,
-			},
+			TargetableFromRangePtr: bodyRange.Ptr(),
+			Type:                   cty.DynamicPseudoType,
+			Description:            lang.Markdown("The map value corresponding to this instance. (If a set was provided, this is the same as `each.key`.)"),
+			RangePtr:               attr.Range.Ptr(),
+			DefRangePtr:            attr.NameRange.Ptr(),
 		},
-	}
-}
-
-func eachKeyHoverData(rng hcl.Range) *lang.HoverData {
-	return &lang.HoverData{
-		Content: lang.Markdown("`each.key` _string_\n\nThe map key (or set member) corresponding to this instance"),
-		Range:   rng,
-	}
-}
-
-func eachValueHoverData(rng hcl.Range) *lang.HoverData {
-	return &lang.HoverData{
-		Content: lang.Markdown("`each.value` _any type_\n\nThe map value corresponding to this instance. (If a set was provided, this is the same as `each.key`.)"),
-		Range:   rng,
 	}
 }

--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/reference"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -180,7 +181,7 @@ func countAttributeSchema() *schema.AttributeSchema {
 			schema.TraversalExpr{OfType: cty.Number},
 			schema.LiteralTypeExpr{Type: cty.Number},
 		},
-		Description: lang.Markdown("The distinct index number (starting with 0) corresponding to the instance"),
+		Description: lang.Markdown("Total number of instances of this block"),
 	}
 }
 
@@ -248,24 +249,17 @@ func dynamicBlockSchema() *schema.BlockSchema {
 	}
 }
 
-func countIndexHoverData(rng hcl.Range) *lang.HoverData {
-	return &lang.HoverData{
-		Content: lang.Markdown("`count.index` _number_\n\nThe distinct index number (starting with 0) corresponding to the instance"),
-		Range:   rng,
-	}
-}
-
-func countIndexCandidate(editRng hcl.Range) lang.Candidate {
-	return lang.Candidate{
-		Label:       "count.index",
-		Detail:      "number",
-		Description: lang.PlainText("The distinct index number (starting with 0) corresponding to the instance"),
-		Kind:        lang.TraversalCandidateKind,
-		TextEdit: lang.TextEdit{
-			NewText: "count.index",
-			Snippet: "count.index",
-			Range:   editRng,
+func countIndexReferenceTarget(attr *hcl.Attribute, bodyRange hcl.Range) reference.Target {
+	return reference.Target{
+		LocalAddr: lang.Address{
+			lang.RootStep{Name: "count"},
+			lang.AttrStep{Name: "index"},
 		},
+		TargetableFromRangePtr: bodyRange.Ptr(),
+		Type:                   cty.Number,
+		Description:            lang.Markdown("The distinct index number (starting with 0) corresponding to the instance"),
+		RangePtr:               attr.Range.Ptr(),
+		DefRangePtr:            attr.NameRange.Ptr(),
 	}
 }
 

--- a/decoder/expression_candidates.go
+++ b/decoder/expression_candidates.go
@@ -328,9 +328,6 @@ func (d *PathDecoder) constraintToCandidates(ctx context.Context, constraint sch
 			},
 		})
 	case schema.TraversalExpr:
-		if schema.ActiveCountFromContext(ctx) && attr.Name != "count" {
-			candidates = append(candidates, countIndexCandidate(editRng))
-		}
 		if schema.ActiveForEachFromContext(ctx) && attr.Name != "for_each" {
 			candidates = append(candidates, foreachEachCandidate(editRng)...)
 		}

--- a/decoder/expression_candidates.go
+++ b/decoder/expression_candidates.go
@@ -471,8 +471,8 @@ func (d *PathDecoder) candidatesForTraversalConstraint(ctx context.Context, tc s
 
 	prefix, _ := d.bytesFromRange(prefixRng)
 
-	d.pathCtx.ReferenceTargets.MatchWalk(tc, string(prefix), outermostBodyRng, editRng, func(target reference.Target) error {
-		address := target.Address().String()
+	d.pathCtx.ReferenceTargets.MatchWalk(ctx, tc, string(prefix), outermostBodyRng, editRng, func(target reference.Target) error {
+		address := target.Address(ctx).String()
 
 		candidates = append(candidates, lang.Candidate{
 			Label:       address,

--- a/decoder/expression_candidates.go
+++ b/decoder/expression_candidates.go
@@ -328,10 +328,6 @@ func (d *PathDecoder) constraintToCandidates(ctx context.Context, constraint sch
 			},
 		})
 	case schema.TraversalExpr:
-		if schema.ActiveForEachFromContext(ctx) && attr.Name != "for_each" {
-			candidates = append(candidates, foreachEachCandidate(editRng)...)
-		}
-
 		candidates = append(candidates, d.candidatesForTraversalConstraint(c, outerBodyRng, prefixRng, editRng)...)
 	case schema.TupleConsExpr:
 		candidates = append(candidates, lang.Candidate{

--- a/decoder/expression_candidates.go
+++ b/decoder/expression_candidates.go
@@ -474,7 +474,7 @@ func (d *PathDecoder) candidatesForTraversalConstraint(tc schema.TraversalExpr, 
 	d.pathCtx.ReferenceTargets.MatchWalk(tc, string(prefix), editRng, func(target reference.Target) error {
 		// avoid suggesting references to block's own fields from within (for now)
 		// TODO: Reflect LocalAddr here
-		if referenceTargetIsInRange(target, outerBodyRng) {
+		if len(target.LocalAddr) == 0 && referenceTargetIsInRange(target, outerBodyRng) {
 			return nil
 		}
 

--- a/decoder/hover.go
+++ b/decoder/hover.go
@@ -264,20 +264,6 @@ func (d *PathDecoder) hoverDataForExpr(ctx context.Context, expr hcl.Expression,
 			}, nil
 		}
 
-		address, err := lang.TraversalToAddress(e.AsTraversal())
-		if err != nil {
-			return nil, err
-		}
-
-		eachKeyAddr := lang.Address{lang.RootStep{Name: "each"}, lang.AttrStep{Name: "key"}}
-		eachValueAddr := lang.Address{lang.RootStep{Name: "each"}, lang.AttrStep{Name: "value"}}
-
-		if address.Equals(eachKeyAddr) && schema.ActiveForEachFromContext(ctx) {
-			return eachKeyHoverData(expr.Range()), nil
-		} else if address.Equals(eachValueAddr) && schema.ActiveForEachFromContext(ctx) {
-			return eachValueHoverData(expr.Range()), nil
-		}
-
 		tes, ok := constraints.TraversalExprs()
 		if ok {
 			content, err := d.hoverContentForTraversalExpr(e.AsTraversal(), tes, pos)

--- a/decoder/hover.go
+++ b/decoder/hover.go
@@ -269,13 +269,10 @@ func (d *PathDecoder) hoverDataForExpr(ctx context.Context, expr hcl.Expression,
 			return nil, err
 		}
 
-		countIndexAddr := lang.Address{lang.RootStep{Name: "count"}, lang.AttrStep{Name: "index"}}
 		eachKeyAddr := lang.Address{lang.RootStep{Name: "each"}, lang.AttrStep{Name: "key"}}
 		eachValueAddr := lang.Address{lang.RootStep{Name: "each"}, lang.AttrStep{Name: "value"}}
 
-		if address.Equals(countIndexAddr) && schema.ActiveCountFromContext(ctx) {
-			return countIndexHoverData(expr.Range()), nil
-		} else if address.Equals(eachKeyAddr) && schema.ActiveForEachFromContext(ctx) {
+		if address.Equals(eachKeyAddr) && schema.ActiveForEachFromContext(ctx) {
 			return eachKeyHoverData(expr.Range()), nil
 		} else if address.Equals(eachValueAddr) && schema.ActiveForEachFromContext(ctx) {
 			return eachValueHoverData(expr.Range()), nil

--- a/decoder/hover_test.go
+++ b/decoder/hover_test.go
@@ -970,7 +970,7 @@ func TestDecoder_HoverAtPos_extension(t *testing.T) {
 `,
 			hcl.Pos{Line: 2, Column: 5, Byte: 24},
 			&lang.HoverData{
-				Content: lang.Markdown("**count** _optional, number_\n\nThe distinct index number (starting with 0) corresponding to the instance"),
+				Content: lang.Markdown("**count** _optional, number_\n\nTotal number of instances of this block"),
 				Range: hcl.Range{
 					Filename: "test.tf",
 					Start:    hcl.Pos{Line: 2, Column: 3, Byte: 24},
@@ -1034,7 +1034,7 @@ func TestDecoder_HoverAtPos_extension(t *testing.T) {
 `,
 			hcl.Pos{Line: 3, Column: 15, Byte: 48},
 			&lang.HoverData{
-				Content: lang.Markdown("`count.index` _number_\n\nThe distinct index number (starting with 0) corresponding to the instance"),
+				Content: lang.Markdown("`count.index`\n_number_\n\nThe distinct index number (starting with 0) corresponding to the instance"),
 				Range: hcl.Range{
 					Filename: "test.tf",
 					Start:    hcl.Pos{Line: 3, Column: 11, Byte: 44},

--- a/decoder/hover_test.go
+++ b/decoder/hover_test.go
@@ -1252,7 +1252,7 @@ func TestDecoder_HoverAtPos_foreach_extension(t *testing.T) {
 `,
 			hcl.Pos{Line: 2, Column: 8, Byte: 30},
 			&lang.HoverData{
-				Content: lang.Markdown("`each.key` _string_\n\nThe map key (or set member) corresponding to this instance"),
+				Content: lang.Markdown("`each.key`\n_string_\n\nThe map key (or set member) corresponding to this instance"),
 				Range: hcl.Range{
 					Filename: "test.tf",
 					Start:    hcl.Pos{Line: 2, Column: 8, Byte: 29},
@@ -1356,7 +1356,7 @@ func TestDecoder_HoverAtPos_foreach_extension(t *testing.T) {
 `,
 			hcl.Pos{Line: 2, Column: 8, Byte: 30},
 			&lang.HoverData{
-				Content: lang.Markdown("`each.value` _any type_\n\nThe map value corresponding to this instance. (If a set was provided, this is the same as `each.key`.)"),
+				Content: lang.Markdown("`each.value`\n_dynamic_\n\nThe map value corresponding to this instance. (If a set was provided, this is the same as `each.key`.)"),
 				Range: hcl.Range{
 					Filename: "test.tf",
 					Start:    hcl.Pos{Line: 2, Column: 8, Byte: 29},

--- a/decoder/reference_origins.go
+++ b/decoder/reference_origins.go
@@ -58,6 +58,7 @@ func (d *Decoder) ReferenceOriginsTargetingPos(path lang.Path, file string, pos 
 	return origins
 }
 
+// TODO: Avoid collecting self.* origins unless BodySchema.Extension.SelfRef == true
 func (d *PathDecoder) CollectReferenceOrigins() (reference.Origins, error) {
 	refOrigins := make(reference.Origins, 0)
 	impliedOrigins := make([]schema.ImpliedOrigin, 0)

--- a/decoder/reference_origins.go
+++ b/decoder/reference_origins.go
@@ -58,7 +58,6 @@ func (d *Decoder) ReferenceOriginsTargetingPos(path lang.Path, file string, pos 
 	return origins
 }
 
-// TODO: Avoid collecting self.* origins unless BodySchema.Extension.SelfRef == true
 func (d *PathDecoder) CollectReferenceOrigins() (reference.Origins, error) {
 	refOrigins := make(reference.Origins, 0)
 	impliedOrigins := make([]schema.ImpliedOrigin, 0)

--- a/decoder/reference_targets.go
+++ b/decoder/reference_targets.go
@@ -112,6 +112,10 @@ func (d *PathDecoder) decodeReferenceTargetsForBody(body hcl.Body, parentBlock *
 				refs = append(refs, countIndexReferenceTarget(attr, *content.RangePtr))
 				continue
 			}
+			if bodySchema.Extensions.ForEach && attr.Name == "for_each" && content.RangePtr != nil {
+				refs = append(refs, forEachReferenceTargets(attr, *content.RangePtr)...)
+				continue
+			}
 		}
 		attrSchema, ok := bodySchema.Attributes[attr.Name]
 		if !ok {

--- a/decoder/reference_targets.go
+++ b/decoder/reference_targets.go
@@ -855,10 +855,16 @@ func (d *PathDecoder) collectInferredReferenceTargetsForBody(addr lang.Address, 
 
 		blockRef := reference.Target{
 			Addr:        blockAddr,
+			LocalAddr:   make(lang.Address, len(selfRefAddr)),
 			ScopeId:     bAddrSchema.ScopeId,
 			Type:        cty.Map(cty.Object(bodySchemaAsAttrTypes(bCollection.Schema.Body))),
 			Description: bCollection.Schema.Description,
 			RangePtr:    body.MissingItemRange().Ptr(),
+		}
+		if bAddrSchema.DependentBodySelfRef && selfRefBodyRangePtr != nil {
+			copy(blockRef.LocalAddr, selfRefAddr)
+			blockRef.LocalAddr = append(blockRef.LocalAddr, lang.AttrStep{Name: bType})
+			blockRef.TargetableFromRangePtr = selfRefBodyRangePtr.Ptr()
 		}
 
 		for i, b := range bCollection.Blocks {
@@ -872,13 +878,21 @@ func (d *PathDecoder) collectInferredReferenceTargetsForBody(addr lang.Address, 
 
 			elemRef := reference.Target{
 				Addr:        elemAddr,
-				LocalAddr:   make(lang.Address, len(selfRefAddr)),
+				LocalAddr:   make(lang.Address, len(blockRef.LocalAddr)),
 				ScopeId:     bAddrSchema.ScopeId,
 				Type:        refType,
 				Description: bCollection.Schema.Description,
 				RangePtr:    b.Range.Ptr(),
 				DefRangePtr: b.DefRange.Ptr(),
 			}
+			if bAddrSchema.DependentBodySelfRef && selfRefBodyRangePtr != nil {
+				copy(elemRef.LocalAddr, blockRef.LocalAddr)
+				elemRef.LocalAddr = append(elemRef.LocalAddr, lang.IndexStep{
+					Key: cty.StringVal(b.Labels[0]),
+				})
+				elemRef.TargetableFromRangePtr = selfRefBodyRangePtr.Ptr()
+			}
+
 			elemRef.NestedTargets = d.collectInferredReferenceTargetsForBody(
 				elemAddr, bAddrSchema, b.Body, bCollection.Schema.Body, selfRefBodyRangePtr, elemRef.LocalAddr)
 			sort.Sort(elemRef.NestedTargets)

--- a/decoder/reference_targets.go
+++ b/decoder/reference_targets.go
@@ -817,10 +817,16 @@ func (d *PathDecoder) collectInferredReferenceTargetsForBody(addr lang.Address, 
 
 		blockRef := reference.Target{
 			Addr:        blockAddr,
+			LocalAddr:   make(lang.Address, len(selfRefAddr)),
 			ScopeId:     bAddrSchema.ScopeId,
 			Type:        cty.Set(cty.Object(bodySchemaAsAttrTypes(bCollection.Schema.Body))),
 			Description: bCollection.Schema.Description,
 			RangePtr:    body.MissingItemRange().Ptr(),
+		}
+		if bAddrSchema.DependentBodySelfRef && selfRefBodyRangePtr != nil {
+			copy(blockRef.LocalAddr, selfRefAddr)
+			blockRef.LocalAddr = append(blockRef.LocalAddr, lang.AttrStep{Name: bType})
+			blockRef.TargetableFromRangePtr = selfRefBodyRangePtr.Ptr()
 		}
 
 		for i, b := range bCollection.Blocks {

--- a/decoder/reference_targets.go
+++ b/decoder/reference_targets.go
@@ -107,6 +107,12 @@ func (d *PathDecoder) decodeReferenceTargetsForBody(body hcl.Body, parentBlock *
 	content := decodeBody(body, bodySchema)
 
 	for _, attr := range content.Attributes {
+		if bodySchema.Extensions != nil {
+			if bodySchema.Extensions.Count && attr.Name == "count" && content.RangePtr != nil {
+				refs = append(refs, countIndexReferenceTarget(attr, *content.RangePtr))
+				continue
+			}
+		}
 		attrSchema, ok := bodySchema.Attributes[attr.Name]
 		if !ok {
 			if bodySchema.AnyAttribute == nil {

--- a/decoder/reference_targets_collect_extensions_hcl_test.go
+++ b/decoder/reference_targets_collect_extensions_hcl_test.go
@@ -431,6 +431,264 @@ func TestCollectReferenceTargets_extension_hcl(t *testing.T) {
 				},
 			},
 		},
+		{
+			"self references collection - list block",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource": {
+						Address: &schema.BlockAddrSchema{
+							Steps: schema.Address{
+								schema.LabelStep{Index: 0},
+								schema.LabelStep{Index: 1},
+							},
+							DependentBodyAsData:  true,
+							InferDependentBody:   true,
+							DependentBodySelfRef: true,
+						},
+						Labels: []*schema.LabelSchema{
+							{
+								Name:     "type",
+								IsDepKey: true,
+							},
+							{
+								Name: "name",
+							},
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"static": {IsOptional: true, Expr: schema.LiteralTypeOnly(cty.String)},
+							},
+						},
+						DependentBody: map[schema.SchemaKey]*schema.BodySchema{
+							schema.NewSchemaKey(schema.DependencyKeys{
+								Labels: []schema.LabelDependent{
+									{
+										Index: 0,
+										Value: "aws_instance",
+									},
+								},
+							}): {
+								Blocks: map[string]*schema.BlockSchema{
+									"foo": {
+										Type: schema.BlockTypeList,
+										Body: &schema.BodySchema{
+											Attributes: map[string]*schema.AttributeSchema{
+												"bar": {IsOptional: true, Expr: schema.LiteralTypeOnly(cty.Number)},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			`resource "aws_instance" "blah" {
+  static = "test"
+  foo {
+    bar = 42
+  }
+}
+`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "aws_instance"},
+						lang.AttrStep{Name: "blah"},
+					},
+					LocalAddr: lang.Address{
+						lang.RootStep{Name: "self"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+							Byte:   0,
+						},
+						End: hcl.Pos{
+							Line:   6,
+							Column: 2,
+							Byte:   77,
+						},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+							Byte:   0,
+						},
+						End: hcl.Pos{
+							Line:   1,
+							Column: 31,
+							Byte:   30,
+						},
+					},
+					Type: cty.Object(map[string]cty.Type{
+						"foo": cty.List(cty.Object(map[string]cty.Type{
+							"bar": cty.Number,
+						})),
+					}),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "aws_instance"},
+								lang.AttrStep{Name: "blah"},
+								lang.AttrStep{Name: "foo"},
+							},
+							LocalAddr: lang.Address{
+								lang.RootStep{Name: "self"},
+								lang.AttrStep{Name: "foo"},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start: hcl.Pos{
+									Line:   3,
+									Column: 3,
+									Byte:   53,
+								},
+								End: hcl.Pos{
+									Line:   5,
+									Column: 4,
+									Byte:   75,
+								},
+							},
+							Type: cty.List(cty.Object(map[string]cty.Type{
+								"bar": cty.Number,
+							})),
+							TargetableFromRangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start: hcl.Pos{
+									Line:   1,
+									Column: 32,
+									Byte:   31,
+								},
+								End: hcl.Pos{
+									Line:   6,
+									Column: 2,
+									Byte:   77,
+								},
+							},
+							NestedTargets: reference.Targets{
+								{
+									Addr: lang.Address{
+										lang.RootStep{Name: "aws_instance"},
+										lang.AttrStep{Name: "blah"},
+										lang.AttrStep{Name: "foo"},
+										lang.IndexStep{Key: cty.NumberIntVal(0)},
+									},
+									LocalAddr: lang.Address{
+										lang.RootStep{Name: "self"},
+										lang.AttrStep{Name: "foo"},
+										lang.IndexStep{Key: cty.NumberIntVal(0)},
+									},
+									RangePtr: &hcl.Range{
+										Filename: "test.tf",
+										Start: hcl.Pos{
+											Line:   3,
+											Column: 3,
+											Byte:   53,
+										},
+										End: hcl.Pos{
+											Line:   5,
+											Column: 4,
+											Byte:   75,
+										},
+									},
+									DefRangePtr: &hcl.Range{
+										Filename: "test.tf",
+										Start: hcl.Pos{
+											Line:   3,
+											Column: 3,
+											Byte:   53,
+										},
+										End: hcl.Pos{
+											Line:   3,
+											Column: 6,
+											Byte:   56,
+										},
+									},
+									Type: cty.Object(map[string]cty.Type{
+										"bar": cty.Number,
+									}),
+									TargetableFromRangePtr: &hcl.Range{
+										Filename: "test.tf",
+										Start: hcl.Pos{
+											Line:   1,
+											Column: 32,
+											Byte:   31,
+										},
+										End: hcl.Pos{
+											Line:   6,
+											Column: 2,
+											Byte:   77,
+										},
+									},
+									NestedTargets: reference.Targets{
+										{
+											Addr: lang.Address{
+												lang.RootStep{Name: "aws_instance"},
+												lang.AttrStep{Name: "blah"},
+												lang.AttrStep{Name: "foo"},
+												lang.IndexStep{Key: cty.NumberIntVal(0)},
+												lang.AttrStep{Name: "bar"},
+											},
+											LocalAddr: lang.Address{
+												lang.RootStep{Name: "self"},
+												lang.AttrStep{Name: "foo"},
+												lang.IndexStep{Key: cty.NumberIntVal(0)},
+												lang.AttrStep{Name: "bar"},
+											},
+											RangePtr: &hcl.Range{
+												Filename: "test.tf",
+												Start: hcl.Pos{
+													Line:   4,
+													Column: 5,
+													Byte:   63,
+												},
+												End: hcl.Pos{
+													Line:   4,
+													Column: 13,
+													Byte:   71,
+												},
+											},
+											DefRangePtr: &hcl.Range{
+												Filename: "test.tf",
+												Start: hcl.Pos{
+													Line:   4,
+													Column: 5,
+													Byte:   63,
+												},
+												End: hcl.Pos{
+													Line:   4,
+													Column: 8,
+													Byte:   66,
+												},
+											},
+											Type: cty.Number,
+											TargetableFromRangePtr: &hcl.Range{
+												Filename: "test.tf",
+												Start: hcl.Pos{
+													Line:   1,
+													Column: 32,
+													Byte:   31,
+												},
+												End: hcl.Pos{
+													Line:   6,
+													Column: 2,
+													Byte:   77,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for i, tc := range testCases {

--- a/decoder/reference_targets_collect_extensions_hcl_test.go
+++ b/decoder/reference_targets_collect_extensions_hcl_test.go
@@ -22,7 +22,7 @@ func TestCollectReferenceTargets_extension_hcl(t *testing.T) {
 		expectedRefs reference.Targets
 	}{
 		{
-			"self references",
+			"self references collection - attributes",
 			&schema.BodySchema{
 				Blocks: map[string]*schema.BlockSchema{
 					"resource": {
@@ -78,6 +78,9 @@ func TestCollectReferenceTargets_extension_hcl(t *testing.T) {
 					Addr: lang.Address{
 						lang.RootStep{Name: "aws_instance"},
 						lang.AttrStep{Name: "blah"},
+					},
+					LocalAddr: lang.Address{
+						lang.RootStep{Name: "self"},
 					},
 					RangePtr: &hcl.Range{
 						Filename: "test.tf",
@@ -151,13 +154,13 @@ func TestCollectReferenceTargets_extension_hcl(t *testing.T) {
 								Filename: "test.tf",
 								Start: hcl.Pos{
 									Line:   1,
-									Column: 33,
-									Byte:   32,
+									Column: 32,
+									Byte:   31,
 								},
 								End: hcl.Pos{
 									Line:   5,
-									Column: 1,
-									Byte:   77,
+									Column: 2,
+									Byte:   78,
 								},
 							},
 						},
@@ -202,13 +205,225 @@ func TestCollectReferenceTargets_extension_hcl(t *testing.T) {
 								Filename: "test.tf",
 								Start: hcl.Pos{
 									Line:   1,
-									Column: 33,
-									Byte:   32,
+									Column: 32,
+									Byte:   31,
 								},
 								End: hcl.Pos{
 									Line:   5,
-									Column: 1,
+									Column: 2,
+									Byte:   78,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"self references collection - object block",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource": {
+						Address: &schema.BlockAddrSchema{
+							Steps: schema.Address{
+								schema.LabelStep{Index: 0},
+								schema.LabelStep{Index: 1},
+							},
+							DependentBodyAsData:  true,
+							InferDependentBody:   true,
+							DependentBodySelfRef: true,
+						},
+						Labels: []*schema.LabelSchema{
+							{
+								Name:     "type",
+								IsDepKey: true,
+							},
+							{
+								Name: "name",
+							},
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"static": {IsOptional: true, Expr: schema.LiteralTypeOnly(cty.String)},
+							},
+						},
+						DependentBody: map[schema.SchemaKey]*schema.BodySchema{
+							schema.NewSchemaKey(schema.DependencyKeys{
+								Labels: []schema.LabelDependent{
+									{
+										Index: 0,
+										Value: "aws_instance",
+									},
+								},
+							}): {
+								Blocks: map[string]*schema.BlockSchema{
+									"foo": {
+										Type: schema.BlockTypeObject,
+										Body: &schema.BodySchema{
+											Attributes: map[string]*schema.AttributeSchema{
+												"bar": {IsOptional: true, Expr: schema.LiteralTypeOnly(cty.Number)},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			`resource "aws_instance" "blah" {
+  static = "test"
+  foo {
+    bar = 42
+  }
+}
+`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "aws_instance"},
+						lang.AttrStep{Name: "blah"},
+					},
+					LocalAddr: lang.Address{
+						lang.RootStep{Name: "self"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+							Byte:   0,
+						},
+						End: hcl.Pos{
+							Line:   6,
+							Column: 2,
+							Byte:   77,
+						},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+							Byte:   0,
+						},
+						End: hcl.Pos{
+							Line:   1,
+							Column: 31,
+							Byte:   30,
+						},
+					},
+					Type: cty.Object(map[string]cty.Type{
+						"foo": cty.Object(map[string]cty.Type{
+							"bar": cty.Number,
+						}),
+					}),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "aws_instance"},
+								lang.AttrStep{Name: "blah"},
+								lang.AttrStep{Name: "foo"},
+							},
+							LocalAddr: lang.Address{
+								lang.RootStep{Name: "self"},
+								lang.AttrStep{Name: "foo"},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start: hcl.Pos{
+									Line:   3,
+									Column: 3,
+									Byte:   53,
+								},
+								End: hcl.Pos{
+									Line:   5,
+									Column: 4,
+									Byte:   75,
+								},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start: hcl.Pos{
+									Line:   3,
+									Column: 3,
+									Byte:   53,
+								},
+								End: hcl.Pos{
+									Line:   3,
+									Column: 6,
+									Byte:   56,
+								},
+							},
+							Type: cty.Object(map[string]cty.Type{
+								"bar": cty.Number,
+							}),
+							TargetableFromRangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start: hcl.Pos{
+									Line:   1,
+									Column: 32,
+									Byte:   31,
+								},
+								End: hcl.Pos{
+									Line:   6,
+									Column: 2,
 									Byte:   77,
+								},
+							},
+							NestedTargets: reference.Targets{
+								{
+									Addr: lang.Address{
+										lang.RootStep{Name: "aws_instance"},
+										lang.AttrStep{Name: "blah"},
+										lang.AttrStep{Name: "foo"},
+										lang.AttrStep{Name: "bar"},
+									},
+									LocalAddr: lang.Address{
+										lang.RootStep{Name: "self"},
+										lang.AttrStep{Name: "foo"},
+										lang.AttrStep{Name: "bar"},
+									},
+									RangePtr: &hcl.Range{
+										Filename: "test.tf",
+										Start: hcl.Pos{
+											Line:   4,
+											Column: 5,
+											Byte:   63,
+										},
+										End: hcl.Pos{
+											Line:   4,
+											Column: 13,
+											Byte:   71,
+										},
+									},
+									DefRangePtr: &hcl.Range{
+										Filename: "test.tf",
+										Start: hcl.Pos{
+											Line:   4,
+											Column: 5,
+											Byte:   63,
+										},
+										End: hcl.Pos{
+											Line:   4,
+											Column: 8,
+											Byte:   66,
+										},
+									},
+									Type: cty.Number,
+									TargetableFromRangePtr: &hcl.Range{
+										Filename: "test.tf",
+										Start: hcl.Pos{
+											Line:   1,
+											Column: 32,
+											Byte:   31,
+										},
+										End: hcl.Pos{
+											Line:   6,
+											Column: 2,
+											Byte:   77,
+										},
+									},
 								},
 							},
 						},

--- a/decoder/reference_targets_collect_extensions_hcl_test.go
+++ b/decoder/reference_targets_collect_extensions_hcl_test.go
@@ -1,0 +1,242 @@
+package decoder
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/reference"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty-debug/ctydebug"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestCollectReferenceTargets_extension_hcl(t *testing.T) {
+	testCases := []struct {
+		name         string
+		schema       *schema.BodySchema
+		cfg          string
+		expectedRefs reference.Targets
+	}{
+		{
+			"self references",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource": {
+						Address: &schema.BlockAddrSchema{
+							Steps: schema.Address{
+								schema.LabelStep{Index: 0},
+								schema.LabelStep{Index: 1},
+							},
+							DependentBodyAsData:  true,
+							InferDependentBody:   true,
+							DependentBodySelfRef: true,
+						},
+						Labels: []*schema.LabelSchema{
+							{
+								Name:     "type",
+								IsDepKey: true,
+							},
+							{
+								Name: "name",
+							},
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"static": {IsOptional: true, Expr: schema.LiteralTypeOnly(cty.String)},
+							},
+						},
+						DependentBody: map[schema.SchemaKey]*schema.BodySchema{
+							schema.NewSchemaKey(schema.DependencyKeys{
+								Labels: []schema.LabelDependent{
+									{
+										Index: 0,
+										Value: "aws_instance",
+									},
+								},
+							}): {
+								Attributes: map[string]*schema.AttributeSchema{
+									"bar": {IsOptional: true, Expr: schema.LiteralTypeOnly(cty.Number)},
+									"foo": {IsOptional: true, Expr: schema.LiteralTypeOnly(cty.String)},
+								},
+							},
+						},
+					},
+				},
+			},
+			`resource "aws_instance" "blah" {
+  static = "test"
+  foo = "test"
+  bar = 42
+}
+`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "aws_instance"},
+						lang.AttrStep{Name: "blah"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+							Byte:   0,
+						},
+						End: hcl.Pos{
+							Line:   5,
+							Column: 2,
+							Byte:   78,
+						},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+							Byte:   0,
+						},
+						End: hcl.Pos{
+							Line:   1,
+							Column: 31,
+							Byte:   30,
+						},
+					},
+					Type: cty.Object(map[string]cty.Type{
+						"bar": cty.Number,
+						"foo": cty.String,
+					}),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "aws_instance"},
+								lang.AttrStep{Name: "blah"},
+								lang.AttrStep{Name: "bar"},
+							},
+							LocalAddr: lang.Address{
+								lang.RootStep{Name: "self"},
+								lang.AttrStep{Name: "bar"},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start: hcl.Pos{
+									Line:   4,
+									Column: 3,
+									Byte:   68,
+								},
+								End: hcl.Pos{
+									Line:   4,
+									Column: 11,
+									Byte:   76,
+								},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start: hcl.Pos{
+									Line:   4,
+									Column: 3,
+									Byte:   68,
+								},
+								End: hcl.Pos{
+									Line:   4,
+									Column: 6,
+									Byte:   71,
+								},
+							},
+							Type: cty.Number,
+							TargetableFromRangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start: hcl.Pos{
+									Line:   1,
+									Column: 33,
+									Byte:   32,
+								},
+								End: hcl.Pos{
+									Line:   5,
+									Column: 1,
+									Byte:   77,
+								},
+							},
+						},
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "aws_instance"},
+								lang.AttrStep{Name: "blah"},
+								lang.AttrStep{Name: "foo"},
+							},
+							LocalAddr: lang.Address{
+								lang.RootStep{Name: "self"},
+								lang.AttrStep{Name: "foo"},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start: hcl.Pos{
+									Line:   3,
+									Column: 3,
+									Byte:   53,
+								},
+								End: hcl.Pos{
+									Line:   3,
+									Column: 15,
+									Byte:   65,
+								},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start: hcl.Pos{
+									Line:   3,
+									Column: 3,
+									Byte:   53,
+								},
+								End: hcl.Pos{
+									Line:   3,
+									Column: 6,
+									Byte:   56,
+								},
+							},
+							Type: cty.String,
+							TargetableFromRangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start: hcl.Pos{
+									Line:   1,
+									Column: 33,
+									Byte:   32,
+								},
+								End: hcl.Pos{
+									Line:   5,
+									Column: 1,
+									Byte:   77,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {
+			f, _ := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+
+			d := testPathDecoder(t, &PathContext{
+				Schema: tc.schema,
+				Files: map[string]*hcl.File{
+					"test.tf": f,
+				},
+			})
+
+			refs, err := d.CollectReferenceTargets()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedRefs, refs, ctydebug.CmpOptions); diff != "" {
+				t.Fatalf("mismatch of references: %s", diff)
+			}
+		})
+	}
+}

--- a/decoder/reference_targets_collect_extensions_hcl_test.go
+++ b/decoder/reference_targets_collect_extensions_hcl_test.go
@@ -833,6 +833,264 @@ func TestCollectReferenceTargets_extension_hcl(t *testing.T) {
 				},
 			},
 		},
+		{
+			"self references collection - map block",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource": {
+						Address: &schema.BlockAddrSchema{
+							Steps: schema.Address{
+								schema.LabelStep{Index: 0},
+								schema.LabelStep{Index: 1},
+							},
+							DependentBodyAsData:  true,
+							InferDependentBody:   true,
+							DependentBodySelfRef: true,
+						},
+						Labels: []*schema.LabelSchema{
+							{
+								Name:     "type",
+								IsDepKey: true,
+							},
+							{
+								Name: "name",
+							},
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"static": {IsOptional: true, Expr: schema.LiteralTypeOnly(cty.String)},
+							},
+						},
+						DependentBody: map[schema.SchemaKey]*schema.BodySchema{
+							schema.NewSchemaKey(schema.DependencyKeys{
+								Labels: []schema.LabelDependent{
+									{
+										Index: 0,
+										Value: "aws_instance",
+									},
+								},
+							}): {
+								Blocks: map[string]*schema.BlockSchema{
+									"foo": {
+										Type: schema.BlockTypeMap,
+										Body: &schema.BodySchema{
+											Attributes: map[string]*schema.AttributeSchema{
+												"bar": {IsOptional: true, Expr: schema.LiteralTypeOnly(cty.Number)},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			`resource "aws_instance" "blah" {
+  static = "test"
+  foo "dog" {
+    bar = 42
+  }
+}
+`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "aws_instance"},
+						lang.AttrStep{Name: "blah"},
+					},
+					LocalAddr: lang.Address{
+						lang.RootStep{Name: "self"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+							Byte:   0,
+						},
+						End: hcl.Pos{
+							Line:   6,
+							Column: 2,
+							Byte:   83,
+						},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+							Byte:   0,
+						},
+						End: hcl.Pos{
+							Line:   1,
+							Column: 31,
+							Byte:   30,
+						},
+					},
+					Type: cty.Object(map[string]cty.Type{
+						"foo": cty.Map(cty.Object(map[string]cty.Type{
+							"bar": cty.Number,
+						})),
+					}),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "aws_instance"},
+								lang.AttrStep{Name: "blah"},
+								lang.AttrStep{Name: "foo"},
+							},
+							LocalAddr: lang.Address{
+								lang.RootStep{Name: "self"},
+								lang.AttrStep{Name: "foo"},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start: hcl.Pos{
+									Line:   3,
+									Column: 3,
+									Byte:   53,
+								},
+								End: hcl.Pos{
+									Line:   5,
+									Column: 4,
+									Byte:   81,
+								},
+							},
+							Type: cty.Map(cty.Object(map[string]cty.Type{
+								"bar": cty.Number,
+							})),
+							TargetableFromRangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start: hcl.Pos{
+									Line:   1,
+									Column: 32,
+									Byte:   31,
+								},
+								End: hcl.Pos{
+									Line:   6,
+									Column: 2,
+									Byte:   83,
+								},
+							},
+							NestedTargets: reference.Targets{
+								{
+									Addr: lang.Address{
+										lang.RootStep{Name: "aws_instance"},
+										lang.AttrStep{Name: "blah"},
+										lang.AttrStep{Name: "foo"},
+										lang.IndexStep{Key: cty.StringVal("dog")},
+									},
+									LocalAddr: lang.Address{
+										lang.RootStep{Name: "self"},
+										lang.AttrStep{Name: "foo"},
+										lang.IndexStep{Key: cty.StringVal("dog")},
+									},
+									RangePtr: &hcl.Range{
+										Filename: "test.tf",
+										Start: hcl.Pos{
+											Line:   3,
+											Column: 3,
+											Byte:   53,
+										},
+										End: hcl.Pos{
+											Line:   5,
+											Column: 4,
+											Byte:   81,
+										},
+									},
+									DefRangePtr: &hcl.Range{
+										Filename: "test.tf",
+										Start: hcl.Pos{
+											Line:   3,
+											Column: 3,
+											Byte:   53,
+										},
+										End: hcl.Pos{
+											Line:   3,
+											Column: 12,
+											Byte:   62,
+										},
+									},
+									Type: cty.Object(map[string]cty.Type{
+										"bar": cty.Number,
+									}),
+									TargetableFromRangePtr: &hcl.Range{
+										Filename: "test.tf",
+										Start: hcl.Pos{
+											Line:   1,
+											Column: 32,
+											Byte:   31,
+										},
+										End: hcl.Pos{
+											Line:   6,
+											Column: 2,
+											Byte:   83,
+										},
+									},
+									NestedTargets: reference.Targets{
+										{
+											Addr: lang.Address{
+												lang.RootStep{Name: "aws_instance"},
+												lang.AttrStep{Name: "blah"},
+												lang.AttrStep{Name: "foo"},
+												lang.IndexStep{Key: cty.StringVal("dog")},
+												lang.AttrStep{Name: "bar"},
+											},
+											LocalAddr: lang.Address{
+												lang.RootStep{Name: "self"},
+												lang.AttrStep{Name: "foo"},
+												lang.IndexStep{Key: cty.StringVal("dog")},
+												lang.AttrStep{Name: "bar"},
+											},
+											RangePtr: &hcl.Range{
+												Filename: "test.tf",
+												Start: hcl.Pos{
+													Line:   4,
+													Column: 5,
+													Byte:   69,
+												},
+												End: hcl.Pos{
+													Line:   4,
+													Column: 13,
+													Byte:   77,
+												},
+											},
+											DefRangePtr: &hcl.Range{
+												Filename: "test.tf",
+												Start: hcl.Pos{
+													Line:   4,
+													Column: 5,
+													Byte:   69,
+												},
+												End: hcl.Pos{
+													Line:   4,
+													Column: 8,
+													Byte:   72,
+												},
+											},
+											Type: cty.Number,
+											TargetableFromRangePtr: &hcl.Range{
+												Filename: "test.tf",
+												Start: hcl.Pos{
+													Line:   1,
+													Column: 32,
+													Byte:   31,
+												},
+												End: hcl.Pos{
+													Line:   6,
+													Column: 2,
+													Byte:   83,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for i, tc := range testCases {

--- a/decoder/reference_targets_collect_hcl_test.go
+++ b/decoder/reference_targets_collect_hcl_test.go
@@ -2379,6 +2379,7 @@ provider "test" {
 								lang.AttrStep{Name: "aws"},
 								lang.AttrStep{Name: "listblock"},
 							},
+							LocalAddr: lang.Address{},
 							RangePtr: &hcl.Range{
 								Filename: "test.tf",
 								Start: hcl.Pos{
@@ -2928,6 +2929,7 @@ provider "test" {
 								lang.AttrStep{Name: "aws"},
 								lang.AttrStep{Name: "listblock"},
 							},
+							LocalAddr: lang.Address{},
 							RangePtr: &hcl.Range{
 								Filename: "test.tf",
 								Start: hcl.Pos{

--- a/decoder/reference_targets_collect_hcl_test.go
+++ b/decoder/reference_targets_collect_hcl_test.go
@@ -3321,6 +3321,7 @@ provider "test" {
 								lang.AttrStep{Name: "aws"},
 								lang.AttrStep{Name: "listener"},
 							},
+							LocalAddr: lang.Address{},
 							RangePtr: &hcl.Range{
 								Filename: "test.tf",
 								Start: hcl.Pos{

--- a/decoder/reference_targets_collect_hcl_test.go
+++ b/decoder/reference_targets_collect_hcl_test.go
@@ -1677,6 +1677,7 @@ provider "test" {
 					Addr: lang.Address{
 						lang.RootStep{Name: "aws"},
 					},
+					LocalAddr: lang.Address{},
 					Type: cty.Object(map[string]cty.Type{
 						"attr":      cty.Number,
 						"name":      cty.String,
@@ -2133,6 +2134,7 @@ provider "test" {
 								lang.AttrStep{Name: "aws"},
 								lang.AttrStep{Name: "objblock"},
 							},
+							LocalAddr: lang.Address{},
 							RangePtr: &hcl.Range{
 								Filename: "test.tf",
 								Start: hcl.Pos{
@@ -2403,6 +2405,7 @@ provider "test" {
 										lang.AttrStep{Name: "listblock"},
 										lang.IndexStep{Key: cty.NumberIntVal(0)},
 									},
+									LocalAddr: lang.Address{},
 									RangePtr: &hcl.Range{
 										Filename: "test.tf",
 										Start: hcl.Pos{
@@ -2515,6 +2518,7 @@ provider "test" {
 										lang.AttrStep{Name: "listblock"},
 										lang.IndexStep{Key: cty.NumberIntVal(1)},
 									},
+									LocalAddr: lang.Address{},
 									RangePtr: &hcl.Range{
 										Filename: "test.tf",
 										Start: hcl.Pos{
@@ -2950,6 +2954,7 @@ provider "test" {
 										lang.AttrStep{Name: "listblock"},
 										lang.IndexStep{Key: cty.NumberIntVal(0)},
 									},
+									LocalAddr: lang.Address{},
 									RangePtr: &hcl.Range{
 										Filename: "test.tf",
 										Start: hcl.Pos{
@@ -3062,6 +3067,7 @@ provider "test" {
 										lang.AttrStep{Name: "listblock"},
 										lang.IndexStep{Key: cty.NumberIntVal(1)},
 									},
+									LocalAddr: lang.Address{},
 									RangePtr: &hcl.Range{
 										Filename: "test.tf",
 										Start: hcl.Pos{
@@ -3338,6 +3344,7 @@ provider "test" {
 										lang.AttrStep{Name: "listener"},
 										lang.IndexStep{Key: cty.StringVal("http")},
 									},
+									LocalAddr: lang.Address{},
 									Type: cty.Object(map[string]cty.Type{
 										"port":     cty.Number,
 										"protocol": cty.String,
@@ -3450,6 +3457,7 @@ provider "test" {
 										lang.AttrStep{Name: "listener"},
 										lang.IndexStep{Key: cty.StringVal("https")},
 									},
+									LocalAddr: lang.Address{},
 									Type: cty.Object(map[string]cty.Type{
 										"port":     cty.Number,
 										"protocol": cty.String,
@@ -4234,6 +4242,7 @@ module "different" {
 						lang.RootStep{Name: "module"},
 						lang.AttrStep{Name: "test"},
 					},
+					LocalAddr: lang.Address{},
 					Type: cty.Object(map[string]cty.Type{
 						"attr": cty.String,
 					}),

--- a/decoder/reference_targets_collect_hcl_test.go
+++ b/decoder/reference_targets_collect_hcl_test.go
@@ -2768,6 +2768,7 @@ provider "test" {
 								lang.AttrStep{Name: "aws"},
 								lang.AttrStep{Name: "setblock"},
 							},
+							LocalAddr: lang.Address{},
 							RangePtr: &hcl.Range{
 								Filename: "test.tf",
 								Start: hcl.Pos{

--- a/decoder/reference_targets_collect_json_test.go
+++ b/decoder/reference_targets_collect_json_test.go
@@ -1473,6 +1473,7 @@ func TestCollectReferenceTargets_json(t *testing.T) {
 					Addr: lang.Address{
 						lang.RootStep{Name: "aws"},
 					},
+					LocalAddr: lang.Address{},
 					Type: cty.Object(map[string]cty.Type{
 						"attr":      cty.Number,
 						"name":      cty.String,
@@ -1826,6 +1827,7 @@ func TestCollectReferenceTargets_json(t *testing.T) {
 								lang.AttrStep{Name: "aws"},
 								lang.AttrStep{Name: "objblock"},
 							},
+							LocalAddr: lang.Address{},
 							RangePtr: &hcl.Range{
 								Filename: "test.tf.json",
 								Start: hcl.Pos{
@@ -2100,6 +2102,7 @@ func TestCollectReferenceTargets_json(t *testing.T) {
 										lang.AttrStep{Name: "listblock"},
 										lang.IndexStep{Key: cty.NumberIntVal(0)},
 									},
+									LocalAddr: lang.Address{},
 									RangePtr: &hcl.Range{
 										Filename: "test.tf.json",
 										Start: hcl.Pos{
@@ -2212,6 +2215,7 @@ func TestCollectReferenceTargets_json(t *testing.T) {
 										lang.AttrStep{Name: "listblock"},
 										lang.IndexStep{Key: cty.NumberIntVal(1)},
 									},
+									LocalAddr: lang.Address{},
 									RangePtr: &hcl.Range{
 										Filename: "test.tf.json",
 										Start: hcl.Pos{
@@ -2655,6 +2659,7 @@ func TestCollectReferenceTargets_json(t *testing.T) {
 										lang.AttrStep{Name: "listblock"},
 										lang.IndexStep{Key: cty.NumberIntVal(0)},
 									},
+									LocalAddr: lang.Address{},
 									RangePtr: &hcl.Range{
 										Filename: "test.tf.json",
 										Start: hcl.Pos{
@@ -2767,6 +2772,7 @@ func TestCollectReferenceTargets_json(t *testing.T) {
 										lang.AttrStep{Name: "listblock"},
 										lang.IndexStep{Key: cty.NumberIntVal(1)},
 									},
+									LocalAddr: lang.Address{},
 									RangePtr: &hcl.Range{
 										Filename: "test.tf.json",
 										Start: hcl.Pos{
@@ -3049,6 +3055,7 @@ func TestCollectReferenceTargets_json(t *testing.T) {
 										lang.AttrStep{Name: "listener"},
 										lang.IndexStep{Key: cty.StringVal("http")},
 									},
+									LocalAddr: lang.Address{},
 									Type: cty.Object(map[string]cty.Type{
 										"port":     cty.Number,
 										"protocol": cty.String,
@@ -3161,6 +3168,7 @@ func TestCollectReferenceTargets_json(t *testing.T) {
 										lang.AttrStep{Name: "listener"},
 										lang.IndexStep{Key: cty.StringVal("https")},
 									},
+									LocalAddr: lang.Address{},
 									Type: cty.Object(map[string]cty.Type{
 										"port":     cty.Number,
 										"protocol": cty.String,
@@ -3954,6 +3962,7 @@ func TestCollectReferenceTargets_json(t *testing.T) {
 						lang.RootStep{Name: "module"},
 						lang.AttrStep{Name: "test"},
 					},
+					LocalAddr: lang.Address{},
 					Type: cty.Object(map[string]cty.Type{
 						"attr": cty.String,
 					}),

--- a/decoder/reference_targets_collect_json_test.go
+++ b/decoder/reference_targets_collect_json_test.go
@@ -2469,6 +2469,7 @@ func TestCollectReferenceTargets_json(t *testing.T) {
 								lang.AttrStep{Name: "aws"},
 								lang.AttrStep{Name: "setblock"},
 							},
+							LocalAddr: lang.Address{},
 							RangePtr: &hcl.Range{
 								Filename: "test.tf.json",
 								Start: hcl.Pos{

--- a/decoder/reference_targets_collect_json_test.go
+++ b/decoder/reference_targets_collect_json_test.go
@@ -2076,6 +2076,7 @@ func TestCollectReferenceTargets_json(t *testing.T) {
 								lang.AttrStep{Name: "aws"},
 								lang.AttrStep{Name: "listblock"},
 							},
+							LocalAddr: lang.Address{},
 							RangePtr: &hcl.Range{
 								Filename: "test.tf.json",
 								Start: hcl.Pos{
@@ -2633,6 +2634,7 @@ func TestCollectReferenceTargets_json(t *testing.T) {
 								lang.AttrStep{Name: "aws"},
 								lang.AttrStep{Name: "listblock"},
 							},
+							LocalAddr: lang.Address{},
 							RangePtr: &hcl.Range{
 								Filename: "test.tf.json",
 								Start: hcl.Pos{

--- a/decoder/reference_targets_collect_json_test.go
+++ b/decoder/reference_targets_collect_json_test.go
@@ -3032,6 +3032,7 @@ func TestCollectReferenceTargets_json(t *testing.T) {
 								lang.AttrStep{Name: "aws"},
 								lang.AttrStep{Name: "listener"},
 							},
+							LocalAddr: lang.Address{},
 							RangePtr: &hcl.Range{
 								Filename: "test.tf.json",
 								Start: hcl.Pos{

--- a/decoder/semantic_tokens.go
+++ b/decoder/semantic_tokens.go
@@ -187,17 +187,6 @@ func (d *PathDecoder) tokensForExpression(ctx context.Context, expr hclsyntax.Ex
 			return tokens
 		}
 
-		countAvailable := schema.ActiveCountFromContext(ctx)
-		countIndexAttr := lang.Address{
-			lang.RootStep{Name: "count"}, lang.AttrStep{Name: "index"},
-		}
-
-		if address.Equals(countIndexAttr) && countAvailable {
-			tokens = append(tokens, semanticTokensForTraversalExpression(eType.AsTraversal())...)
-
-			return tokens
-		}
-
 		foreachAvailable := schema.ActiveForEachFromContext(ctx)
 		eachKeyAddress := lang.Address{
 			lang.RootStep{Name: "each"}, lang.AttrStep{Name: "key"},

--- a/decoder/semantic_tokens_test.go
+++ b/decoder/semantic_tokens_test.go
@@ -853,7 +853,7 @@ resource "vault_auth_backend" "blah" {
 	}
 }
 
-func TestDecoder_SemanticTokensInFile_extensions(t *testing.T) {
+func TestDecoder_SemanticTokensInFile_extensions_basic(t *testing.T) {
 	bodySchema := &schema.BodySchema{
 		Blocks: map[string]*schema.BlockSchema{
 			"resource": {
@@ -1079,8 +1079,8 @@ resource "aws_instance" "app_server" {
 				},
 				End: hcl.Pos{
 					Line:   4,
-					Column: 32,
-					Byte:   92,
+					Column: 31,
+					Byte:   91,
 				},
 			},
 		},
@@ -1329,8 +1329,8 @@ resource "aws_instance" "app_server" {
 				},
 				End: hcl.Pos{
 					Line:   4,
-					Column: 32,
-					Byte:   92,
+					Column: 31,
+					Byte:   91,
 				},
 			},
 		},
@@ -1492,7 +1492,9 @@ func TestDecoder_SemanticTokensInFile_extensions_countIndexInSubBlock(t *testing
 							Body: &schema.BodySchema{
 								Attributes: map[string]*schema.AttributeSchema{
 									"attr": {
-										Expr: schema.LiteralTypeOnly(cty.Number),
+										Expr: schema.ExprConstraints{
+											schema.TraversalExpr{OfType: cty.Number},
+										},
 									},
 								},
 							},
@@ -1726,8 +1728,8 @@ resource "foobar" "name" {
 				},
 				End: hcl.Pos{
 					Line:   5,
-					Column: 22,
-					Byte:   69,
+					Column: 21,
+					Byte:   68,
 				},
 			},
 		},

--- a/reference/target.go
+++ b/reference/target.go
@@ -1,6 +1,8 @@
 package reference
 
 import (
+	"context"
+
 	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
@@ -95,11 +97,10 @@ func copyHclRangePtr(rng *hcl.Range) *hcl.Range {
 }
 
 // Address returns any of the two non-empty addresses
-//
-// TODO: Return address based on context when we have both
-func (r Target) Address() lang.Address {
+func (r Target) Address(ctx context.Context) lang.Address {
 	addr := r.Addr
-	if len(r.LocalAddr) > 0 {
+	if len(r.LocalAddr) > 0 &&
+		(len(r.Addr) == 0 || schema.ActiveSelfRefsFromContext(ctx)) {
 		addr = r.LocalAddr
 	}
 

--- a/reference/targets.go
+++ b/reference/targets.go
@@ -1,6 +1,7 @@
 package reference
 
 import (
+	"context"
 	"errors"
 	"strings"
 
@@ -72,34 +73,67 @@ func (w refTargetDeepWalker) walk(refTargets Targets) {
 	}
 }
 
-func (refs Targets) MatchWalk(te schema.TraversalExpr, prefix string, outermostBodyRng, originRng hcl.Range, f TargetWalkFunc) {
+func (refs Targets) MatchWalk(ctx context.Context, te schema.TraversalExpr, prefix string, outermostBodyRng, originRng hcl.Range, f TargetWalkFunc) {
 	for _, ref := range refs {
-		matched := false
-		if len(ref.LocalAddr) > 0 && strings.HasPrefix(ref.LocalAddr.String(), prefix) {
-			// Check if origin is inside the targetable range
-			if ref.TargetableFromRangePtr == nil || rangeOverlaps(*ref.TargetableFromRangePtr, originRng) {
-				nestedMatches := ref.NestedTargets.containsMatch(te, prefix)
-				if ref.MatchesConstraint(te) || nestedMatches {
-					matched = true
-				}
-			}
-		}
-		if len(ref.Addr) > 0 && strings.HasPrefix(ref.Addr.String(), prefix) {
-			nestedMatches := ref.NestedTargets.containsMatch(te, prefix)
-
-			// avoid suggesting references to block's own fields from within
-			if !referenceTargetIsInRange(ref, outermostBodyRng) &&
-				(ref.MatchesConstraint(te) || nestedMatches) {
-				matched = true
-			}
-		}
-		if matched {
+		if localTargetMatches(ctx, ref, te, prefix, outermostBodyRng, originRng) ||
+			absTargetMatches(ctx, ref, te, prefix, outermostBodyRng, originRng) {
 			f(ref)
 			continue
 		}
 
-		ref.NestedTargets.MatchWalk(te, prefix, outermostBodyRng, originRng, f)
+		ref.NestedTargets.MatchWalk(ctx, te, prefix, outermostBodyRng, originRng, f)
 	}
+}
+
+func localTargetMatches(ctx context.Context, target Target, te schema.TraversalExpr, prefix string, outermostBodyRng, originRng hcl.Range) bool {
+	if len(target.LocalAddr) > 0 && strings.HasPrefix(target.LocalAddr.String(), prefix) {
+		// reject self references if not enabled
+		if !schema.ActiveSelfRefsFromContext(ctx) && target.LocalAddr[0].String() == "self" {
+			return false
+		}
+
+		hasNestedMatches := target.NestedTargets.containsMatch(ctx, te, prefix, outermostBodyRng, originRng)
+
+		// Avoid suggesting cyclical reference to the same attribute
+		// unless it has nested matches - i.e. we still consider "self"
+		// as match if it refers to the outside block
+		if target.RangePtr != nil && !hasNestedMatches {
+			if rangeOverlaps(*target.RangePtr, originRng) {
+				return false
+			}
+			// We compare line in case the (incomplete) attribute
+			// ends w/ whitespace which wouldn't be included in the range
+			if target.RangePtr.Filename == originRng.Filename &&
+				target.RangePtr.End.Line == originRng.Start.Line {
+				return false
+			}
+		}
+
+		// Reject origins which are outside the targetable range
+		if target.TargetableFromRangePtr != nil && !rangeOverlaps(*target.TargetableFromRangePtr, originRng) {
+			return false
+		}
+
+		if target.MatchesConstraint(te) || hasNestedMatches {
+			return true
+		}
+	}
+
+	return false
+}
+
+func absTargetMatches(ctx context.Context, target Target, te schema.TraversalExpr, prefix string, outermostBodyRng, originRng hcl.Range) bool {
+	if len(target.Addr) > 0 && strings.HasPrefix(target.Addr.String(), prefix) {
+		// Reject references to block's own fields from within the body
+		if referenceTargetIsInRange(target, outermostBodyRng) {
+			return false
+		}
+
+		if target.MatchesConstraint(te) || target.NestedTargets.containsMatch(ctx, te, prefix, outermostBodyRng, originRng) {
+			return true
+		}
+	}
+	return false
 }
 
 func referenceTargetIsInRange(target Target, bodyRange hcl.Range) bool {
@@ -115,18 +149,17 @@ func posEqual(pos, other hcl.Pos) bool {
 		pos.Byte == other.Byte
 }
 
-func (refs Targets) containsMatch(te schema.TraversalExpr, prefix string) bool {
+func (refs Targets) containsMatch(ctx context.Context, te schema.TraversalExpr, prefix string, outermostBodyRng, originRng hcl.Range) bool {
 	for _, ref := range refs {
-		if strings.HasPrefix(ref.LocalAddr.String(), prefix) &&
-			ref.MatchesConstraint(te) {
+		if localTargetMatches(ctx, ref, te, prefix, outermostBodyRng, originRng) {
 			return true
 		}
-		if strings.HasPrefix(ref.Addr.String(), prefix) &&
-			ref.MatchesConstraint(te) {
+		if absTargetMatches(ctx, ref, te, prefix, outermostBodyRng, originRng) {
 			return true
 		}
+
 		if len(ref.NestedTargets) > 0 {
-			if match := ref.NestedTargets.containsMatch(te, prefix); match {
+			if match := ref.NestedTargets.containsMatch(ctx, te, prefix, outermostBodyRng, originRng); match {
 				return true
 			}
 		}

--- a/reference/targets_test.go
+++ b/reference/targets_test.go
@@ -1036,8 +1036,58 @@ func TestTargets_MatchWalk_localRefs(t *testing.T) {
 				},
 			},
 		},
-		// TODO: test matching of originRng vs outermostBodyRng (cyclical references)
-		// TODO: test matching of TargetableFromRangePtr
+		{
+			"targets matching only the local block",
+			Targets{
+				{
+					LocalAddr: lang.Address{
+						lang.RootStep{Name: "count"},
+						lang.AttrStep{Name: "index"},
+					},
+					TargetableFromRangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 10, Column: 1, Byte: 50},
+					},
+				},
+				{
+					LocalAddr: lang.Address{
+						lang.RootStep{Name: "count"},
+						lang.AttrStep{Name: "index"},
+					},
+					TargetableFromRangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 12, Column: 1, Byte: 52},
+						End:      hcl.Pos{Line: 20, Column: 1, Byte: 80},
+					},
+				},
+			},
+			schema.TraversalExpr{},
+			"co",
+			hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.InitialPos,
+				End:      hcl.InitialPos,
+			},
+			hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.Pos{Line: 5, Column: 1, Byte: 25},
+				End:      hcl.Pos{Line: 5, Column: 10, Byte: 35},
+			},
+			Targets{
+				{
+					LocalAddr: lang.Address{
+						lang.RootStep{Name: "count"},
+						lang.AttrStep{Name: "index"},
+					},
+					TargetableFromRangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 10, Column: 1, Byte: 50},
+					},
+				},
+			},
+		},
 	}
 
 	for i, tc := range testCases {

--- a/reference/targets_test.go
+++ b/reference/targets_test.go
@@ -612,17 +612,29 @@ func TestTargets_OutermostInFile(t *testing.T) {
 
 func TestTargets_MatchWalk(t *testing.T) {
 	testCases := []struct {
-		name            string
-		targets         Targets
-		traversalConst  schema.TraversalExpr
-		prefix          string
-		expectedTargets Targets
+		name             string
+		targets          Targets
+		traversalConst   schema.TraversalExpr
+		prefix           string
+		outermostBodyRng hcl.Range
+		originRng        hcl.Range
+		expectedTargets  Targets
 	}{
 		{
 			"no targets",
 			Targets{},
 			schema.TraversalExpr{},
 			"test",
+			hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.InitialPos,
+				End:      hcl.InitialPos,
+			},
+			hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.InitialPos,
+				End:      hcl.InitialPos,
+			},
 			Targets{},
 		},
 		{
@@ -643,6 +655,16 @@ func TestTargets_MatchWalk(t *testing.T) {
 			},
 			schema.TraversalExpr{},
 			"",
+			hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.InitialPos,
+				End:      hcl.InitialPos,
+			},
+			hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.InitialPos,
+				End:      hcl.InitialPos,
+			},
 			Targets{
 				Target{
 					Addr: lang.Address{
@@ -676,6 +698,16 @@ func TestTargets_MatchWalk(t *testing.T) {
 			},
 			schema.TraversalExpr{},
 			"var.f",
+			hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.InitialPos,
+				End:      hcl.InitialPos,
+			},
+			hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.InitialPos,
+				End:      hcl.InitialPos,
+			},
 			Targets{
 				Target{
 					Addr: lang.Address{
@@ -707,6 +739,16 @@ func TestTargets_MatchWalk(t *testing.T) {
 				OfType: cty.String,
 			},
 			"",
+			hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.InitialPos,
+				End:      hcl.InitialPos,
+			},
+			hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.InitialPos,
+				End:      hcl.InitialPos,
+			},
 			Targets{
 				Target{
 					Addr: lang.Address{
@@ -739,6 +781,16 @@ func TestTargets_MatchWalk(t *testing.T) {
 				OfScopeId: lang.ScopeId("green"),
 			},
 			"",
+			hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.InitialPos,
+				End:      hcl.InitialPos,
+			},
+			hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.InitialPos,
+				End:      hcl.InitialPos,
+			},
 			Targets{
 				Target{
 					Addr: lang.Address{
@@ -782,6 +834,16 @@ func TestTargets_MatchWalk(t *testing.T) {
 				OfScopeId: lang.ScopeId("blue"),
 			},
 			"",
+			hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.InitialPos,
+				End:      hcl.InitialPos,
+			},
+			hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.InitialPos,
+				End:      hcl.InitialPos,
+			},
 			Targets{
 				Target{
 					Addr: lang.Address{
@@ -793,17 +855,13 @@ func TestTargets_MatchWalk(t *testing.T) {
 				},
 			},
 		},
+		// TODO: test matching of originRng vs outermostBodyRng (cyclical references)
 	}
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {
 			targets := make(Targets, 0)
-			rng := hcl.Range{
-				Filename: "test.tf",
-				Start:    hcl.InitialPos,
-				End:      hcl.InitialPos,
-			}
-			tc.targets.MatchWalk(tc.traversalConst, tc.prefix, rng, func(t Target) error {
+			tc.targets.MatchWalk(tc.traversalConst, tc.prefix, tc.outermostBodyRng, tc.originRng, func(t Target) error {
 				targets = append(targets, t)
 				return nil
 			})
@@ -816,17 +874,29 @@ func TestTargets_MatchWalk(t *testing.T) {
 
 func TestTargets_MatchWalk_localRefs(t *testing.T) {
 	testCases := []struct {
-		name            string
-		targets         Targets
-		traversalConst  schema.TraversalExpr
-		prefix          string
-		expectedTargets Targets
+		name             string
+		targets          Targets
+		traversalConst   schema.TraversalExpr
+		prefix           string
+		outermostBodyRng hcl.Range
+		originRng        hcl.Range
+		expectedTargets  Targets
 	}{
 		{
 			"no targets",
 			Targets{},
 			schema.TraversalExpr{},
 			"test",
+			hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.InitialPos,
+				End:      hcl.InitialPos,
+			},
+			hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.InitialPos,
+				End:      hcl.InitialPos,
+			},
 			Targets{},
 		},
 		{
@@ -847,6 +917,16 @@ func TestTargets_MatchWalk_localRefs(t *testing.T) {
 			},
 			schema.TraversalExpr{},
 			"co",
+			hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.InitialPos,
+				End:      hcl.InitialPos,
+			},
+			hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.InitialPos,
+				End:      hcl.InitialPos,
+			},
 			Targets{
 				{
 					LocalAddr: lang.Address{
@@ -882,6 +962,16 @@ func TestTargets_MatchWalk_localRefs(t *testing.T) {
 			},
 			schema.TraversalExpr{},
 			"abs",
+			hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.InitialPos,
+				End:      hcl.InitialPos,
+			},
+			hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.InitialPos,
+				End:      hcl.InitialPos,
+			},
 			Targets{
 				{
 					LocalAddr: lang.Address{
@@ -905,17 +995,14 @@ func TestTargets_MatchWalk_localRefs(t *testing.T) {
 				},
 			},
 		},
+		// TODO: test matching of originRng vs outermostBodyRng (cyclical references)
+		// TODO: test matching of TargetableFromRangePtr
 	}
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {
 			targets := make(Targets, 0)
-			rng := hcl.Range{
-				Filename: "test.tf",
-				Start:    hcl.InitialPos,
-				End:      hcl.InitialPos,
-			}
-			tc.targets.MatchWalk(tc.traversalConst, tc.prefix, rng, func(t Target) error {
+			tc.targets.MatchWalk(tc.traversalConst, tc.prefix, tc.outermostBodyRng, tc.originRng, func(t Target) error {
 				targets = append(targets, t)
 				return nil
 			})

--- a/reference/targets_test.go
+++ b/reference/targets_test.go
@@ -1,6 +1,7 @@
 package reference
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -892,7 +893,8 @@ func TestTargets_MatchWalk(t *testing.T) {
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {
 			targets := make(Targets, 0)
-			tc.targets.MatchWalk(tc.traversalConst, tc.prefix, tc.outermostBodyRng, tc.originRng, func(t Target) error {
+			ctx := context.Background()
+			tc.targets.MatchWalk(ctx, tc.traversalConst, tc.prefix, tc.outermostBodyRng, tc.originRng, func(t Target) error {
 				targets = append(targets, t)
 				return nil
 			})
@@ -1088,12 +1090,14 @@ func TestTargets_MatchWalk_localRefs(t *testing.T) {
 				},
 			},
 		},
+		// TODO: active vs inactive self
 	}
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {
 			targets := make(Targets, 0)
-			tc.targets.MatchWalk(tc.traversalConst, tc.prefix, tc.outermostBodyRng, tc.originRng, func(t Target) error {
+			ctx := context.Background()
+			tc.targets.MatchWalk(ctx, tc.traversalConst, tc.prefix, tc.outermostBodyRng, tc.originRng, func(t Target) error {
 				targets = append(targets, t)
 				return nil
 			})

--- a/reference/targets_test.go
+++ b/reference/targets_test.go
@@ -855,7 +855,38 @@ func TestTargets_MatchWalk(t *testing.T) {
 				},
 			},
 		},
-		// TODO: test matching of originRng vs outermostBodyRng (cyclical references)
+		{
+			"avoid matching references to block's own fields",
+			Targets{
+				Target{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "test"},
+					},
+					Type: cty.String,
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 5, Column: 1, Byte: 25},
+						End:      hcl.Pos{Line: 5, Column: 10, Byte: 35},
+					},
+				},
+			},
+			schema.TraversalExpr{
+				OfType: cty.String,
+			},
+			"",
+			hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+				End:      hcl.Pos{Line: 10, Column: 1, Byte: 50},
+			},
+			hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.InitialPos,
+				End:      hcl.InitialPos,
+			},
+			Targets{},
+		},
 	}
 
 	for i, tc := range testCases {
@@ -937,7 +968,7 @@ func TestTargets_MatchWalk_localRefs(t *testing.T) {
 			},
 		},
 		{
-			"targets with mixed address",
+			"targets with mixed address and same block",
 			Targets{
 				{
 					LocalAddr: lang.Address{
@@ -947,6 +978,11 @@ func TestTargets_MatchWalk_localRefs(t *testing.T) {
 					Addr: lang.Address{
 						lang.RootStep{Name: "abs"},
 						lang.AttrStep{Name: "foobar"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 5, Column: 1, Byte: 25},
+						End:      hcl.Pos{Line: 5, Column: 10, Byte: 35},
 					},
 				},
 				{
@@ -961,11 +997,11 @@ func TestTargets_MatchWalk_localRefs(t *testing.T) {
 				},
 			},
 			schema.TraversalExpr{},
-			"abs",
+			"local",
 			hcl.Range{
 				Filename: "test.tf",
-				Start:    hcl.InitialPos,
-				End:      hcl.InitialPos,
+				Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+				End:      hcl.Pos{Line: 10, Column: 1, Byte: 50},
 			},
 			hcl.Range{
 				Filename: "test.tf",
@@ -981,6 +1017,11 @@ func TestTargets_MatchWalk_localRefs(t *testing.T) {
 					Addr: lang.Address{
 						lang.RootStep{Name: "abs"},
 						lang.AttrStep{Name: "foobar"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 5, Column: 1, Byte: 25},
+						End:      hcl.Pos{Line: 5, Column: 10, Byte: 35},
 					},
 				},
 				{

--- a/reference/traversal.go
+++ b/reference/traversal.go
@@ -6,9 +6,16 @@ import (
 	"github.com/hashicorp/hcl/v2"
 )
 
-func TraversalsToLocalOrigins(traversals []hcl.Traversal, tes schema.TraversalExprs) Origins {
+func TraversalsToLocalOrigins(traversals []hcl.Traversal, tes schema.TraversalExprs, allowSelfRefs bool) Origins {
 	origins := make(Origins, 0)
 	for _, traversal := range traversals {
+		// traversal should not be relative here, since the input to this
+		// function `expr.Variables()` only returns absolute traversals
+		if !traversal.IsRelative() && traversal.RootName() == "self" && !allowSelfRefs {
+			// Only if a block allows the usage of self.* we create a origin,
+			// else just continue
+			continue
+		}
 		origin, err := TraversalToLocalOrigin(traversal, tes)
 		if err != nil {
 			continue

--- a/reference/traversal_test.go
+++ b/reference/traversal_test.go
@@ -98,3 +98,81 @@ func TestTraversalToOrigin(t *testing.T) {
 		})
 	}
 }
+
+func TestTraversalsToOrigin(t *testing.T) {
+	testCases := []struct {
+		testName        string
+		rawTraversals   []string
+		traversalExprs  schema.TraversalExprs
+		allowSelfRefs   bool
+		expectedOrigins Origins
+	}{
+		{
+			"origin collection without self refs",
+			[]string{"foo.bar", "self.bar"},
+			schema.TraversalExprs{},
+			false,
+			Origins{
+				LocalOrigin{
+					Addr: lang.Address{
+						lang.RootStep{Name: "foo"},
+						lang.AttrStep{Name: "bar"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					},
+				},
+			},
+		},
+		{
+			"origin collection with self refs",
+			[]string{"foo.bar", "self.bar"},
+			schema.TraversalExprs{},
+			true,
+			Origins{
+				LocalOrigin{
+					Addr: lang.Address{
+						lang.RootStep{Name: "foo"},
+						lang.AttrStep{Name: "bar"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					},
+				},
+				LocalOrigin{
+					Addr: lang.Address{
+						lang.RootStep{Name: "self"},
+						lang.AttrStep{Name: "bar"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 9, Byte: 8},
+					},
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+			traversals := make([]hcl.Traversal, 0)
+			for _, rawTraversal := range tc.rawTraversals {
+				traversal, diags := hclsyntax.ParseTraversalAbs([]byte(rawTraversal), "test.tf", hcl.InitialPos)
+				if len(diags) > 0 {
+					t.Fatal(diags)
+				}
+				traversals = append(traversals, traversal)
+			}
+
+			origins := TraversalsToLocalOrigins(traversals, tc.traversalExprs, tc.allowSelfRefs)
+			if diff := cmp.Diff(tc.expectedOrigins, origins, ctydebug.CmpOptions); diff != "" {
+				t.Fatalf("origin mismatch: %s", diff)
+			}
+		})
+	}
+}

--- a/schema/block_schema.go
+++ b/schema/block_schema.go
@@ -69,6 +69,9 @@ type BlockAddrSchema struct {
 	// blocks and attributes are also walked
 	// and their addresses inferred as data
 	InferDependentBody bool
+
+	// DependentBodySelfRef TODO
+	DependentBodySelfRef bool
 }
 
 type BlockAsTypeOf struct {
@@ -99,6 +102,10 @@ func (bas *BlockAddrSchema) Validate() error {
 		return errors.New("InferDependentBody requires DependentBodyAsData")
 	}
 
+	if bas.DependentBodySelfRef && !bas.InferDependentBody {
+		return errors.New("DependentBodySelfRef requires InferDependentBody")
+	}
+
 	return nil
 }
 
@@ -108,15 +115,16 @@ func (bas *BlockAddrSchema) Copy() *BlockAddrSchema {
 	}
 
 	newBas := &BlockAddrSchema{
-		FriendlyName:        bas.FriendlyName,
-		ScopeId:             bas.ScopeId,
-		AsReference:         bas.AsReference,
-		AsTypeOf:            bas.AsTypeOf.Copy(),
-		BodyAsData:          bas.BodyAsData,
-		InferBody:           bas.InferBody,
-		DependentBodyAsData: bas.DependentBodyAsData,
-		InferDependentBody:  bas.InferDependentBody,
-		Steps:               bas.Steps.Copy(),
+		FriendlyName:         bas.FriendlyName,
+		ScopeId:              bas.ScopeId,
+		AsReference:          bas.AsReference,
+		AsTypeOf:             bas.AsTypeOf.Copy(),
+		BodyAsData:           bas.BodyAsData,
+		InferBody:            bas.InferBody,
+		DependentBodyAsData:  bas.DependentBodyAsData,
+		InferDependentBody:   bas.InferDependentBody,
+		DependentBodySelfRef: bas.DependentBodySelfRef,
+		Steps:                bas.Steps.Copy(),
 	}
 
 	return newBas

--- a/schema/block_schema.go
+++ b/schema/block_schema.go
@@ -70,7 +70,14 @@ type BlockAddrSchema struct {
 	// and their addresses inferred as data
 	InferDependentBody bool
 
-	// DependentBodySelfRef TODO
+	// DependentBodySelfRef instructs collection of reference
+	// targets with an additional self.* LocalAddr and
+	// makes those targetable by origins within the block body
+	// via reference.Target.TargetableFromRangePtr.
+	//
+	// The targetting (matching w/ origins) is further limited by
+	// BodySchema.Extensions.SelfRef, where only self.* origins
+	// within a body w/ SelfRef:true will be collected.
 	DependentBodySelfRef bool
 }
 

--- a/schema/body_schema.go
+++ b/schema/body_schema.go
@@ -54,6 +54,7 @@ type BodyExtensions struct {
 	Count         bool // count attribute + count.index refs
 	ForEach       bool // for_each attribute + each.* refs
 	DynamicBlocks bool // dynamic "block-name" w/ content & for_each inside
+	SelfRefs      bool // self.* refs
 }
 
 func (be *BodyExtensions) Copy() *BodyExtensions {
@@ -65,6 +66,7 @@ func (be *BodyExtensions) Copy() *BodyExtensions {
 		Count:         be.Count,
 		ForEach:       be.ForEach,
 		DynamicBlocks: be.DynamicBlocks,
+		SelfRefs:      be.SelfRefs,
 	}
 }
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -33,6 +33,16 @@ func ActiveForEachFromContext(ctx context.Context) bool {
 	return ctx.Value(bodyActiveForEachCtxKey{}) != nil
 }
 
+type bodyActiveSelfRefsCtxKey struct{}
+
+func WithActiveSelfRefs(ctx context.Context) context.Context {
+	return context.WithValue(ctx, bodyActiveSelfRefsCtxKey{}, true)
+}
+
+func ActiveSelfRefsFromContext(ctx context.Context) bool {
+	return ctx.Value(bodyActiveSelfRefsCtxKey{}) != nil
+}
+
 type bodyActiveDynamicBlockCtxKey struct{}
 
 func WithActiveDynamicBlock(ctx context.Context) context.Context {


### PR DESCRIPTION
## TODO

Reference Matching Logic:

 - [x] fix panic when trying to shorten a local reference - @radeksimko 
 - [x] fix mismatch of global nested target with local address set - @radeksimko 

Completion:

 - [x] fix broken `count.index` completion - @dbanck 

Self References:
 - [x] Filter invalid self during origin collection
 - [x] Fix broken references output
 - [x] Use localAddr for hover
 - [x] Use localAddr for autocompletion
 - [x] Use localAddr for semantic tokens
 - [x] Refactoring to use collected origins
   - [x] for hover
   - [x] for semantic tokens
 - [ ] Add more tests