### PR TITLE
Enable dynamic label completions

### DIFF
--- a/decoder/body_candidates.go
+++ b/decoder/body_candidates.go
@@ -34,10 +34,6 @@ func (d *PathDecoder) bodySchemaCandidates(body *hclsyntax.Body, schema *schema.
 				candidates.List = append(candidates.List, attributeSchemaToCandidate("for_each", forEachAttributeSchema(), editRng))
 			}
 		}
-
-		if schema.Extensions.DynamicBlocks {
-			candidates.List = append(candidates.List, d.blockSchemaToCandidate("dynamic", dynamicBlockSchema(), editRng))
-		}
 	}
 
 	if len(schema.Attributes) > 0 {

--- a/decoder/body_extensions_test.go
+++ b/decoder/body_extensions_test.go
@@ -2030,7 +2030,7 @@ resource "aws_elastic_beanstalk_environment" "example" {
 									"foo": {
 										Body: &schema.BodySchema{
 											Attributes: map[string]*schema.AttributeSchema{
-												"thing": &schema.AttributeSchema{
+												"thing": {
 													IsOptional: true,
 													Expr:       schema.LiteralTypeOnly(cty.String),
 												},

--- a/decoder/body_extensions_test.go
+++ b/decoder/body_extensions_test.go
@@ -2075,52 +2075,28 @@ resource "aws_elastic_beanstalk_environment" "example" {
 				},
 			}),
 		},
-		//test that lifecycle is not completed
 		{
-			"dynamic block inner completion lifecycle is not completed",
+			"dynamic block label only completes dependent blocks",
 			&schema.BodySchema{
 				Blocks: map[string]*schema.BlockSchema{
 					"resource": {
 						Labels: []*schema.LabelSchema{
-							{Name: "type", IsDepKey: true}, {Name: "name"},
+							{
+								Name:        "type",
+								IsDepKey:    true,
+								Completable: true,
+							},
+							{Name: "name"},
 						},
 						Body: &schema.BodySchema{
 							Extensions: &schema.BodyExtensions{
 								DynamicBlocks: true,
 							},
 							Blocks: map[string]*schema.BlockSchema{
-								"life_cycle": {
-									Body: &schema.BodySchema{
-										Attributes: map[string]*schema.AttributeSchema{
-											"create_before_destroy": {
-												Expr:       schema.LiteralTypeOnly(cty.Bool),
-												IsOptional: true,
-												Description: lang.Markdown("Whether to reverse the default order of operations (destroy -> create) during apply " +
-													"when the resource requires replacement (cannot be updated in-place)"),
-											},
-											"prevent_destroy": {
-												Expr:       schema.LiteralTypeOnly(cty.Bool),
-												IsOptional: true,
-												Description: lang.Markdown("Whether to prevent accidental destruction of the resource and cause Terraform " +
-													"to reject with an error any plan that would destroy the resource"),
-											},
-											"ignore_changes": {
-												Expr: schema.ExprConstraints{
-													schema.TupleConsExpr{},
-													schema.KeywordExpr{
-														Keyword: "all",
-														Description: lang.Markdown("Ignore all attributes, which means that Terraform can create" +
-															" and destroy the remote object but will never propose updates to it"),
-													},
-												},
-												IsOptional:  true,
-												Description: lang.Markdown("A set of fields (references) of which to ignore changes to, e.g. `tags`"),
-											},
-										},
-									},
+								"lifecycle": {
+									Body: schema.NewBodySchema(),
 								},
 							},
-							Attributes: make(map[string]*schema.AttributeSchema, 0),
 						},
 						DependentBody: map[schema.SchemaKey]*schema.BodySchema{
 							schema.NewSchemaKey(schema.DependencyKeys{
@@ -2133,101 +2109,34 @@ resource "aws_elastic_beanstalk_environment" "example" {
 										Body: schema.NewBodySchema(),
 									},
 								},
-								Attributes: map[string]*schema.AttributeSchema{
-									"instance_size": {
-										IsOptional: true,
-										Expr:       schema.LiteralTypeOnly(cty.String),
-									},
-								},
 							},
 						},
 					},
 				},
 			},
 			`resource "aws_instance" "example" {
-	name = "example"
-	dynamic "foo" {
-		
-	}
+  name = "example"
+  dynamic "" {
+    
+  }
 }`,
-			hcl.Pos{Line: 4, Column: 5, Byte: 73},
+			hcl.Pos{Line: 3, Column: 12, Byte: 66},
 			lang.CompleteCandidates([]lang.Candidate{
 				{
-					Label: "content",
-					Description: lang.MarkupContent{
-						Value: "The body of each generated block",
-						Kind:  lang.PlainTextKind,
-					},
-					Detail: "Block, max: 1",
-					Kind:   lang.BlockCandidateKind,
+					Label: "foo",
+					Kind:  lang.LabelCandidateKind,
 					TextEdit: lang.TextEdit{
 						Range: hcl.Range{
 							Filename: "test.tf",
-							Start:    hcl.Pos{Line: 4, Column: 5, Byte: 73},
-							End:      hcl.Pos{Line: 4, Column: 5, Byte: 73},
+							Start:    hcl.Pos{Line: 3, Column: 12, Byte: 66},
+							End:      hcl.Pos{Line: 3, Column: 12, Byte: 66},
 						},
-						NewText: "content",
-						Snippet: "content {\n  ${1}\n}",
-					},
-				},
-				{
-					Label: "for_each",
-					Description: lang.MarkupContent{
-						Value: "A meta-argument that accepts a map or a set of strings, and creates an instance for each item in that map or set.\n\n**Note**: A given block cannot use both `count` and `for_each`.",
-						Kind:  lang.MarkdownKind,
-					},
-					Detail:         "required, map of any single type or set of string",
-					Kind:           lang.AttributeCandidateKind,
-					TriggerSuggest: true,
-					TextEdit: lang.TextEdit{
-						Range: hcl.Range{
-							Filename: "test.tf",
-							Start:    hcl.Pos{Line: 4, Column: 5, Byte: 73},
-							End:      hcl.Pos{Line: 4, Column: 5, Byte: 73},
-						},
-						NewText: "for_each",
-						Snippet: "for_each = ",
-					},
-				},
-				{
-					Label: "iterator",
-					Description: lang.MarkupContent{
-						Value: "The name of a temporary variable that represents the current element of the complex value. Defaults to the label of the dynamic block.",
-						Kind:  lang.MarkdownKind,
-					},
-					Detail: "optional, string",
-					Kind:   lang.AttributeCandidateKind,
-					TextEdit: lang.TextEdit{
-						Range: hcl.Range{
-							Filename: "test.tf",
-							Start:    hcl.Pos{Line: 4, Column: 5, Byte: 73},
-							End:      hcl.Pos{Line: 4, Column: 5, Byte: 73},
-						},
-						NewText: "iterator",
-						Snippet: `iterator = "${1:value}"`,
-					},
-				},
-				{
-					Label: "labels",
-					Description: lang.MarkupContent{
-						Value: "A list of strings that specifies the block labels, in order, to use for each generated block.",
-						Kind:  lang.MarkdownKind,
-					},
-					Detail: "optional, list of string",
-					Kind:   lang.AttributeCandidateKind,
-					TextEdit: lang.TextEdit{
-						Range: hcl.Range{
-							Filename: "test.tf",
-							Start:    hcl.Pos{Line: 4, Column: 5, Byte: 73},
-							End:      hcl.Pos{Line: 4, Column: 5, Byte: 73},
-						},
-						NewText: "labels",
-						Snippet: "labels = [\n  ${0}\n]",
+						NewText: "foo",
+						Snippet: "foo",
 					},
 				},
 			}),
 		},
-
 		// completion nesting should work
 		{
 			"dynamic block completion nesting should work",
@@ -2254,7 +2163,9 @@ resource "aws_elastic_beanstalk_environment" "example" {
 									"foo": {
 										Body: &schema.BodySchema{
 											Blocks: map[string]*schema.BlockSchema{
-												"bar": {},
+												"bar": {
+													Body: schema.NewBodySchema(),
+												},
 											},
 											Attributes: map[string]*schema.AttributeSchema{
 												"thing": {
@@ -2301,6 +2212,25 @@ resource "aws_elastic_beanstalk_environment" "example" {
 					},
 				},
 				{
+					Label: "dynamic",
+					Description: lang.MarkupContent{
+						Value: "A dynamic block to produce blocks dynamically by iterating over a given complex value",
+						Kind:  lang.MarkdownKind,
+					},
+					Detail:         "Block, map",
+					Kind:           lang.BlockCandidateKind,
+					TriggerSuggest: true,
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 5, Column: 7, Byte: 86},
+							End:      hcl.Pos{Line: 5, Column: 7, Byte: 86},
+						},
+						NewText: "dynamic",
+						Snippet: "dynamic \"${1}\" {\n  ${2}\n}",
+					},
+				},
+				{
 					Label:  "thing",
 					Detail: "optional, string",
 					Kind:   lang.AttributeCandidateKind,
@@ -2312,20 +2242,6 @@ resource "aws_elastic_beanstalk_environment" "example" {
 						},
 						NewText: "thing",
 						Snippet: `thing = "${1:value}"`,
-					},
-				},
-				{
-					Label:  "dynamic",
-					Detail: "Block",
-					Kind:   lang.BlockCandidateKind,
-					TextEdit: lang.TextEdit{
-						Range: hcl.Range{
-							Filename: "test.tf",
-							Start:    hcl.Pos{Line: 4, Column: 7, Byte: 86},
-							End:      hcl.Pos{Line: 4, Column: 7, Byte: 86},
-						},
-						NewText: "dynamic",
-						Snippet: "dynamic {\n  ${1}\n}",
 					},
 				},
 			}),
@@ -2418,7 +2334,7 @@ resource "aws_elastic_beanstalk_environment" "example" {
 				},
 			}),
 		},
-		// check allows more than one dynamic - what schema for this?
+		// check allows more than one dynamic
 		{
 			"allows more than one dynamic",
 			&schema.BodySchema{
@@ -2494,8 +2410,9 @@ resource "aws_elastic_beanstalk_environment" "example" {
 				},
 			}),
 		},
+		// allows dynamic blocks in blocks
 		{
-			"allows more nested dynamic",
+			"allows dynamic blocks in blocks",
 			&schema.BodySchema{
 				Blocks: map[string]*schema.BlockSchema{
 					"resource": {
@@ -2546,39 +2463,102 @@ resource "aws_elastic_beanstalk_environment" "example" {
 			hcl.Pos{Line: 4, Column: 5, Byte: 63},
 			lang.CompleteCandidates([]lang.Candidate{
 				{
-					Label: "bar",
-					Description: lang.MarkupContent{
-						Value: "The body of each generated block",
-						Kind:  lang.PlainTextKind,
-					},
-					Detail: "Block, max: 1",
+					Label:  "bar",
+					Detail: "Block",
 					Kind:   lang.BlockCandidateKind,
 					TextEdit: lang.TextEdit{
 						Range: hcl.Range{
 							Filename: "test.tf",
-							Start:    hcl.Pos{Line: 6, Column: 3, Byte: 78},
-							End:      hcl.Pos{Line: 6, Column: 3, Byte: 78},
+							Start:    hcl.Pos{Line: 4, Column: 5, Byte: 63},
+							End:      hcl.Pos{Line: 4, Column: 5, Byte: 63},
 						},
-						NewText: "dynamic",
-						Snippet: "dynamic \"${1}\" {\n  ${2}\n}",
+						NewText: "bar",
+						Snippet: "bar {\n  ${1}\n}",
 					},
 				},
 				{
 					Label: "dynamic",
 					Description: lang.MarkupContent{
-						Value: "The body of each generated block",
-						Kind:  lang.PlainTextKind,
+						Value: "A dynamic block to produce blocks dynamically by iterating over a given complex value",
+						Kind:  lang.MarkdownKind,
 					},
-					Detail: "Block, max: 1",
-					Kind:   lang.BlockCandidateKind,
+					Detail:         "Block, map",
+					Kind:           lang.BlockCandidateKind,
+					TriggerSuggest: true,
 					TextEdit: lang.TextEdit{
 						Range: hcl.Range{
 							Filename: "test.tf",
-							Start:    hcl.Pos{Line: 6, Column: 3, Byte: 78},
-							End:      hcl.Pos{Line: 6, Column: 3, Byte: 78},
+							Start:    hcl.Pos{Line: 4, Column: 5, Byte: 63},
+							End:      hcl.Pos{Line: 4, Column: 5, Byte: 63},
 						},
 						NewText: "dynamic",
 						Snippet: "dynamic \"${1}\" {\n  ${2}\n}",
+					},
+				},
+			}),
+		},
+		// never complete dynamic as a dynamic label
+		{
+			"never complete dynamic as a dynamic label",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource": {
+						Labels: []*schema.LabelSchema{
+							{
+								Name:        "type",
+								IsDepKey:    true,
+								Completable: true,
+							},
+							{Name: "name"},
+						},
+						Body: &schema.BodySchema{
+							Extensions: &schema.BodyExtensions{
+								DynamicBlocks: true,
+							},
+							Blocks: make(map[string]*schema.BlockSchema, 0),
+						},
+						DependentBody: map[schema.SchemaKey]*schema.BodySchema{
+							schema.NewSchemaKey(schema.DependencyKeys{
+								Labels: []schema.LabelDependent{
+									{Index: 0, Value: "aws_instance"},
+								},
+							}): {
+								Blocks: map[string]*schema.BlockSchema{
+									"foo": {
+										Body: &schema.BodySchema{
+											Blocks: map[string]*schema.BlockSchema{
+												"bar": {
+													Body: schema.NewBodySchema(),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			`resource "aws_instance" "example" {
+  foo {
+    dynamic "" {
+      
+    }
+  }
+}`,
+			hcl.Pos{Line: 3, Column: 14, Byte: 57},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label: "bar",
+					Kind:  lang.LabelCandidateKind,
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 3, Column: 14, Byte: 57},
+							End:      hcl.Pos{Line: 3, Column: 14, Byte: 57},
+						},
+						NewText: "bar",
+						Snippet: "bar",
 					},
 				},
 			}),
@@ -2596,6 +2576,11 @@ resource "aws_elastic_beanstalk_environment" "example" {
 				},
 			})
 
+			// We're triggering completion twice her, to cover any unintended side effects
+			_, err := d.CandidatesAtPos(ctx, "test.tf", tc.pos)
+			if err != nil {
+				t.Fatal(err)
+			}
 			candidates, err := d.CandidatesAtPos(ctx, "test.tf", tc.pos)
 			if err != nil {
 				t.Fatal(err)

--- a/decoder/body_extensions_test.go
+++ b/decoder/body_extensions_test.go
@@ -2076,10 +2076,513 @@ resource "aws_elastic_beanstalk_environment" "example" {
 			}),
 		},
 		//test that lifecycle is not completed
+		{
+			"dynamic block inner completion lifecycle is not completed",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource": {
+						Labels: []*schema.LabelSchema{
+							{Name: "type", IsDepKey: true}, {Name: "name"},
+						},
+						Body: &schema.BodySchema{
+							Extensions: &schema.BodyExtensions{
+								DynamicBlocks: true,
+							},
+							Blocks: map[string]*schema.BlockSchema{
+								"life_cycle": {
+									Body: &schema.BodySchema{
+										Attributes: map[string]*schema.AttributeSchema{
+											"create_before_destroy": {
+												Expr:       schema.LiteralTypeOnly(cty.Bool),
+												IsOptional: true,
+												Description: lang.Markdown("Whether to reverse the default order of operations (destroy -> create) during apply " +
+													"when the resource requires replacement (cannot be updated in-place)"),
+											},
+											"prevent_destroy": {
+												Expr:       schema.LiteralTypeOnly(cty.Bool),
+												IsOptional: true,
+												Description: lang.Markdown("Whether to prevent accidental destruction of the resource and cause Terraform " +
+													"to reject with an error any plan that would destroy the resource"),
+											},
+											"ignore_changes": {
+												Expr: schema.ExprConstraints{
+													schema.TupleConsExpr{},
+													schema.KeywordExpr{
+														Keyword: "all",
+														Description: lang.Markdown("Ignore all attributes, which means that Terraform can create" +
+															" and destroy the remote object but will never propose updates to it"),
+													},
+												},
+												IsOptional:  true,
+												Description: lang.Markdown("A set of fields (references) of which to ignore changes to, e.g. `tags`"),
+											},
+										},
+									},
+								},
+							},
+							Attributes: make(map[string]*schema.AttributeSchema, 0),
+						},
+						DependentBody: map[schema.SchemaKey]*schema.BodySchema{
+							schema.NewSchemaKey(schema.DependencyKeys{
+								Labels: []schema.LabelDependent{
+									{Index: 0, Value: "aws_instance"},
+								},
+							}): {
+								Blocks: map[string]*schema.BlockSchema{
+									"foo": {
+										Body: schema.NewBodySchema(),
+									},
+								},
+								Attributes: map[string]*schema.AttributeSchema{
+									"instance_size": {
+										IsOptional: true,
+										Expr:       schema.LiteralTypeOnly(cty.String),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			`resource "aws_instance" "example" {
+	name = "example"
+	dynamic "foo" {
+		
+	}
+}`,
+			hcl.Pos{Line: 4, Column: 5, Byte: 73},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label: "content",
+					Description: lang.MarkupContent{
+						Value: "The body of each generated block",
+						Kind:  lang.PlainTextKind,
+					},
+					Detail: "Block, max: 1",
+					Kind:   lang.BlockCandidateKind,
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 4, Column: 5, Byte: 73},
+							End:      hcl.Pos{Line: 4, Column: 5, Byte: 73},
+						},
+						NewText: "content",
+						Snippet: "content {\n  ${1}\n}",
+					},
+				},
+				{
+					Label: "for_each",
+					Description: lang.MarkupContent{
+						Value: "A meta-argument that accepts a map or a set of strings, and creates an instance for each item in that map or set.\n\n**Note**: A given block cannot use both `count` and `for_each`.",
+						Kind:  lang.MarkdownKind,
+					},
+					Detail:         "required, map of any single type or set of string",
+					Kind:           lang.AttributeCandidateKind,
+					TriggerSuggest: true,
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 4, Column: 5, Byte: 73},
+							End:      hcl.Pos{Line: 4, Column: 5, Byte: 73},
+						},
+						NewText: "for_each",
+						Snippet: "for_each = ",
+					},
+				},
+				{
+					Label: "iterator",
+					Description: lang.MarkupContent{
+						Value: "The name of a temporary variable that represents the current element of the complex value. Defaults to the label of the dynamic block.",
+						Kind:  lang.MarkdownKind,
+					},
+					Detail: "optional, string",
+					Kind:   lang.AttributeCandidateKind,
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 4, Column: 5, Byte: 73},
+							End:      hcl.Pos{Line: 4, Column: 5, Byte: 73},
+						},
+						NewText: "iterator",
+						Snippet: `iterator = "${1:value}"`,
+					},
+				},
+				{
+					Label: "labels",
+					Description: lang.MarkupContent{
+						Value: "A list of strings that specifies the block labels, in order, to use for each generated block.",
+						Kind:  lang.MarkdownKind,
+					},
+					Detail: "optional, list of string",
+					Kind:   lang.AttributeCandidateKind,
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 4, Column: 5, Byte: 73},
+							End:      hcl.Pos{Line: 4, Column: 5, Byte: 73},
+						},
+						NewText: "labels",
+						Snippet: "labels = [\n  ${0}\n]",
+					},
+				},
+			}),
+		},
 
+		// completion nesting should work
+		{
+			"dynamic block completion nesting should work",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource": {
+						Labels: []*schema.LabelSchema{
+							{Name: "type", IsDepKey: true}, {Name: "name"},
+						},
+						Body: &schema.BodySchema{
+							Extensions: &schema.BodyExtensions{
+								DynamicBlocks: true,
+							},
+							Blocks:     make(map[string]*schema.BlockSchema, 0),
+							Attributes: make(map[string]*schema.AttributeSchema, 0),
+						},
+						DependentBody: map[schema.SchemaKey]*schema.BodySchema{
+							schema.NewSchemaKey(schema.DependencyKeys{
+								Labels: []schema.LabelDependent{
+									{Index: 0, Value: "aws_instance"},
+								},
+							}): {
+								Blocks: map[string]*schema.BlockSchema{
+									"foo": {
+										Body: &schema.BodySchema{
+											Blocks: map[string]*schema.BlockSchema{
+												"bar": {},
+											},
+											Attributes: map[string]*schema.AttributeSchema{
+												"thing": {
+													IsOptional: true,
+													Expr:       schema.LiteralTypeOnly(cty.String),
+												},
+											},
+										},
+									},
+								},
+								Attributes: map[string]*schema.AttributeSchema{
+									"instance_size": {
+										IsOptional: true,
+										Expr:       schema.LiteralTypeOnly(cty.String),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			`resource "aws_instance" "example" {
+	name = "example"
+	dynamic "foo" {
+		content {
+			
+		}
+	}
+}`,
+			hcl.Pos{Line: 5, Column: 7, Byte: 86},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "bar",
+					Detail: "Block",
+					Kind:   lang.BlockCandidateKind,
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 5, Column: 7, Byte: 86},
+							End:      hcl.Pos{Line: 5, Column: 7, Byte: 86},
+						},
+						NewText: "bar",
+						Snippet: "bar {\n  ${1}\n}",
+					},
+				},
+				{
+					Label:  "thing",
+					Detail: "optional, string",
+					Kind:   lang.AttributeCandidateKind,
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 5, Column: 7, Byte: 86},
+							End:      hcl.Pos{Line: 5, Column: 7, Byte: 86},
+						},
+						NewText: "thing",
+						Snippet: `thing = "${1:value}"`,
+					},
+				},
+				{
+					Label:  "dynamic",
+					Detail: "Block",
+					Kind:   lang.BlockCandidateKind,
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 4, Column: 7, Byte: 86},
+							End:      hcl.Pos{Line: 4, Column: 7, Byte: 86},
+						},
+						NewText: "dynamic",
+						Snippet: "dynamic {\n  ${1}\n}",
+					},
+				},
+			}),
+		},
 		// completion after the thing =
-
-		// check docs if nesting is supposed to be supported?
+		{
+			"dynamic block completion after the thing =",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource": {
+						Labels: []*schema.LabelSchema{
+							{
+								Name:     "type",
+								IsDepKey: true,
+							}, {Name: "name"},
+						},
+						Body: &schema.BodySchema{
+							Extensions: &schema.BodyExtensions{
+								DynamicBlocks: true,
+							},
+							Blocks:     make(map[string]*schema.BlockSchema, 0),
+							Attributes: make(map[string]*schema.AttributeSchema, 0),
+						},
+						DependentBody: map[schema.SchemaKey]*schema.BodySchema{
+							schema.NewSchemaKey(schema.DependencyKeys{
+								Labels: []schema.LabelDependent{
+									{Index: 0, Value: "aws_instance"},
+								},
+							}): {
+								Blocks: map[string]*schema.BlockSchema{
+									"foo": {
+										Body: &schema.BodySchema{
+											Attributes: map[string]*schema.AttributeSchema{
+												"thing": {
+													IsOptional: true,
+													Expr:       schema.LiteralTypeOnly(cty.Bool),
+												},
+											},
+										},
+									},
+								},
+								Attributes: map[string]*schema.AttributeSchema{
+									"instance_size": {
+										IsOptional: true,
+										Expr:       schema.LiteralTypeOnly(cty.String),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			`resource "aws_instance" "example" {
+	name = "example"
+	dynamic "foo" {
+		content {
+			thing = 
+		}
+	}
+}`,
+			hcl.Pos{Line: 5, Column: 15, Byte: 94},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "true",
+					Detail: "bool",
+					Kind:   lang.BoolCandidateKind,
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 5, Column: 12, Byte: 94},
+							End:      hcl.Pos{Line: 5, Column: 12, Byte: 94},
+						},
+						NewText: "true",
+						Snippet: `${1:true}`,
+					},
+				},
+				{
+					Label:  "false",
+					Detail: "bool",
+					Kind:   lang.BoolCandidateKind,
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 5, Column: 12, Byte: 94},
+							End:      hcl.Pos{Line: 5, Column: 12, Byte: 94},
+						},
+						NewText: "false",
+						Snippet: `${1:false}`,
+					},
+				},
+			}),
+		},
+		// check allows more than one dynamic - what schema for this?
+		{
+			"allows more than one dynamic",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource": {
+						Labels: []*schema.LabelSchema{
+							{Name: "type", IsDepKey: true}, {Name: "name"},
+						},
+						Body: &schema.BodySchema{
+							Extensions: &schema.BodyExtensions{
+								DynamicBlocks: true,
+							},
+							Blocks:     make(map[string]*schema.BlockSchema, 0),
+							Attributes: make(map[string]*schema.AttributeSchema, 0),
+						},
+						DependentBody: map[schema.SchemaKey]*schema.BodySchema{
+							schema.NewSchemaKey(schema.DependencyKeys{
+								Labels: []schema.LabelDependent{
+									{Index: 0, Value: "aws_instance"},
+								},
+							}): {
+								Blocks: map[string]*schema.BlockSchema{
+									"foo": {
+										Body: schema.NewBodySchema(),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			`resource "aws_instance" "example" {
+	name = "example"
+	dynamic "foo" {
+		
+	}
+	
+}`,
+			hcl.Pos{Line: 6, Column: 3, Byte: 78},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label: "dynamic",
+					Description: lang.MarkupContent{
+						Value: "A dynamic block to produce blocks dynamically by iterating over a given complex value",
+						Kind:  lang.MarkdownKind,
+					},
+					Detail:         "Block, map",
+					Kind:           lang.BlockCandidateKind,
+					TriggerSuggest: true,
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 6, Column: 3, Byte: 78},
+							End:      hcl.Pos{Line: 6, Column: 3, Byte: 78},
+						},
+						NewText: "dynamic",
+						Snippet: "dynamic \"${1}\" {\n  ${2}\n}",
+					},
+				},
+				{
+					Label:  "foo",
+					Detail: "Block",
+					Kind:   lang.BlockCandidateKind,
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 6, Column: 3, Byte: 78},
+							End:      hcl.Pos{Line: 6, Column: 3, Byte: 78},
+						},
+						NewText: "foo",
+						Snippet: "foo {\n  ${1}\n}",
+					},
+				},
+			}),
+		},
+		{
+			"allows more nested dynamic",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource": {
+						Labels: []*schema.LabelSchema{
+							{Name: "type", IsDepKey: true}, {Name: "name"},
+						},
+						Body: &schema.BodySchema{
+							Extensions: &schema.BodyExtensions{
+								DynamicBlocks: true,
+							},
+							Blocks:     make(map[string]*schema.BlockSchema, 0),
+							Attributes: make(map[string]*schema.AttributeSchema, 0),
+						},
+						DependentBody: map[schema.SchemaKey]*schema.BodySchema{
+							schema.NewSchemaKey(schema.DependencyKeys{
+								Labels: []schema.LabelDependent{
+									{Index: 0, Value: "aws_instance"},
+								},
+							}): {
+								Blocks: map[string]*schema.BlockSchema{
+									"foo": {
+										Body: &schema.BodySchema{
+											Blocks: map[string]*schema.BlockSchema{
+												"bar": {
+													Body: schema.NewBodySchema(),
+												},
+											},
+										},
+									},
+								},
+								Attributes: map[string]*schema.AttributeSchema{
+									"instance_size": {
+										IsOptional: true,
+										Expr:       schema.LiteralTypeOnly(cty.String),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			`resource "aws_instance" "example" {
+	name = "example"
+	foo {
+		
+	}	
+}`,
+			hcl.Pos{Line: 4, Column: 5, Byte: 63},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label: "bar",
+					Description: lang.MarkupContent{
+						Value: "The body of each generated block",
+						Kind:  lang.PlainTextKind,
+					},
+					Detail: "Block, max: 1",
+					Kind:   lang.BlockCandidateKind,
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 6, Column: 3, Byte: 78},
+							End:      hcl.Pos{Line: 6, Column: 3, Byte: 78},
+						},
+						NewText: "dynamic",
+						Snippet: "dynamic \"${1}\" {\n  ${2}\n}",
+					},
+				},
+				{
+					Label: "dynamic",
+					Description: lang.MarkupContent{
+						Value: "The body of each generated block",
+						Kind:  lang.PlainTextKind,
+					},
+					Detail: "Block, max: 1",
+					Kind:   lang.BlockCandidateKind,
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 6, Column: 3, Byte: 78},
+							End:      hcl.Pos{Line: 6, Column: 3, Byte: 78},
+						},
+						NewText: "dynamic",
+						Snippet: "dynamic \"${1}\" {\n  ${2}\n}",
+					},
+				},
+			}),
+		},
 	}
 
 	for i, tc := range testCases {

--- a/decoder/candidates.go
+++ b/decoder/candidates.go
@@ -160,26 +160,9 @@ func (d *PathDecoder) candidatesAtPos(ctx context.Context, body *hclsyntax.Body,
 				if bSchema.Body != nil && bSchema.Body.Extensions != nil && bSchema.Body.Extensions.DynamicBlocks {
 					depSchema, _, ok := NewBlockSchema(bSchema).DependentBodySchema(block.AsHCLBlock())
 					if ok && len(depSchema.Blocks) > 0 {
-						dynamicBlockSchema := buildDynamicBlockSchema()
-						dynamicBlockDependentBody := make(map[schema.SchemaKey]*schema.BodySchema)
-						for blockName, block := range depSchema.Blocks {
-							dynamicBlockDependentBody[schema.NewSchemaKey(schema.DependencyKeys{
-								Labels: []schema.LabelDependent{
-									{Index: 0, Value: blockName},
-								},
-							})] = &schema.BodySchema{
-								Blocks: map[string]*schema.BlockSchema{
-									"content": {
-										Description: lang.PlainText("The body of each generated block"),
-										MaxItems:    1,
-										Body:        block.Body,
-									},
-								},
-							}
-						}
-
-						dynamicBlockSchema.DependentBody = dynamicBlockDependentBody
-						bSchema.Body.Blocks["dynamic"] = dynamicBlockSchema
+						bSchema.Body.Blocks["dynamic"] = buildDynamicBlockSchema(depSchema)
+					} else if !ok && len(bSchema.Body.Blocks) > 0 {
+						bSchema.Body.Blocks["dynamic"] = buildDynamicBlockSchema(bSchema.Body)
 					}
 				}
 

--- a/decoder/candidates.go
+++ b/decoder/candidates.go
@@ -62,10 +62,6 @@ func (d *PathDecoder) candidatesAtPos(ctx context.Context, body *hclsyntax.Body,
 				ctx = schema.WithActiveForEach(ctx)
 			}
 		}
-
-		if bodySchema.Extensions.DynamicBlocks {
-			ctx = schema.WithActiveDynamicBlock(ctx)
-		}
 	}
 
 	for _, attr := range body.Attributes {

--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -200,12 +200,16 @@ func forEachAttributeSchema() *schema.AttributeSchema {
 	}
 }
 
-func dynamicBlockSchema() *schema.BlockSchema {
+func buildDynamicBlockSchema() *schema.BlockSchema {
 	return &schema.BlockSchema{
 		Description: lang.Markdown("A dynamic block to produce blocks dynamically by iterating over a given complex value"),
 		Type:        schema.BlockTypeMap,
 		Labels: []*schema.LabelSchema{
-			{Name: "name"},
+			{
+				Name:        "name",
+				Completable: true,
+				IsDepKey:    true,
+			},
 		},
 		Body: &schema.BodySchema{
 			Attributes: map[string]*schema.AttributeSchema{
@@ -238,12 +242,6 @@ func dynamicBlockSchema() *schema.BlockSchema {
 					IsOptional: true,
 					Description: lang.Markdown("A list of strings that specifies the block labels, " +
 						"in order, to use for each generated block."),
-				},
-			},
-			Blocks: map[string]*schema.BlockSchema{
-				"content": {
-					Description: lang.PlainText("The body of each generated block"),
-					MaxItems:    1,
 				},
 			},
 		},

--- a/decoder/hover.go
+++ b/decoder/hover.go
@@ -55,10 +55,6 @@ func (d *PathDecoder) hoverAtPos(ctx context.Context, body *hclsyntax.Body, body
 		if bodySchema.Extensions.ForEach {
 			ctx = schema.WithActiveForEach(ctx)
 		}
-
-		if bodySchema.Extensions.DynamicBlocks {
-			ctx = schema.WithActiveDynamicBlock(ctx)
-		}
 	}
 
 	for name, attr := range body.Attributes {

--- a/decoder/hover.go
+++ b/decoder/hover.go
@@ -113,7 +113,7 @@ func (d *PathDecoder) hoverAtPos(ctx context.Context, body *hclsyntax.Body, body
 		if block.Range().ContainsPos(pos) {
 			var bSchema *schema.BlockSchema
 			if bodySchema.Extensions != nil && bodySchema.Extensions.DynamicBlocks && block.Type == "dynamic" {
-				bSchema = dynamicBlockSchema()
+				bSchema = buildDynamicBlockSchema()
 			} else {
 				var ok bool
 				bSchema, ok = bodySchema.Blocks[block.Type]

--- a/decoder/semantic_tokens.go
+++ b/decoder/semantic_tokens.go
@@ -63,10 +63,6 @@ func (d *PathDecoder) tokensForBody(ctx context.Context, body *hclsyntax.Body, b
 			// append to context we need count provided
 			ctx = schema.WithActiveForEach(ctx)
 		}
-
-		if bodySchema.Extensions.DynamicBlocks {
-			ctx = schema.WithActiveDynamicBlock(ctx)
-		}
 	}
 
 	for name, attr := range body.Attributes {

--- a/decoder/semantic_tokens.go
+++ b/decoder/semantic_tokens.go
@@ -103,7 +103,7 @@ func (d *PathDecoder) tokensForBody(ctx context.Context, body *hclsyntax.Body, b
 		blockSchema, ok := bodySchema.Blocks[block.Type]
 		if !ok {
 			if bodySchema.Extensions != nil && bodySchema.Extensions.DynamicBlocks && block.Type == "dynamic" {
-				blockSchema = dynamicBlockSchema()
+				blockSchema = buildDynamicBlockSchema()
 			} else {
 				// unknown block
 				continue

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -42,13 +42,3 @@ func WithActiveSelfRefs(ctx context.Context) context.Context {
 func ActiveSelfRefsFromContext(ctx context.Context) bool {
 	return ctx.Value(bodyActiveSelfRefsCtxKey{}) != nil
 }
-
-type bodyActiveDynamicBlockCtxKey struct{}
-
-func WithActiveDynamicBlock(ctx context.Context) context.Context {
-	return context.WithValue(ctx, bodyActiveDynamicBlockCtxKey{}, true)
-}
-
-func ActiveDynamicBlockFromContext(ctx context.Context) bool {
-	return ctx.Value(bodyActiveDynamicBlockCtxKey{}) != nil
-}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -49,6 +49,6 @@ func WithActiveDynamicBlock(ctx context.Context) context.Context {
 	return context.WithValue(ctx, bodyActiveDynamicBlockCtxKey{}, true)
 }
 
-func ActiveActiveDynamicBlockFromContext(ctx context.Context) bool {
+func ActiveDynamicBlockFromContext(ctx context.Context) bool {
 	return ctx.Value(bodyActiveDynamicBlockCtxKey{}) != nil
 }


### PR DESCRIPTION
This PR enables the next stage for dynamic block completion. Based on the blocks of a dependent body, we can now complete the label for `dynamic` blocks based on the available block names and the block-related attributes in the `content` block. It works for nested blocks, too.

--- 

## UX in Terraform

### Completion
![2022-11-23 12 00 15](https://user-images.githubusercontent.com/45985/203530792-f988e51c-8a2f-4e70-b82c-b57fd8b06e37.gif)

### Hover
![CleanShot 2022-11-23 at 11 58 08](https://user-images.githubusercontent.com/45985/203530715-514d7939-9455-4be5-9093-7edc5b0b262e.png)

In nested blocks
![CleanShot 2022-11-23 at 11 57 56](https://user-images.githubusercontent.com/45985/203530717-25a22843-8ab7-41a9-877c-24a8edfb7f68.png)

### Semantic tokens
![CleanShot 2022-11-23 at 12 02 40](https://user-images.githubusercontent.com/45985/203530904-0187a504-8380-46e7-b468-f75bfcd82451.png)
