### PR TITLE
reference: Fix matching for targets which involve ranges & both addresses

### DIFF
--- a/reference/target.go
+++ b/reference/target.go
@@ -187,10 +187,12 @@ func (target Target) Matches(origin MatchableOrigin) bool {
 		}
 	}
 
-	// Reject origin if it's outside the targetable range
+	// If the target is only targetable from a particular range
+	// we confirm that the origin is within that range.
+	targetRangeMatches := true
 	if target.TargetableFromRangePtr != nil && !rangeOverlaps(*target.TargetableFromRangePtr, origin.OriginRange()) {
-		return false
+		targetRangeMatches = false
 	}
 
-	return (target.LocalAddr.Equals(localOriginAddr) || target.Addr.Equals(originAddr)) && matchesCons
+	return ((target.LocalAddr.Equals(localOriginAddr) && targetRangeMatches) || target.Addr.Equals(originAddr)) && matchesCons
 }

--- a/reference/targets_test.go
+++ b/reference/targets_test.go
@@ -193,6 +193,79 @@ func TestTargets_Match(t *testing.T) {
 			},
 			true,
 		},
+		{
+			"match of global nested target with local addrs set",
+			Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "aws_acmpca_certificate"},
+						lang.AttrStep{Name: "foo"},
+					},
+					LocalAddr: lang.Address{
+						lang.RootStep{Name: "self"},
+					},
+					Type: cty.Object(map[string]cty.Type{
+						"signing_algorithm": cty.String,
+					}),
+					ScopeId: "resource",
+					NestedTargets: Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "aws_acmpca_certificate"},
+								lang.AttrStep{Name: "foo"},
+								lang.AttrStep{Name: "signing_algorithm"},
+							},
+							LocalAddr: lang.Address{
+								lang.RootStep{Name: "self"},
+								lang.AttrStep{Name: "signing_algorithm"},
+							},
+							Type: cty.String,
+							TargetableFromRangePtr: &hcl.Range{
+								Filename: "main.tf",
+								Start:    hcl.Pos{Line: 26, Column: 41, Byte: 360},
+								End:      hcl.Pos{Line: 41, Column: 2, Byte: 657},
+							},
+						},
+					},
+				},
+			},
+			LocalOrigin{
+				Addr: lang.Address{
+					lang.RootStep{Name: "aws_acmpca_certificate"},
+					lang.AttrStep{Name: "foo"},
+					lang.AttrStep{Name: "signing_algorithm"},
+				},
+
+				Constraints: OriginConstraints{
+					{OfType: cty.DynamicPseudoType},
+				},
+				Range: hcl.Range{
+					Filename: "main.tf",
+					Start:    hcl.Pos{Line: 44, Column: 11, Byte: 684},
+					End:      hcl.Pos{Line: 44, Column: 55, Byte: 728},
+				},
+			},
+			Targets{
+				Target{
+					Addr: lang.Address{
+						lang.RootStep{Name: "aws_acmpca_certificate"},
+						lang.AttrStep{Name: "foo"},
+						lang.AttrStep{Name: "signing_algorithm"},
+					},
+					LocalAddr: lang.Address{
+						lang.RootStep{Name: "self"},
+						lang.AttrStep{Name: "signing_algorithm"},
+					},
+					Type: cty.String,
+					TargetableFromRangePtr: &hcl.Range{
+						Filename: "main.tf",
+						Start:    hcl.Pos{Line: 26, Column: 41, Byte: 360},
+						End:      hcl.Pos{Line: 41, Column: 2, Byte: 657},
+					},
+				},
+			},
+			true,
+		},
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {


### PR DESCRIPTION
As the test shows, we'd previously consider `TargetableFromRangePtr` mismatch as complete mismatch, even though the same target could be a match using the absolute address.

Mostly for convenience in test, the implementation treats `TargetableFromRangePtr: nil` as an automatic match, but I can be convinced to change that, if we deem it's a bad idea.