### PR TITLE
Add support for local reference targets

### DIFF
--- a/decoder/hover.go
+++ b/decoder/hover.go
@@ -638,7 +638,7 @@ func (d *PathDecoder) hoverContentForTraversalExpr(traversal hcl.Traversal, tes 
 		return "", nil
 	}
 
-	targets, ok := d.pathCtx.ReferenceTargets.Match(origin.Address(), origin.OriginConstraints())
+	targets, ok := d.pathCtx.ReferenceTargets.Match(origin)
 	if !ok {
 		return "", &reference.NoTargetFound{}
 	}
@@ -648,7 +648,7 @@ func (d *PathDecoder) hoverContentForTraversalExpr(traversal hcl.Traversal, tes 
 }
 
 func hoverContentForReferenceTarget(ref reference.Target) (string, error) {
-	content := fmt.Sprintf("`%s`", ref.Addr.String())
+	content := fmt.Sprintf("`%s`", ref.Address())
 
 	var friendlyName string
 	if ref.Type != cty.NilType {

--- a/decoder/reference_targets.go
+++ b/decoder/reference_targets.go
@@ -55,7 +55,7 @@ func (d *Decoder) ReferenceTargetsForOriginAtPos(path lang.Path, file string, po
 		if !ok {
 			continue
 		}
-		targets, ok := targetCtx.ReferenceTargets.Match(matchableOrigin.Address(), matchableOrigin.OriginConstraints())
+		targets, ok := targetCtx.ReferenceTargets.Match(matchableOrigin)
 		if !ok {
 			// target not found
 			continue

--- a/decoder/semantic_tokens.go
+++ b/decoder/semantic_tokens.go
@@ -207,7 +207,7 @@ func (d *PathDecoder) tokensForExpression(ctx context.Context, expr hclsyntax.Ex
 				return tokens
 			}
 
-			_, targetFound := d.pathCtx.ReferenceTargets.Match(origin.Address(), origin.OriginConstraints())
+			_, targetFound := d.pathCtx.ReferenceTargets.Match(origin)
 			if !targetFound {
 				return tokens
 			}

--- a/lang/address.go
+++ b/lang/address.go
@@ -9,6 +9,13 @@ import (
 type Address []AddressStep
 
 func (a Address) Equals(addr Address) bool {
+	// Empty address may come up in context where there are
+	// two addresses for the same target and only is declared
+	// (LocalAddr / Addr) in which case we don't want the empty
+	// one to be treated as a match.
+	if len(a) == 0 && len(addr) == 0 {
+		return false
+	}
 	if len(a) != len(addr) {
 		return false
 	}

--- a/reference/origins.go
+++ b/reference/origins.go
@@ -37,11 +37,11 @@ func (ro Origins) Match(localPath lang.Path, target Target, targetPath lang.Path
 	for _, refOrigin := range ro {
 		switch origin := refOrigin.(type) {
 		case LocalOrigin:
-			if localPath.Equals(targetPath) && target.Matches(origin.Address(), origin.OriginConstraints()) {
+			if localPath.Equals(targetPath) && target.Matches(origin) {
 				origins = append(origins, refOrigin)
 			}
 		case PathOrigin:
-			if origin.TargetPath.Equals(targetPath) && target.Matches(origin.Address(), origin.OriginConstraints()) {
+			if origin.TargetPath.Equals(targetPath) && target.Matches(origin) {
 				origins = append(origins, refOrigin)
 			}
 		}


### PR DESCRIPTION
This PR intended to be no-op for the end-user.

It introduces the concept of "local references", which can be utilised for `count.index`, `each.*` and `self.*` references, as drafted within https://github.com/hashicorp/hcl-lang/pull/149

While there are tests attached, there is no code actually collecting such local targets - that is left for follow-up PRs which can be made out of the linked PR.

It also leaves out the question of rendering such reference targets. Now that there can be two ways of referring to the same target, there can be some contexts where it is appropriate to use one address over the other, and vice versa. I could not find any way to solve that problem in an abstract sense which would work for all three use cases. So I left this for the follow-up PRs. I did however leave TODOs in a few places where it is likely this problem will need to be addressed + I introduced an `Address()` method to `reference.Target`, which should essentially "just work" for the simpler cases of `count.index` and `each.*`.
