### PR TITLE
reference: Fix panic when trying to shorten origin address

### DIFF
--- a/reference/targets_test.go
+++ b/reference/targets_test.go
@@ -379,6 +379,33 @@ func TestTargets_Match_localRefs(t *testing.T) {
 			},
 			true,
 		},
+		{
+			"local origin and global target",
+			Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "module"},
+						lang.AttrStep{Name: "localmodd"},
+						lang.AttrStep{Name: "someattribute"},
+					},
+					Type: cty.DynamicPseudoType,
+				},
+			},
+			LocalOrigin{
+				Addr: lang.Address{
+					lang.RootStep{Name: "self"},
+					lang.AttrStep{Name: "attribute"},
+				},
+				Constraints: OriginConstraints{
+					{
+						OfScopeId: "",
+						OfType:    cty.String,
+					},
+				},
+			},
+			Targets{},
+			false,
+		},
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {


### PR DESCRIPTION
As the in-line comment explains, previously we'd try to "shorten" the origin address by actually "growing" it.

In theory this could have happened prior to https://github.com/hashicorp/hcl-lang/pull/150 but it apparently never did, or nobody reported it. It would require an origin with less segments than the compared target. In most (all?) cases, the targets have at least 2 segments and so that would require comparison with a single-segment origin, such as `foo`. This was also additionally gated by another condition, which was somewhat naively modified to account for local addresses and that condition is no longer necessary now.