### PR TITLE
reference: refactor & fix matching of cyclical refs

### DIFF
--- a/decoder/expression_candidates.go
+++ b/decoder/expression_candidates.go
@@ -479,12 +479,6 @@ func (d *PathDecoder) candidatesForTraversalConstraint(ctx context.Context, tc s
 	prefix, _ := d.bytesFromRange(prefixRng)
 
 	d.pathCtx.ReferenceTargets.MatchWalk(ctx, tc, string(prefix), outermostBodyRng, editRng, func(target reference.Target) error {
-		// avoid suggesting references to block's own fields from within (for now)
-		// TODO: Reflect LocalAddr here
-		if referenceTargetIsInRange(target, outermostBodyRng) {
-			return nil
-		}
-
 		address := target.Address(ctx).String()
 
 		candidates = append(candidates, lang.Candidate{

--- a/decoder/hover.go
+++ b/decoder/hover.go
@@ -283,7 +283,7 @@ func (d *PathDecoder) hoverDataForExpr(ctx context.Context, expr hcl.Expression,
 
 		tes, ok := constraints.TraversalExprs()
 		if ok {
-			content, err := d.hoverContentForTraversalExpr(e.AsTraversal(), tes, pos)
+			content, err := d.hoverContentForTraversalExpr(ctx, e.AsTraversal(), tes, pos)
 			if err != nil {
 				return nil, err
 			}
@@ -642,7 +642,7 @@ func stringValFromTemplateExpr(tplExpr *hclsyntax.TemplateExpr) (cty.Value, bool
 	return cty.StringVal(value), true
 }
 
-func (d *PathDecoder) hoverContentForTraversalExpr(traversal hcl.Traversal, tes []schema.TraversalExpr, pos hcl.Pos) (string, error) {
+func (d *PathDecoder) hoverContentForTraversalExpr(ctx context.Context, traversal hcl.Traversal, tes []schema.TraversalExpr, pos hcl.Pos) (string, error) {
 	origins, ok := d.pathCtx.ReferenceOrigins.AtPos(traversal.SourceRange().Filename, pos)
 	if !ok {
 		return "", &reference.NoOriginFound{}
@@ -660,14 +660,14 @@ func (d *PathDecoder) hoverContentForTraversalExpr(traversal hcl.Traversal, tes 
 		}
 
 		// TODO: Reflect additional found targets here?
-		return hoverContentForReferenceTarget(targets[0])
+		return hoverContentForReferenceTarget(ctx, targets[0])
 	}
 
 	return "", &reference.NoTargetFound{}
 }
 
-func hoverContentForReferenceTarget(ref reference.Target) (string, error) {
-	content := fmt.Sprintf("`%s`", ref.Address())
+func hoverContentForReferenceTarget(ctx context.Context, ref reference.Target) (string, error) {
+	content := fmt.Sprintf("`%s`", ref.Address(ctx))
 
 	var friendlyName string
 	if ref.Type != cty.NilType {

--- a/reference/target.go
+++ b/reference/target.go
@@ -1,6 +1,8 @@
 package reference
 
 import (
+	"context"
+
 	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
@@ -95,9 +97,8 @@ func copyHclRangePtr(rng *hcl.Range) *hcl.Range {
 }
 
 // Address returns any of the two non-empty addresses
-//
-// TODO: Return address based on context when we have both
-func (r Target) Address() lang.Address {
+// depending on the provided context
+func (r Target) Address(ctx context.Context) lang.Address {
 	addr := r.Addr
 	if len(r.LocalAddr) > 0 {
 		addr = r.LocalAddr

--- a/reference/targets.go
+++ b/reference/targets.go
@@ -1,6 +1,7 @@
 package reference
 
 import (
+	"context"
 	"errors"
 	"strings"
 
@@ -72,7 +73,7 @@ func (w refTargetDeepWalker) walk(refTargets Targets) {
 	}
 }
 
-func (refs Targets) MatchWalk(te schema.TraversalExpr, prefix string, originRng hcl.Range, f TargetWalkFunc) {
+func (refs Targets) MatchWalk(ctx context.Context, te schema.TraversalExpr, prefix string, outermostBodyRng, originRng hcl.Range, f TargetWalkFunc) {
 	for _, ref := range refs {
 		if len(ref.LocalAddr) > 0 && strings.HasPrefix(ref.LocalAddr.String(), prefix) {
 			// Check if origin is inside the targetable range
@@ -91,7 +92,7 @@ func (refs Targets) MatchWalk(te schema.TraversalExpr, prefix string, originRng 
 			}
 		}
 
-		ref.NestedTargets.MatchWalk(te, prefix, originRng, f)
+		ref.NestedTargets.MatchWalk(ctx, te, prefix, outermostBodyRng, originRng, f)
 	}
 }
 

--- a/reference/targets.go
+++ b/reference/targets.go
@@ -75,39 +75,90 @@ func (w refTargetDeepWalker) walk(refTargets Targets) {
 
 func (refs Targets) MatchWalk(ctx context.Context, te schema.TraversalExpr, prefix string, outermostBodyRng, originRng hcl.Range, f TargetWalkFunc) {
 	for _, ref := range refs {
-		if len(ref.LocalAddr) > 0 && strings.HasPrefix(ref.LocalAddr.String(), prefix) {
-			// Check if origin is inside the targetable range
-			if ref.TargetableFromRangePtr == nil || rangeOverlaps(*ref.TargetableFromRangePtr, originRng) {
-				nestedMatches := ref.NestedTargets.containsMatch(te, prefix)
-				if ref.MatchesConstraint(te) || nestedMatches {
-					f(ref)
-				}
-			}
-		}
-		if len(ref.Addr) > 0 && strings.HasPrefix(ref.Addr.String(), prefix) {
-			nestedMatches := ref.NestedTargets.containsMatch(te, prefix)
-			if ref.MatchesConstraint(te) || nestedMatches {
-				f(ref)
-				continue
-			}
+		if localTargetMatches(ctx, ref, te, prefix, outermostBodyRng, originRng) ||
+			absTargetMatches(ctx, ref, te, prefix, outermostBodyRng, originRng) {
+			f(ref)
+			continue
 		}
 
 		ref.NestedTargets.MatchWalk(ctx, te, prefix, outermostBodyRng, originRng, f)
 	}
 }
 
-func (refs Targets) containsMatch(te schema.TraversalExpr, prefix string) bool {
+func localTargetMatches(ctx context.Context, target Target, te schema.TraversalExpr, prefix string, outermostBodyRng, originRng hcl.Range) bool {
+	if len(target.LocalAddr) > 0 && strings.HasPrefix(target.LocalAddr.String(), prefix) {
+		hasNestedMatches := target.NestedTargets.containsMatch(ctx, te, prefix, outermostBodyRng, originRng)
+
+		// Avoid suggesting cyclical reference to the same attribute
+		// unless it has nested matches - i.e. still consider reference
+		// to the outside block/body as valid.
+		//
+		// For example, block { foo = self } where "self" refers to the "block"
+		// is considered valid. The use case this is important for is
+		// Terraform's self references inside nested block such as "connection".
+		if target.RangePtr != nil && !hasNestedMatches {
+			if rangeOverlaps(*target.RangePtr, originRng) {
+				return false
+			}
+			// We compare line in case the (incomplete) attribute
+			// ends w/ whitespace which wouldn't be included in the range
+			if target.RangePtr.Filename == originRng.Filename &&
+				target.RangePtr.End.Line == originRng.Start.Line {
+				return false
+			}
+		}
+
+		// Reject origins which are outside the targetable range
+		if target.TargetableFromRangePtr != nil && !rangeOverlaps(*target.TargetableFromRangePtr, originRng) {
+			return false
+		}
+
+		if target.MatchesConstraint(te) || hasNestedMatches {
+			return true
+		}
+	}
+
+	return false
+}
+
+func absTargetMatches(ctx context.Context, target Target, te schema.TraversalExpr, prefix string, outermostBodyRng, originRng hcl.Range) bool {
+	if len(target.Addr) > 0 && strings.HasPrefix(target.Addr.String(), prefix) {
+		// Reject references to block's own fields from within the body
+		if referenceTargetIsInRange(target, outermostBodyRng) {
+			return false
+		}
+
+		if target.MatchesConstraint(te) || target.NestedTargets.containsMatch(ctx, te, prefix, outermostBodyRng, originRng) {
+			return true
+		}
+	}
+	return false
+}
+
+func referenceTargetIsInRange(target Target, bodyRange hcl.Range) bool {
+	return target.RangePtr != nil &&
+		bodyRange.Filename == target.RangePtr.Filename &&
+		(bodyRange.ContainsPos(target.RangePtr.Start) ||
+			posEqual(bodyRange.End, target.RangePtr.End))
+}
+
+func posEqual(pos, other hcl.Pos) bool {
+	return pos.Line == other.Line &&
+		pos.Column == other.Column &&
+		pos.Byte == other.Byte
+}
+
+func (refs Targets) containsMatch(ctx context.Context, te schema.TraversalExpr, prefix string, outermostBodyRng, originRng hcl.Range) bool {
 	for _, ref := range refs {
-		if strings.HasPrefix(ref.LocalAddr.String(), prefix) &&
-			ref.MatchesConstraint(te) {
+		if localTargetMatches(ctx, ref, te, prefix, outermostBodyRng, originRng) {
 			return true
 		}
-		if strings.HasPrefix(ref.Addr.String(), prefix) &&
-			ref.MatchesConstraint(te) {
+		if absTargetMatches(ctx, ref, te, prefix, outermostBodyRng, originRng) {
 			return true
 		}
+
 		if len(ref.NestedTargets) > 0 {
-			if match := ref.NestedTargets.containsMatch(te, prefix); match {
+			if match := ref.NestedTargets.containsMatch(ctx, te, prefix, outermostBodyRng, originRng); match {
 				return true
 			}
 		}

--- a/reference/targets_test.go
+++ b/reference/targets_test.go
@@ -1,6 +1,7 @@
 package reference
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -612,17 +613,29 @@ func TestTargets_OutermostInFile(t *testing.T) {
 
 func TestTargets_MatchWalk(t *testing.T) {
 	testCases := []struct {
-		name            string
-		targets         Targets
-		traversalConst  schema.TraversalExpr
-		prefix          string
-		expectedTargets Targets
+		name             string
+		targets          Targets
+		traversalConst   schema.TraversalExpr
+		prefix           string
+		outermostBodyRng hcl.Range
+		originRng        hcl.Range
+		expectedTargets  Targets
 	}{
 		{
 			"no targets",
 			Targets{},
 			schema.TraversalExpr{},
 			"test",
+			hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.InitialPos,
+				End:      hcl.InitialPos,
+			},
+			hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.InitialPos,
+				End:      hcl.InitialPos,
+			},
 			Targets{},
 		},
 		{
@@ -643,6 +656,16 @@ func TestTargets_MatchWalk(t *testing.T) {
 			},
 			schema.TraversalExpr{},
 			"",
+			hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.InitialPos,
+				End:      hcl.InitialPos,
+			},
+			hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.InitialPos,
+				End:      hcl.InitialPos,
+			},
 			Targets{
 				Target{
 					Addr: lang.Address{
@@ -676,6 +699,16 @@ func TestTargets_MatchWalk(t *testing.T) {
 			},
 			schema.TraversalExpr{},
 			"var.f",
+			hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.InitialPos,
+				End:      hcl.InitialPos,
+			},
+			hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.InitialPos,
+				End:      hcl.InitialPos,
+			},
 			Targets{
 				Target{
 					Addr: lang.Address{
@@ -707,6 +740,16 @@ func TestTargets_MatchWalk(t *testing.T) {
 				OfType: cty.String,
 			},
 			"",
+			hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.InitialPos,
+				End:      hcl.InitialPos,
+			},
+			hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.InitialPos,
+				End:      hcl.InitialPos,
+			},
 			Targets{
 				Target{
 					Addr: lang.Address{
@@ -739,6 +782,16 @@ func TestTargets_MatchWalk(t *testing.T) {
 				OfScopeId: lang.ScopeId("green"),
 			},
 			"",
+			hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.InitialPos,
+				End:      hcl.InitialPos,
+			},
+			hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.InitialPos,
+				End:      hcl.InitialPos,
+			},
 			Targets{
 				Target{
 					Addr: lang.Address{
@@ -782,6 +835,16 @@ func TestTargets_MatchWalk(t *testing.T) {
 				OfScopeId: lang.ScopeId("blue"),
 			},
 			"",
+			hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.InitialPos,
+				End:      hcl.InitialPos,
+			},
+			hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.InitialPos,
+				End:      hcl.InitialPos,
+			},
 			Targets{
 				Target{
 					Addr: lang.Address{
@@ -798,12 +861,8 @@ func TestTargets_MatchWalk(t *testing.T) {
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {
 			targets := make(Targets, 0)
-			rng := hcl.Range{
-				Filename: "test.tf",
-				Start:    hcl.InitialPos,
-				End:      hcl.InitialPos,
-			}
-			tc.targets.MatchWalk(tc.traversalConst, tc.prefix, rng, func(t Target) error {
+			ctx := context.Background()
+			tc.targets.MatchWalk(ctx, tc.traversalConst, tc.prefix, tc.outermostBodyRng, tc.originRng, func(t Target) error {
 				targets = append(targets, t)
 				return nil
 			})
@@ -816,17 +875,29 @@ func TestTargets_MatchWalk(t *testing.T) {
 
 func TestTargets_MatchWalk_localRefs(t *testing.T) {
 	testCases := []struct {
-		name            string
-		targets         Targets
-		traversalConst  schema.TraversalExpr
-		prefix          string
-		expectedTargets Targets
+		name             string
+		targets          Targets
+		traversalConst   schema.TraversalExpr
+		prefix           string
+		outermostBodyRng hcl.Range
+		originRng        hcl.Range
+		expectedTargets  Targets
 	}{
 		{
 			"no targets",
 			Targets{},
 			schema.TraversalExpr{},
 			"test",
+			hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.InitialPos,
+				End:      hcl.InitialPos,
+			},
+			hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.InitialPos,
+				End:      hcl.InitialPos,
+			},
 			Targets{},
 		},
 		{
@@ -847,6 +918,16 @@ func TestTargets_MatchWalk_localRefs(t *testing.T) {
 			},
 			schema.TraversalExpr{},
 			"co",
+			hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.InitialPos,
+				End:      hcl.InitialPos,
+			},
+			hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.InitialPos,
+				End:      hcl.InitialPos,
+			},
 			Targets{
 				{
 					LocalAddr: lang.Address{
@@ -857,7 +938,7 @@ func TestTargets_MatchWalk_localRefs(t *testing.T) {
 			},
 		},
 		{
-			"targets with mixed address",
+			"targets with mixed address and same block",
 			Targets{
 				{
 					LocalAddr: lang.Address{
@@ -867,6 +948,11 @@ func TestTargets_MatchWalk_localRefs(t *testing.T) {
 					Addr: lang.Address{
 						lang.RootStep{Name: "abs"},
 						lang.AttrStep{Name: "foobar"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 5, Column: 1, Byte: 25},
+						End:      hcl.Pos{Line: 5, Column: 10, Byte: 35},
 					},
 				},
 				{
@@ -881,7 +967,17 @@ func TestTargets_MatchWalk_localRefs(t *testing.T) {
 				},
 			},
 			schema.TraversalExpr{},
-			"abs",
+			"local",
+			hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+				End:      hcl.Pos{Line: 10, Column: 1, Byte: 50},
+			},
+			hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.InitialPos,
+				End:      hcl.InitialPos,
+			},
 			Targets{
 				{
 					LocalAddr: lang.Address{
@@ -891,6 +987,11 @@ func TestTargets_MatchWalk_localRefs(t *testing.T) {
 					Addr: lang.Address{
 						lang.RootStep{Name: "abs"},
 						lang.AttrStep{Name: "foobar"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 5, Column: 1, Byte: 25},
+						End:      hcl.Pos{Line: 5, Column: 10, Byte: 35},
 					},
 				},
 				{
@@ -905,17 +1006,65 @@ func TestTargets_MatchWalk_localRefs(t *testing.T) {
 				},
 			},
 		},
+		{
+			"targets matching only the local block",
+			Targets{
+				{
+					LocalAddr: lang.Address{
+						lang.RootStep{Name: "count"},
+						lang.AttrStep{Name: "index"},
+					},
+					TargetableFromRangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 10, Column: 1, Byte: 50},
+					},
+				},
+				{
+					LocalAddr: lang.Address{
+						lang.RootStep{Name: "count"},
+						lang.AttrStep{Name: "index"},
+					},
+					TargetableFromRangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 12, Column: 1, Byte: 52},
+						End:      hcl.Pos{Line: 20, Column: 1, Byte: 80},
+					},
+				},
+			},
+			schema.TraversalExpr{},
+			"co",
+			hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.InitialPos,
+				End:      hcl.InitialPos,
+			},
+			hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.Pos{Line: 5, Column: 1, Byte: 25},
+				End:      hcl.Pos{Line: 5, Column: 10, Byte: 35},
+			},
+			Targets{
+				{
+					LocalAddr: lang.Address{
+						lang.RootStep{Name: "count"},
+						lang.AttrStep{Name: "index"},
+					},
+					TargetableFromRangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 10, Column: 1, Byte: 50},
+					},
+				},
+			},
+		},
 	}
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {
 			targets := make(Targets, 0)
-			rng := hcl.Range{
-				Filename: "test.tf",
-				Start:    hcl.InitialPos,
-				End:      hcl.InitialPos,
-			}
-			tc.targets.MatchWalk(tc.traversalConst, tc.prefix, rng, func(t Target) error {
+			ctx := context.Background()
+			tc.targets.MatchWalk(ctx, tc.traversalConst, tc.prefix, tc.outermostBodyRng, tc.originRng, func(t Target) error {
 				targets = append(targets, t)
 				return nil
 			})


### PR DESCRIPTION
This introduces some minor changes to the interfaces, to plumb context through, in preparation for using it to pass down context, such as whether "SelfRefs" is active, i.e. whether `self.*` addresses are relevant in that context.

Additionally, the matching logic is being refactored and updated to account for cyclical references, specifically to continue **rejecting** completion such as

```hcl
resource "aws_instance" "test" {
  count = 4

  cpu_core_count = aws_instance.test.cpu_core_count
}
```
**TODO**: Address hover & semtok highlighting which still _recognize_ the above as valid ^

and

```hcl
resource "aws_instance" "test" {
  count = count.index
}
```

and (future)

```hcl
resource "aws_instance" "test" {
  ami = self.ami
}
```