### PR TITLE
Introduce support for `self.*` references

### DIFF
--- a/decoder/candidates.go
+++ b/decoder/candidates.go
@@ -70,6 +70,9 @@ func (d *PathDecoder) candidatesAtPos(ctx context.Context, body *hclsyntax.Body,
 
 	for _, attr := range body.Attributes {
 		if d.isPosInsideAttrExpr(attr, pos) {
+			if bodySchema.Extensions != nil && bodySchema.Extensions.SelfRefs {
+				ctx = schema.WithActiveSelfRefs(ctx)
+			}
 			if bodySchema.Extensions != nil && bodySchema.Extensions.Count && attr.Name == "count" {
 				return d.attrValueCandidatesAtPos(ctx, attr, countAttributeSchema(), outerBodyRng, pos)
 			}

--- a/decoder/expression_candidates.go
+++ b/decoder/expression_candidates.go
@@ -472,7 +472,7 @@ func (d *PathDecoder) candidatesForTraversalConstraint(ctx context.Context, tc s
 	prefix, _ := d.bytesFromRange(prefixRng)
 
 	d.pathCtx.ReferenceTargets.MatchWalk(ctx, tc, string(prefix), outermostBodyRng, editRng, func(target reference.Target) error {
-		address := target.Address(ctx).String()
+		address := target.Address(ctx, editRng.Start).String()
 
 		candidates = append(candidates, lang.Candidate{
 			Label:       address,

--- a/decoder/hover.go
+++ b/decoder/hover.go
@@ -64,6 +64,10 @@ func (d *PathDecoder) hoverAtPos(ctx context.Context, body *hclsyntax.Body, body
 	for name, attr := range body.Attributes {
 		if attr.Range().ContainsPos(pos) {
 			var aSchema *schema.AttributeSchema
+			if bodySchema.Extensions != nil && bodySchema.Extensions.SelfRefs {
+				ctx = schema.WithActiveSelfRefs(ctx)
+			}
+
 			if bodySchema.Extensions != nil && bodySchema.Extensions.Count && name == "count" {
 				aSchema = countAttributeSchema()
 			} else if bodySchema.Extensions != nil && bodySchema.Extensions.ForEach && name == "for_each" {

--- a/decoder/hover.go
+++ b/decoder/hover.go
@@ -647,14 +647,14 @@ func (d *PathDecoder) hoverContentForTraversalExpr(ctx context.Context, traversa
 		}
 
 		// TODO: Reflect additional found targets here?
-		return hoverContentForReferenceTarget(ctx, targets[0])
+		return hoverContentForReferenceTarget(ctx, targets[0], pos)
 	}
 
 	return "", &reference.NoTargetFound{}
 }
 
-func hoverContentForReferenceTarget(ctx context.Context, ref reference.Target) (string, error) {
-	content := fmt.Sprintf("`%s`", ref.Address(ctx))
+func hoverContentForReferenceTarget(ctx context.Context, ref reference.Target, pos hcl.Pos) (string, error) {
+	content := fmt.Sprintf("`%s`", ref.Address(ctx, pos))
 
 	var friendlyName string
 	if ref.Type != cty.NilType {

--- a/decoder/reference_origins.go
+++ b/decoder/reference_origins.go
@@ -58,7 +58,6 @@ func (d *Decoder) ReferenceOriginsTargetingPos(path lang.Path, file string, pos 
 	return origins
 }
 
-// TODO: Avoid collecting self.* origins unless BodySchema.Extension.SelfRef == true
 func (d *PathDecoder) CollectReferenceOrigins() (reference.Origins, error) {
 	refOrigins := make(reference.Origins, 0)
 	impliedOrigins := make([]schema.ImpliedOrigin, 0)
@@ -157,7 +156,11 @@ func (d *PathDecoder) referenceOriginsInBody(body hcl.Body, bodySchema *schema.B
 			})
 		}
 
-		origins = append(origins, d.findOriginsInExpression(attr.Expr, aSchema.Expr)...)
+		allowSelfRefs := false
+		if bodySchema.Extensions != nil && bodySchema.Extensions.SelfRefs {
+			allowSelfRefs = true
+		}
+		origins = append(origins, d.findOriginsInExpression(attr.Expr, aSchema.Expr, allowSelfRefs)...)
 	}
 
 	for _, block := range content.Blocks {
@@ -181,7 +184,7 @@ func (d *PathDecoder) referenceOriginsInBody(body hcl.Body, bodySchema *schema.B
 	return origins, impliedOrigins
 }
 
-func (d *PathDecoder) findOriginsInExpression(expr hcl.Expression, ec schema.ExprConstraints) reference.Origins {
+func (d *PathDecoder) findOriginsInExpression(expr hcl.Expression, ec schema.ExprConstraints, allowSelfRefs bool) reference.Origins {
 	origins := make(reference.Origins, 0)
 
 	switch eType := expr.(type) {
@@ -189,7 +192,7 @@ func (d *PathDecoder) findOriginsInExpression(expr hcl.Expression, ec schema.Exp
 		tce, ok := ExprConstraints(ec).TupleConsExpr()
 		if ok {
 			for _, elemExpr := range eType.ExprList() {
-				origins = append(origins, d.findOriginsInExpression(elemExpr, tce.AnyElem)...)
+				origins = append(origins, d.findOriginsInExpression(elemExpr, tce.AnyElem, allowSelfRefs)...)
 			}
 			break
 		}
@@ -197,7 +200,7 @@ func (d *PathDecoder) findOriginsInExpression(expr hcl.Expression, ec schema.Exp
 		le, ok := ExprConstraints(ec).ListExpr()
 		if ok {
 			for _, elemExpr := range eType.ExprList() {
-				origins = append(origins, d.findOriginsInExpression(elemExpr, le.Elem)...)
+				origins = append(origins, d.findOriginsInExpression(elemExpr, le.Elem, allowSelfRefs)...)
 			}
 			break
 		}
@@ -205,7 +208,7 @@ func (d *PathDecoder) findOriginsInExpression(expr hcl.Expression, ec schema.Exp
 		se, ok := ExprConstraints(ec).SetExpr()
 		if ok {
 			for _, elemExpr := range eType.ExprList() {
-				origins = append(origins, d.findOriginsInExpression(elemExpr, se.Elem)...)
+				origins = append(origins, d.findOriginsInExpression(elemExpr, se.Elem, allowSelfRefs)...)
 			}
 			break
 		}
@@ -216,7 +219,7 @@ func (d *PathDecoder) findOriginsInExpression(expr hcl.Expression, ec schema.Exp
 				if len(tue.Elems) < i+1 {
 					break
 				}
-				origins = append(origins, d.findOriginsInExpression(elemExpr, tue.Elems[i])...)
+				origins = append(origins, d.findOriginsInExpression(elemExpr, tue.Elems[i], allowSelfRefs)...)
 			}
 		}
 	case *hclsyntax.ObjectConsExpr:
@@ -236,14 +239,14 @@ func (d *PathDecoder) findOriginsInExpression(expr hcl.Expression, ec schema.Exp
 					continue
 				}
 
-				origins = append(origins, d.findOriginsInExpression(item.ValueExpr, attr.Expr)...)
+				origins = append(origins, d.findOriginsInExpression(item.ValueExpr, attr.Expr, allowSelfRefs)...)
 			}
 		}
 
 		me, ok := ExprConstraints(ec).MapExpr()
 		if ok {
 			for _, item := range eType.Items {
-				origins = append(origins, d.findOriginsInExpression(item.ValueExpr, me.Elem)...)
+				origins = append(origins, d.findOriginsInExpression(item.ValueExpr, me.Elem, allowSelfRefs)...)
 			}
 		}
 	case *hclsyntax.AnonSymbolExpr,
@@ -267,7 +270,7 @@ func (d *PathDecoder) findOriginsInExpression(expr hcl.Expression, ec schema.Exp
 		// see https://github.com/hashicorp/terraform-ls/issues/496
 		tes, ok := ExprConstraints(ec).TraversalExprs()
 		if ok {
-			origins = append(origins, reference.TraversalsToLocalOrigins(expr.Variables(), tes)...)
+			origins = append(origins, reference.TraversalsToLocalOrigins(expr.Variables(), tes, allowSelfRefs)...)
 		}
 	case *hclsyntax.LiteralValueExpr:
 		// String constant may also be a traversal in some cases, but currently not recognized
@@ -280,7 +283,7 @@ func (d *PathDecoder) findOriginsInExpression(expr hcl.Expression, ec schema.Exp
 		// This may result in less accurate decoding where even origins
 		// which do not actually conform to the constraints are recognized.
 		// TODO: https://github.com/hashicorp/terraform-ls/issues/675
-		origins = append(origins, reference.TraversalsToLocalOrigins(expr.Variables(), schema.TraversalExprs{})...)
+		origins = append(origins, reference.TraversalsToLocalOrigins(expr.Variables(), schema.TraversalExprs{}, allowSelfRefs)...)
 	}
 
 	return origins
@@ -298,7 +301,11 @@ func (d *PathDecoder) referenceOriginAtPos(body *hclsyntax.Body, bodySchema *sch
 				aSchema = bodySchema.AnyAttribute
 			}
 
-			for _, origin := range d.findOriginsInExpression(attr.Expr, aSchema.Expr) {
+			allowSelfRefs := false
+			if bodySchema.Extensions != nil && bodySchema.Extensions.SelfRefs {
+				allowSelfRefs = true
+			}
+			for _, origin := range d.findOriginsInExpression(attr.Expr, aSchema.Expr, allowSelfRefs) {
 				if origin.OriginRange().ContainsPos(pos) {
 					return &origin, nil
 				}

--- a/decoder/reference_origins.go
+++ b/decoder/reference_origins.go
@@ -58,6 +58,7 @@ func (d *Decoder) ReferenceOriginsTargetingPos(path lang.Path, file string, pos 
 	return origins
 }
 
+// TODO: Avoid collecting self.* origins unless BodySchema.Extension.SelfRef == true
 func (d *PathDecoder) CollectReferenceOrigins() (reference.Origins, error) {
 	refOrigins := make(reference.Origins, 0)
 	impliedOrigins := make([]schema.ImpliedOrigin, 0)

--- a/decoder/reference_targets.go
+++ b/decoder/reference_targets.go
@@ -855,10 +855,16 @@ func (d *PathDecoder) collectInferredReferenceTargetsForBody(addr lang.Address, 
 
 		blockRef := reference.Target{
 			Addr:        blockAddr,
+			LocalAddr:   make(lang.Address, len(selfRefAddr)),
 			ScopeId:     bAddrSchema.ScopeId,
 			Type:        cty.Map(cty.Object(bodySchemaAsAttrTypes(bCollection.Schema.Body))),
 			Description: bCollection.Schema.Description,
 			RangePtr:    body.MissingItemRange().Ptr(),
+		}
+		if bAddrSchema.DependentBodySelfRef && selfRefBodyRangePtr != nil {
+			copy(blockRef.LocalAddr, selfRefAddr)
+			blockRef.LocalAddr = append(blockRef.LocalAddr, lang.AttrStep{Name: bType})
+			blockRef.TargetableFromRangePtr = selfRefBodyRangePtr.Ptr()
 		}
 
 		for i, b := range bCollection.Blocks {
@@ -872,13 +878,21 @@ func (d *PathDecoder) collectInferredReferenceTargetsForBody(addr lang.Address, 
 
 			elemRef := reference.Target{
 				Addr:        elemAddr,
-				LocalAddr:   make(lang.Address, len(selfRefAddr)),
+				LocalAddr:   make(lang.Address, len(blockRef.LocalAddr)),
 				ScopeId:     bAddrSchema.ScopeId,
 				Type:        refType,
 				Description: bCollection.Schema.Description,
 				RangePtr:    b.Range.Ptr(),
 				DefRangePtr: b.DefRange.Ptr(),
 			}
+			if bAddrSchema.DependentBodySelfRef && selfRefBodyRangePtr != nil {
+				copy(elemRef.LocalAddr, blockRef.LocalAddr)
+				elemRef.LocalAddr = append(elemRef.LocalAddr, lang.IndexStep{
+					Key: cty.StringVal(b.Labels[0]),
+				})
+				elemRef.TargetableFromRangePtr = selfRefBodyRangePtr.Ptr()
+			}
+
 			elemRef.NestedTargets = d.collectInferredReferenceTargetsForBody(
 				elemAddr, bAddrSchema, b.Body, bCollection.Schema.Body, selfRefBodyRangePtr, elemRef.LocalAddr)
 			sort.Sort(elemRef.NestedTargets)

--- a/decoder/reference_targets.go
+++ b/decoder/reference_targets.go
@@ -817,10 +817,16 @@ func (d *PathDecoder) collectInferredReferenceTargetsForBody(addr lang.Address, 
 
 		blockRef := reference.Target{
 			Addr:        blockAddr,
+			LocalAddr:   make(lang.Address, len(selfRefAddr)),
 			ScopeId:     bAddrSchema.ScopeId,
 			Type:        cty.Set(cty.Object(bodySchemaAsAttrTypes(bCollection.Schema.Body))),
 			Description: bCollection.Schema.Description,
 			RangePtr:    body.MissingItemRange().Ptr(),
+		}
+		if bAddrSchema.DependentBodySelfRef && selfRefBodyRangePtr != nil {
+			copy(blockRef.LocalAddr, selfRefAddr)
+			blockRef.LocalAddr = append(blockRef.LocalAddr, lang.AttrStep{Name: bType})
+			blockRef.TargetableFromRangePtr = selfRefBodyRangePtr.Ptr()
 		}
 
 		for i, b := range bCollection.Blocks {

--- a/decoder/reference_targets.go
+++ b/decoder/reference_targets.go
@@ -218,6 +218,7 @@ func (d *PathDecoder) decodeReferenceTargetsForBody(body hcl.Body, parentBlock *
 						bodyRef.LocalAddr = lang.Address{
 							lang.RootStep{Name: "self"},
 						}
+						bodyRef.TargetableFromRangePtr = blk.Range.Ptr()
 					} else {
 						bodyRef.LocalAddr = lang.Address{}
 					}

--- a/decoder/reference_targets_collect_extensions_hcl_test.go
+++ b/decoder/reference_targets_collect_extensions_hcl_test.go
@@ -431,6 +431,264 @@ func TestCollectReferenceTargets_extension_hcl(t *testing.T) {
 				},
 			},
 		},
+		{
+			"self references collection - list block",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource": {
+						Address: &schema.BlockAddrSchema{
+							Steps: schema.Address{
+								schema.LabelStep{Index: 0},
+								schema.LabelStep{Index: 1},
+							},
+							DependentBodyAsData:  true,
+							InferDependentBody:   true,
+							DependentBodySelfRef: true,
+						},
+						Labels: []*schema.LabelSchema{
+							{
+								Name:     "type",
+								IsDepKey: true,
+							},
+							{
+								Name: "name",
+							},
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"static": {IsOptional: true, Expr: schema.LiteralTypeOnly(cty.String)},
+							},
+						},
+						DependentBody: map[schema.SchemaKey]*schema.BodySchema{
+							schema.NewSchemaKey(schema.DependencyKeys{
+								Labels: []schema.LabelDependent{
+									{
+										Index: 0,
+										Value: "aws_instance",
+									},
+								},
+							}): {
+								Blocks: map[string]*schema.BlockSchema{
+									"foo": {
+										Type: schema.BlockTypeList,
+										Body: &schema.BodySchema{
+											Attributes: map[string]*schema.AttributeSchema{
+												"bar": {IsOptional: true, Expr: schema.LiteralTypeOnly(cty.Number)},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			`resource "aws_instance" "blah" {
+  static = "test"
+  foo {
+    bar = 42
+  }
+}
+`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "aws_instance"},
+						lang.AttrStep{Name: "blah"},
+					},
+					LocalAddr: lang.Address{
+						lang.RootStep{Name: "self"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+							Byte:   0,
+						},
+						End: hcl.Pos{
+							Line:   6,
+							Column: 2,
+							Byte:   77,
+						},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+							Byte:   0,
+						},
+						End: hcl.Pos{
+							Line:   1,
+							Column: 31,
+							Byte:   30,
+						},
+					},
+					Type: cty.Object(map[string]cty.Type{
+						"foo": cty.List(cty.Object(map[string]cty.Type{
+							"bar": cty.Number,
+						})),
+					}),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "aws_instance"},
+								lang.AttrStep{Name: "blah"},
+								lang.AttrStep{Name: "foo"},
+							},
+							LocalAddr: lang.Address{
+								lang.RootStep{Name: "self"},
+								lang.AttrStep{Name: "foo"},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start: hcl.Pos{
+									Line:   3,
+									Column: 3,
+									Byte:   53,
+								},
+								End: hcl.Pos{
+									Line:   5,
+									Column: 4,
+									Byte:   75,
+								},
+							},
+							Type: cty.List(cty.Object(map[string]cty.Type{
+								"bar": cty.Number,
+							})),
+							TargetableFromRangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start: hcl.Pos{
+									Line:   1,
+									Column: 32,
+									Byte:   31,
+								},
+								End: hcl.Pos{
+									Line:   6,
+									Column: 2,
+									Byte:   77,
+								},
+							},
+							NestedTargets: reference.Targets{
+								{
+									Addr: lang.Address{
+										lang.RootStep{Name: "aws_instance"},
+										lang.AttrStep{Name: "blah"},
+										lang.AttrStep{Name: "foo"},
+										lang.IndexStep{Key: cty.NumberIntVal(0)},
+									},
+									LocalAddr: lang.Address{
+										lang.RootStep{Name: "self"},
+										lang.AttrStep{Name: "foo"},
+										lang.IndexStep{Key: cty.NumberIntVal(0)},
+									},
+									RangePtr: &hcl.Range{
+										Filename: "test.tf",
+										Start: hcl.Pos{
+											Line:   3,
+											Column: 3,
+											Byte:   53,
+										},
+										End: hcl.Pos{
+											Line:   5,
+											Column: 4,
+											Byte:   75,
+										},
+									},
+									DefRangePtr: &hcl.Range{
+										Filename: "test.tf",
+										Start: hcl.Pos{
+											Line:   3,
+											Column: 3,
+											Byte:   53,
+										},
+										End: hcl.Pos{
+											Line:   3,
+											Column: 6,
+											Byte:   56,
+										},
+									},
+									Type: cty.Object(map[string]cty.Type{
+										"bar": cty.Number,
+									}),
+									TargetableFromRangePtr: &hcl.Range{
+										Filename: "test.tf",
+										Start: hcl.Pos{
+											Line:   1,
+											Column: 32,
+											Byte:   31,
+										},
+										End: hcl.Pos{
+											Line:   6,
+											Column: 2,
+											Byte:   77,
+										},
+									},
+									NestedTargets: reference.Targets{
+										{
+											Addr: lang.Address{
+												lang.RootStep{Name: "aws_instance"},
+												lang.AttrStep{Name: "blah"},
+												lang.AttrStep{Name: "foo"},
+												lang.IndexStep{Key: cty.NumberIntVal(0)},
+												lang.AttrStep{Name: "bar"},
+											},
+											LocalAddr: lang.Address{
+												lang.RootStep{Name: "self"},
+												lang.AttrStep{Name: "foo"},
+												lang.IndexStep{Key: cty.NumberIntVal(0)},
+												lang.AttrStep{Name: "bar"},
+											},
+											RangePtr: &hcl.Range{
+												Filename: "test.tf",
+												Start: hcl.Pos{
+													Line:   4,
+													Column: 5,
+													Byte:   63,
+												},
+												End: hcl.Pos{
+													Line:   4,
+													Column: 13,
+													Byte:   71,
+												},
+											},
+											DefRangePtr: &hcl.Range{
+												Filename: "test.tf",
+												Start: hcl.Pos{
+													Line:   4,
+													Column: 5,
+													Byte:   63,
+												},
+												End: hcl.Pos{
+													Line:   4,
+													Column: 8,
+													Byte:   66,
+												},
+											},
+											Type: cty.Number,
+											TargetableFromRangePtr: &hcl.Range{
+												Filename: "test.tf",
+												Start: hcl.Pos{
+													Line:   1,
+													Column: 32,
+													Byte:   31,
+												},
+												End: hcl.Pos{
+													Line:   6,
+													Column: 2,
+													Byte:   77,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for i, tc := range testCases {

--- a/decoder/reference_targets_collect_extensions_hcl_test.go
+++ b/decoder/reference_targets_collect_extensions_hcl_test.go
@@ -22,7 +22,7 @@ func TestCollectReferenceTargets_extension_hcl(t *testing.T) {
 		expectedRefs reference.Targets
 	}{
 		{
-			"self references",
+			"self references collection - attributes",
 			&schema.BodySchema{
 				Blocks: map[string]*schema.BlockSchema{
 					"resource": {
@@ -78,6 +78,9 @@ func TestCollectReferenceTargets_extension_hcl(t *testing.T) {
 					Addr: lang.Address{
 						lang.RootStep{Name: "aws_instance"},
 						lang.AttrStep{Name: "blah"},
+					},
+					LocalAddr: lang.Address{
+						lang.RootStep{Name: "self"},
 					},
 					RangePtr: &hcl.Range{
 						Filename: "test.tf",
@@ -151,13 +154,13 @@ func TestCollectReferenceTargets_extension_hcl(t *testing.T) {
 								Filename: "test.tf",
 								Start: hcl.Pos{
 									Line:   1,
-									Column: 33,
-									Byte:   32,
+									Column: 32,
+									Byte:   31,
 								},
 								End: hcl.Pos{
 									Line:   5,
-									Column: 1,
-									Byte:   77,
+									Column: 2,
+									Byte:   78,
 								},
 							},
 						},
@@ -202,13 +205,225 @@ func TestCollectReferenceTargets_extension_hcl(t *testing.T) {
 								Filename: "test.tf",
 								Start: hcl.Pos{
 									Line:   1,
-									Column: 33,
-									Byte:   32,
+									Column: 32,
+									Byte:   31,
 								},
 								End: hcl.Pos{
 									Line:   5,
-									Column: 1,
+									Column: 2,
+									Byte:   78,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"self references collection - object block",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource": {
+						Address: &schema.BlockAddrSchema{
+							Steps: schema.Address{
+								schema.LabelStep{Index: 0},
+								schema.LabelStep{Index: 1},
+							},
+							DependentBodyAsData:  true,
+							InferDependentBody:   true,
+							DependentBodySelfRef: true,
+						},
+						Labels: []*schema.LabelSchema{
+							{
+								Name:     "type",
+								IsDepKey: true,
+							},
+							{
+								Name: "name",
+							},
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"static": {IsOptional: true, Expr: schema.LiteralTypeOnly(cty.String)},
+							},
+						},
+						DependentBody: map[schema.SchemaKey]*schema.BodySchema{
+							schema.NewSchemaKey(schema.DependencyKeys{
+								Labels: []schema.LabelDependent{
+									{
+										Index: 0,
+										Value: "aws_instance",
+									},
+								},
+							}): {
+								Blocks: map[string]*schema.BlockSchema{
+									"foo": {
+										Type: schema.BlockTypeObject,
+										Body: &schema.BodySchema{
+											Attributes: map[string]*schema.AttributeSchema{
+												"bar": {IsOptional: true, Expr: schema.LiteralTypeOnly(cty.Number)},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			`resource "aws_instance" "blah" {
+  static = "test"
+  foo {
+    bar = 42
+  }
+}
+`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "aws_instance"},
+						lang.AttrStep{Name: "blah"},
+					},
+					LocalAddr: lang.Address{
+						lang.RootStep{Name: "self"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+							Byte:   0,
+						},
+						End: hcl.Pos{
+							Line:   6,
+							Column: 2,
+							Byte:   77,
+						},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+							Byte:   0,
+						},
+						End: hcl.Pos{
+							Line:   1,
+							Column: 31,
+							Byte:   30,
+						},
+					},
+					Type: cty.Object(map[string]cty.Type{
+						"foo": cty.Object(map[string]cty.Type{
+							"bar": cty.Number,
+						}),
+					}),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "aws_instance"},
+								lang.AttrStep{Name: "blah"},
+								lang.AttrStep{Name: "foo"},
+							},
+							LocalAddr: lang.Address{
+								lang.RootStep{Name: "self"},
+								lang.AttrStep{Name: "foo"},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start: hcl.Pos{
+									Line:   3,
+									Column: 3,
+									Byte:   53,
+								},
+								End: hcl.Pos{
+									Line:   5,
+									Column: 4,
+									Byte:   75,
+								},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start: hcl.Pos{
+									Line:   3,
+									Column: 3,
+									Byte:   53,
+								},
+								End: hcl.Pos{
+									Line:   3,
+									Column: 6,
+									Byte:   56,
+								},
+							},
+							Type: cty.Object(map[string]cty.Type{
+								"bar": cty.Number,
+							}),
+							TargetableFromRangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start: hcl.Pos{
+									Line:   1,
+									Column: 32,
+									Byte:   31,
+								},
+								End: hcl.Pos{
+									Line:   6,
+									Column: 2,
 									Byte:   77,
+								},
+							},
+							NestedTargets: reference.Targets{
+								{
+									Addr: lang.Address{
+										lang.RootStep{Name: "aws_instance"},
+										lang.AttrStep{Name: "blah"},
+										lang.AttrStep{Name: "foo"},
+										lang.AttrStep{Name: "bar"},
+									},
+									LocalAddr: lang.Address{
+										lang.RootStep{Name: "self"},
+										lang.AttrStep{Name: "foo"},
+										lang.AttrStep{Name: "bar"},
+									},
+									RangePtr: &hcl.Range{
+										Filename: "test.tf",
+										Start: hcl.Pos{
+											Line:   4,
+											Column: 5,
+											Byte:   63,
+										},
+										End: hcl.Pos{
+											Line:   4,
+											Column: 13,
+											Byte:   71,
+										},
+									},
+									DefRangePtr: &hcl.Range{
+										Filename: "test.tf",
+										Start: hcl.Pos{
+											Line:   4,
+											Column: 5,
+											Byte:   63,
+										},
+										End: hcl.Pos{
+											Line:   4,
+											Column: 8,
+											Byte:   66,
+										},
+									},
+									Type: cty.Number,
+									TargetableFromRangePtr: &hcl.Range{
+										Filename: "test.tf",
+										Start: hcl.Pos{
+											Line:   1,
+											Column: 32,
+											Byte:   31,
+										},
+										End: hcl.Pos{
+											Line:   6,
+											Column: 2,
+											Byte:   77,
+										},
+									},
 								},
 							},
 						},

--- a/decoder/reference_targets_collect_extensions_hcl_test.go
+++ b/decoder/reference_targets_collect_extensions_hcl_test.go
@@ -108,6 +108,19 @@ func TestCollectReferenceTargets_extension_hcl(t *testing.T) {
 							Byte:   30,
 						},
 					},
+					TargetableFromRangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+							Byte:   0,
+						},
+						End: hcl.Pos{
+							Line:   5,
+							Column: 2,
+							Byte:   78,
+						},
+					},
 					Type: cty.Object(map[string]cty.Type{
 						"bar": cty.Number,
 						"foo": cty.String,
@@ -311,6 +324,19 @@ func TestCollectReferenceTargets_extension_hcl(t *testing.T) {
 							Line:   1,
 							Column: 31,
 							Byte:   30,
+						},
+					},
+					TargetableFromRangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+							Byte:   0,
+						},
+						End: hcl.Pos{
+							Line:   6,
+							Column: 2,
+							Byte:   77,
 						},
 					},
 					Type: cty.Object(map[string]cty.Type{
@@ -523,6 +549,19 @@ func TestCollectReferenceTargets_extension_hcl(t *testing.T) {
 							Line:   1,
 							Column: 31,
 							Byte:   30,
+						},
+					},
+					TargetableFromRangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+							Byte:   0,
+						},
+						End: hcl.Pos{
+							Line:   6,
+							Column: 2,
+							Byte:   77,
 						},
 					},
 					Type: cty.Object(map[string]cty.Type{
@@ -783,6 +822,19 @@ func TestCollectReferenceTargets_extension_hcl(t *testing.T) {
 							Byte:   30,
 						},
 					},
+					TargetableFromRangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+							Byte:   0,
+						},
+						End: hcl.Pos{
+							Line:   6,
+							Column: 2,
+							Byte:   77,
+						},
+					},
 					Type: cty.Object(map[string]cty.Type{
 						"foo": cty.Set(cty.Object(map[string]cty.Type{
 							"bar": cty.Number,
@@ -925,6 +977,19 @@ func TestCollectReferenceTargets_extension_hcl(t *testing.T) {
 							Line:   1,
 							Column: 31,
 							Byte:   30,
+						},
+					},
+					TargetableFromRangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+							Byte:   0,
+						},
+						End: hcl.Pos{
+							Line:   6,
+							Column: 2,
+							Byte:   83,
 						},
 					},
 					Type: cty.Object(map[string]cty.Type{

--- a/decoder/reference_targets_collect_extensions_hcl_test.go
+++ b/decoder/reference_targets_collect_extensions_hcl_test.go
@@ -1,0 +1,242 @@
+package decoder
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/reference"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty-debug/ctydebug"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestCollectReferenceTargets_extension_hcl(t *testing.T) {
+	testCases := []struct {
+		name         string
+		schema       *schema.BodySchema
+		cfg          string
+		expectedRefs reference.Targets
+	}{
+		{
+			"self references",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource": {
+						Address: &schema.BlockAddrSchema{
+							Steps: schema.Address{
+								schema.LabelStep{Index: 0},
+								schema.LabelStep{Index: 1},
+							},
+							DependentBodyAsData:  true,
+							InferDependentBody:   true,
+							DependentBodySelfRef: true,
+						},
+						Labels: []*schema.LabelSchema{
+							{
+								Name:     "type",
+								IsDepKey: true,
+							},
+							{
+								Name: "name",
+							},
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"static": {IsOptional: true, Expr: schema.LiteralTypeOnly(cty.String)},
+							},
+						},
+						DependentBody: map[schema.SchemaKey]*schema.BodySchema{
+							schema.NewSchemaKey(schema.DependencyKeys{
+								Labels: []schema.LabelDependent{
+									{
+										Index: 0,
+										Value: "aws_instance",
+									},
+								},
+							}): {
+								Attributes: map[string]*schema.AttributeSchema{
+									"bar": {IsOptional: true, Expr: schema.LiteralTypeOnly(cty.Number)},
+									"foo": {IsOptional: true, Expr: schema.LiteralTypeOnly(cty.String)},
+								},
+							},
+						},
+					},
+				},
+			},
+			`resource "aws_instance" "blah" {
+  static = "test"
+  foo = "test"
+  bar = 42
+}
+`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "aws_instance"},
+						lang.AttrStep{Name: "blah"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+							Byte:   0,
+						},
+						End: hcl.Pos{
+							Line:   5,
+							Column: 2,
+							Byte:   78,
+						},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+							Byte:   0,
+						},
+						End: hcl.Pos{
+							Line:   1,
+							Column: 31,
+							Byte:   30,
+						},
+					},
+					Type: cty.Object(map[string]cty.Type{
+						"bar": cty.Number,
+						"foo": cty.String,
+					}),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "aws_instance"},
+								lang.AttrStep{Name: "blah"},
+								lang.AttrStep{Name: "bar"},
+							},
+							LocalAddr: lang.Address{
+								lang.RootStep{Name: "self"},
+								lang.AttrStep{Name: "bar"},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start: hcl.Pos{
+									Line:   4,
+									Column: 3,
+									Byte:   68,
+								},
+								End: hcl.Pos{
+									Line:   4,
+									Column: 11,
+									Byte:   76,
+								},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start: hcl.Pos{
+									Line:   4,
+									Column: 3,
+									Byte:   68,
+								},
+								End: hcl.Pos{
+									Line:   4,
+									Column: 6,
+									Byte:   71,
+								},
+							},
+							Type: cty.Number,
+							TargetableFromRangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start: hcl.Pos{
+									Line:   1,
+									Column: 33,
+									Byte:   32,
+								},
+								End: hcl.Pos{
+									Line:   5,
+									Column: 1,
+									Byte:   77,
+								},
+							},
+						},
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "aws_instance"},
+								lang.AttrStep{Name: "blah"},
+								lang.AttrStep{Name: "foo"},
+							},
+							LocalAddr: lang.Address{
+								lang.RootStep{Name: "self"},
+								lang.AttrStep{Name: "foo"},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start: hcl.Pos{
+									Line:   3,
+									Column: 3,
+									Byte:   53,
+								},
+								End: hcl.Pos{
+									Line:   3,
+									Column: 15,
+									Byte:   65,
+								},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start: hcl.Pos{
+									Line:   3,
+									Column: 3,
+									Byte:   53,
+								},
+								End: hcl.Pos{
+									Line:   3,
+									Column: 6,
+									Byte:   56,
+								},
+							},
+							Type: cty.String,
+							TargetableFromRangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start: hcl.Pos{
+									Line:   1,
+									Column: 33,
+									Byte:   32,
+								},
+								End: hcl.Pos{
+									Line:   5,
+									Column: 1,
+									Byte:   77,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {
+			f, _ := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+
+			d := testPathDecoder(t, &PathContext{
+				Schema: tc.schema,
+				Files: map[string]*hcl.File{
+					"test.tf": f,
+				},
+			})
+
+			refs, err := d.CollectReferenceTargets()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedRefs, refs, ctydebug.CmpOptions); diff != "" {
+				t.Fatalf("mismatch of references: %s", diff)
+			}
+		})
+	}
+}

--- a/decoder/reference_targets_collect_extensions_hcl_test.go
+++ b/decoder/reference_targets_collect_extensions_hcl_test.go
@@ -833,6 +833,264 @@ func TestCollectReferenceTargets_extension_hcl(t *testing.T) {
 				},
 			},
 		},
+		{
+			"self references collection - map block",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource": {
+						Address: &schema.BlockAddrSchema{
+							Steps: schema.Address{
+								schema.LabelStep{Index: 0},
+								schema.LabelStep{Index: 1},
+							},
+							DependentBodyAsData:  true,
+							InferDependentBody:   true,
+							DependentBodySelfRef: true,
+						},
+						Labels: []*schema.LabelSchema{
+							{
+								Name:     "type",
+								IsDepKey: true,
+							},
+							{
+								Name: "name",
+							},
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"static": {IsOptional: true, Expr: schema.LiteralTypeOnly(cty.String)},
+							},
+						},
+						DependentBody: map[schema.SchemaKey]*schema.BodySchema{
+							schema.NewSchemaKey(schema.DependencyKeys{
+								Labels: []schema.LabelDependent{
+									{
+										Index: 0,
+										Value: "aws_instance",
+									},
+								},
+							}): {
+								Blocks: map[string]*schema.BlockSchema{
+									"foo": {
+										Type: schema.BlockTypeMap,
+										Body: &schema.BodySchema{
+											Attributes: map[string]*schema.AttributeSchema{
+												"bar": {IsOptional: true, Expr: schema.LiteralTypeOnly(cty.Number)},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			`resource "aws_instance" "blah" {
+  static = "test"
+  foo "dog" {
+    bar = 42
+  }
+}
+`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "aws_instance"},
+						lang.AttrStep{Name: "blah"},
+					},
+					LocalAddr: lang.Address{
+						lang.RootStep{Name: "self"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+							Byte:   0,
+						},
+						End: hcl.Pos{
+							Line:   6,
+							Column: 2,
+							Byte:   83,
+						},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+							Byte:   0,
+						},
+						End: hcl.Pos{
+							Line:   1,
+							Column: 31,
+							Byte:   30,
+						},
+					},
+					Type: cty.Object(map[string]cty.Type{
+						"foo": cty.Map(cty.Object(map[string]cty.Type{
+							"bar": cty.Number,
+						})),
+					}),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "aws_instance"},
+								lang.AttrStep{Name: "blah"},
+								lang.AttrStep{Name: "foo"},
+							},
+							LocalAddr: lang.Address{
+								lang.RootStep{Name: "self"},
+								lang.AttrStep{Name: "foo"},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start: hcl.Pos{
+									Line:   3,
+									Column: 3,
+									Byte:   53,
+								},
+								End: hcl.Pos{
+									Line:   5,
+									Column: 4,
+									Byte:   81,
+								},
+							},
+							Type: cty.Map(cty.Object(map[string]cty.Type{
+								"bar": cty.Number,
+							})),
+							TargetableFromRangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start: hcl.Pos{
+									Line:   1,
+									Column: 32,
+									Byte:   31,
+								},
+								End: hcl.Pos{
+									Line:   6,
+									Column: 2,
+									Byte:   83,
+								},
+							},
+							NestedTargets: reference.Targets{
+								{
+									Addr: lang.Address{
+										lang.RootStep{Name: "aws_instance"},
+										lang.AttrStep{Name: "blah"},
+										lang.AttrStep{Name: "foo"},
+										lang.IndexStep{Key: cty.StringVal("dog")},
+									},
+									LocalAddr: lang.Address{
+										lang.RootStep{Name: "self"},
+										lang.AttrStep{Name: "foo"},
+										lang.IndexStep{Key: cty.StringVal("dog")},
+									},
+									RangePtr: &hcl.Range{
+										Filename: "test.tf",
+										Start: hcl.Pos{
+											Line:   3,
+											Column: 3,
+											Byte:   53,
+										},
+										End: hcl.Pos{
+											Line:   5,
+											Column: 4,
+											Byte:   81,
+										},
+									},
+									DefRangePtr: &hcl.Range{
+										Filename: "test.tf",
+										Start: hcl.Pos{
+											Line:   3,
+											Column: 3,
+											Byte:   53,
+										},
+										End: hcl.Pos{
+											Line:   3,
+											Column: 12,
+											Byte:   62,
+										},
+									},
+									Type: cty.Object(map[string]cty.Type{
+										"bar": cty.Number,
+									}),
+									TargetableFromRangePtr: &hcl.Range{
+										Filename: "test.tf",
+										Start: hcl.Pos{
+											Line:   1,
+											Column: 32,
+											Byte:   31,
+										},
+										End: hcl.Pos{
+											Line:   6,
+											Column: 2,
+											Byte:   83,
+										},
+									},
+									NestedTargets: reference.Targets{
+										{
+											Addr: lang.Address{
+												lang.RootStep{Name: "aws_instance"},
+												lang.AttrStep{Name: "blah"},
+												lang.AttrStep{Name: "foo"},
+												lang.IndexStep{Key: cty.StringVal("dog")},
+												lang.AttrStep{Name: "bar"},
+											},
+											LocalAddr: lang.Address{
+												lang.RootStep{Name: "self"},
+												lang.AttrStep{Name: "foo"},
+												lang.IndexStep{Key: cty.StringVal("dog")},
+												lang.AttrStep{Name: "bar"},
+											},
+											RangePtr: &hcl.Range{
+												Filename: "test.tf",
+												Start: hcl.Pos{
+													Line:   4,
+													Column: 5,
+													Byte:   69,
+												},
+												End: hcl.Pos{
+													Line:   4,
+													Column: 13,
+													Byte:   77,
+												},
+											},
+											DefRangePtr: &hcl.Range{
+												Filename: "test.tf",
+												Start: hcl.Pos{
+													Line:   4,
+													Column: 5,
+													Byte:   69,
+												},
+												End: hcl.Pos{
+													Line:   4,
+													Column: 8,
+													Byte:   72,
+												},
+											},
+											Type: cty.Number,
+											TargetableFromRangePtr: &hcl.Range{
+												Filename: "test.tf",
+												Start: hcl.Pos{
+													Line:   1,
+													Column: 32,
+													Byte:   31,
+												},
+												End: hcl.Pos{
+													Line:   6,
+													Column: 2,
+													Byte:   83,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for i, tc := range testCases {

--- a/decoder/reference_targets_collect_hcl_test.go
+++ b/decoder/reference_targets_collect_hcl_test.go
@@ -2379,6 +2379,7 @@ provider "test" {
 								lang.AttrStep{Name: "aws"},
 								lang.AttrStep{Name: "listblock"},
 							},
+							LocalAddr: lang.Address{},
 							RangePtr: &hcl.Range{
 								Filename: "test.tf",
 								Start: hcl.Pos{
@@ -2928,6 +2929,7 @@ provider "test" {
 								lang.AttrStep{Name: "aws"},
 								lang.AttrStep{Name: "listblock"},
 							},
+							LocalAddr: lang.Address{},
 							RangePtr: &hcl.Range{
 								Filename: "test.tf",
 								Start: hcl.Pos{

--- a/decoder/reference_targets_collect_hcl_test.go
+++ b/decoder/reference_targets_collect_hcl_test.go
@@ -3321,6 +3321,7 @@ provider "test" {
 								lang.AttrStep{Name: "aws"},
 								lang.AttrStep{Name: "listener"},
 							},
+							LocalAddr: lang.Address{},
 							RangePtr: &hcl.Range{
 								Filename: "test.tf",
 								Start: hcl.Pos{

--- a/decoder/reference_targets_collect_hcl_test.go
+++ b/decoder/reference_targets_collect_hcl_test.go
@@ -1677,6 +1677,7 @@ provider "test" {
 					Addr: lang.Address{
 						lang.RootStep{Name: "aws"},
 					},
+					LocalAddr: lang.Address{},
 					Type: cty.Object(map[string]cty.Type{
 						"attr":      cty.Number,
 						"name":      cty.String,
@@ -2133,6 +2134,7 @@ provider "test" {
 								lang.AttrStep{Name: "aws"},
 								lang.AttrStep{Name: "objblock"},
 							},
+							LocalAddr: lang.Address{},
 							RangePtr: &hcl.Range{
 								Filename: "test.tf",
 								Start: hcl.Pos{
@@ -2403,6 +2405,7 @@ provider "test" {
 										lang.AttrStep{Name: "listblock"},
 										lang.IndexStep{Key: cty.NumberIntVal(0)},
 									},
+									LocalAddr: lang.Address{},
 									RangePtr: &hcl.Range{
 										Filename: "test.tf",
 										Start: hcl.Pos{
@@ -2515,6 +2518,7 @@ provider "test" {
 										lang.AttrStep{Name: "listblock"},
 										lang.IndexStep{Key: cty.NumberIntVal(1)},
 									},
+									LocalAddr: lang.Address{},
 									RangePtr: &hcl.Range{
 										Filename: "test.tf",
 										Start: hcl.Pos{
@@ -2950,6 +2954,7 @@ provider "test" {
 										lang.AttrStep{Name: "listblock"},
 										lang.IndexStep{Key: cty.NumberIntVal(0)},
 									},
+									LocalAddr: lang.Address{},
 									RangePtr: &hcl.Range{
 										Filename: "test.tf",
 										Start: hcl.Pos{
@@ -3062,6 +3067,7 @@ provider "test" {
 										lang.AttrStep{Name: "listblock"},
 										lang.IndexStep{Key: cty.NumberIntVal(1)},
 									},
+									LocalAddr: lang.Address{},
 									RangePtr: &hcl.Range{
 										Filename: "test.tf",
 										Start: hcl.Pos{
@@ -3338,6 +3344,7 @@ provider "test" {
 										lang.AttrStep{Name: "listener"},
 										lang.IndexStep{Key: cty.StringVal("http")},
 									},
+									LocalAddr: lang.Address{},
 									Type: cty.Object(map[string]cty.Type{
 										"port":     cty.Number,
 										"protocol": cty.String,
@@ -3450,6 +3457,7 @@ provider "test" {
 										lang.AttrStep{Name: "listener"},
 										lang.IndexStep{Key: cty.StringVal("https")},
 									},
+									LocalAddr: lang.Address{},
 									Type: cty.Object(map[string]cty.Type{
 										"port":     cty.Number,
 										"protocol": cty.String,
@@ -4234,6 +4242,7 @@ module "different" {
 						lang.RootStep{Name: "module"},
 						lang.AttrStep{Name: "test"},
 					},
+					LocalAddr: lang.Address{},
 					Type: cty.Object(map[string]cty.Type{
 						"attr": cty.String,
 					}),

--- a/decoder/reference_targets_collect_hcl_test.go
+++ b/decoder/reference_targets_collect_hcl_test.go
@@ -2768,6 +2768,7 @@ provider "test" {
 								lang.AttrStep{Name: "aws"},
 								lang.AttrStep{Name: "setblock"},
 							},
+							LocalAddr: lang.Address{},
 							RangePtr: &hcl.Range{
 								Filename: "test.tf",
 								Start: hcl.Pos{

--- a/decoder/reference_targets_collect_json_test.go
+++ b/decoder/reference_targets_collect_json_test.go
@@ -1473,6 +1473,7 @@ func TestCollectReferenceTargets_json(t *testing.T) {
 					Addr: lang.Address{
 						lang.RootStep{Name: "aws"},
 					},
+					LocalAddr: lang.Address{},
 					Type: cty.Object(map[string]cty.Type{
 						"attr":      cty.Number,
 						"name":      cty.String,
@@ -1826,6 +1827,7 @@ func TestCollectReferenceTargets_json(t *testing.T) {
 								lang.AttrStep{Name: "aws"},
 								lang.AttrStep{Name: "objblock"},
 							},
+							LocalAddr: lang.Address{},
 							RangePtr: &hcl.Range{
 								Filename: "test.tf.json",
 								Start: hcl.Pos{
@@ -2100,6 +2102,7 @@ func TestCollectReferenceTargets_json(t *testing.T) {
 										lang.AttrStep{Name: "listblock"},
 										lang.IndexStep{Key: cty.NumberIntVal(0)},
 									},
+									LocalAddr: lang.Address{},
 									RangePtr: &hcl.Range{
 										Filename: "test.tf.json",
 										Start: hcl.Pos{
@@ -2212,6 +2215,7 @@ func TestCollectReferenceTargets_json(t *testing.T) {
 										lang.AttrStep{Name: "listblock"},
 										lang.IndexStep{Key: cty.NumberIntVal(1)},
 									},
+									LocalAddr: lang.Address{},
 									RangePtr: &hcl.Range{
 										Filename: "test.tf.json",
 										Start: hcl.Pos{
@@ -2655,6 +2659,7 @@ func TestCollectReferenceTargets_json(t *testing.T) {
 										lang.AttrStep{Name: "listblock"},
 										lang.IndexStep{Key: cty.NumberIntVal(0)},
 									},
+									LocalAddr: lang.Address{},
 									RangePtr: &hcl.Range{
 										Filename: "test.tf.json",
 										Start: hcl.Pos{
@@ -2767,6 +2772,7 @@ func TestCollectReferenceTargets_json(t *testing.T) {
 										lang.AttrStep{Name: "listblock"},
 										lang.IndexStep{Key: cty.NumberIntVal(1)},
 									},
+									LocalAddr: lang.Address{},
 									RangePtr: &hcl.Range{
 										Filename: "test.tf.json",
 										Start: hcl.Pos{
@@ -3049,6 +3055,7 @@ func TestCollectReferenceTargets_json(t *testing.T) {
 										lang.AttrStep{Name: "listener"},
 										lang.IndexStep{Key: cty.StringVal("http")},
 									},
+									LocalAddr: lang.Address{},
 									Type: cty.Object(map[string]cty.Type{
 										"port":     cty.Number,
 										"protocol": cty.String,
@@ -3161,6 +3168,7 @@ func TestCollectReferenceTargets_json(t *testing.T) {
 										lang.AttrStep{Name: "listener"},
 										lang.IndexStep{Key: cty.StringVal("https")},
 									},
+									LocalAddr: lang.Address{},
 									Type: cty.Object(map[string]cty.Type{
 										"port":     cty.Number,
 										"protocol": cty.String,
@@ -3954,6 +3962,7 @@ func TestCollectReferenceTargets_json(t *testing.T) {
 						lang.RootStep{Name: "module"},
 						lang.AttrStep{Name: "test"},
 					},
+					LocalAddr: lang.Address{},
 					Type: cty.Object(map[string]cty.Type{
 						"attr": cty.String,
 					}),

--- a/decoder/reference_targets_collect_json_test.go
+++ b/decoder/reference_targets_collect_json_test.go
@@ -2469,6 +2469,7 @@ func TestCollectReferenceTargets_json(t *testing.T) {
 								lang.AttrStep{Name: "aws"},
 								lang.AttrStep{Name: "setblock"},
 							},
+							LocalAddr: lang.Address{},
 							RangePtr: &hcl.Range{
 								Filename: "test.tf.json",
 								Start: hcl.Pos{

--- a/decoder/reference_targets_collect_json_test.go
+++ b/decoder/reference_targets_collect_json_test.go
@@ -2076,6 +2076,7 @@ func TestCollectReferenceTargets_json(t *testing.T) {
 								lang.AttrStep{Name: "aws"},
 								lang.AttrStep{Name: "listblock"},
 							},
+							LocalAddr: lang.Address{},
 							RangePtr: &hcl.Range{
 								Filename: "test.tf.json",
 								Start: hcl.Pos{
@@ -2633,6 +2634,7 @@ func TestCollectReferenceTargets_json(t *testing.T) {
 								lang.AttrStep{Name: "aws"},
 								lang.AttrStep{Name: "listblock"},
 							},
+							LocalAddr: lang.Address{},
 							RangePtr: &hcl.Range{
 								Filename: "test.tf.json",
 								Start: hcl.Pos{

--- a/decoder/reference_targets_collect_json_test.go
+++ b/decoder/reference_targets_collect_json_test.go
@@ -3032,6 +3032,7 @@ func TestCollectReferenceTargets_json(t *testing.T) {
 								lang.AttrStep{Name: "aws"},
 								lang.AttrStep{Name: "listener"},
 							},
+							LocalAddr: lang.Address{},
 							RangePtr: &hcl.Range{
 								Filename: "test.tf.json",
 								Start: hcl.Pos{

--- a/reference/target.go
+++ b/reference/target.go
@@ -100,7 +100,8 @@ func copyHclRangePtr(rng *hcl.Range) *hcl.Range {
 // depending on the provided context
 func (r Target) Address(ctx context.Context) lang.Address {
 	addr := r.Addr
-	if len(r.LocalAddr) > 0 {
+	if len(r.LocalAddr) > 0 &&
+		(len(r.Addr) == 0 || schema.ActiveSelfRefsFromContext(ctx)) {
 		addr = r.LocalAddr
 	}
 

--- a/reference/target.go
+++ b/reference/target.go
@@ -98,14 +98,23 @@ func copyHclRangePtr(rng *hcl.Range) *hcl.Range {
 
 // Address returns any of the two non-empty addresses
 // depending on the provided context
-func (r Target) Address(ctx context.Context) lang.Address {
-	addr := r.Addr
-	if len(r.LocalAddr) > 0 &&
-		(len(r.Addr) == 0 || schema.ActiveSelfRefsFromContext(ctx)) {
-		addr = r.LocalAddr
+func (r Target) Address(ctx context.Context, pos hcl.Pos) lang.Address {
+	if len(r.LocalAddr) > 0 {
+		// If the target has only local address, use it
+		if len(r.Addr) == 0 {
+			return r.LocalAddr
+		}
+
+		// If the target has local self address & self is active
+		if r.LocalAddr[0].String() == "self" && schema.ActiveSelfRefsFromContext(ctx) {
+			// and we targeting it from the expected range
+			if r.TargetableFromRangePtr != nil && r.TargetableFromRangePtr.ContainsPos(pos) {
+				return r.LocalAddr
+			}
+		}
 	}
 
-	return addr
+	return r.Addr
 }
 
 func (r Target) FriendlyName() string {

--- a/reference/target_test.go
+++ b/reference/target_test.go
@@ -1,0 +1,160 @@
+package reference
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty-debug/ctydebug"
+)
+
+func TestTarget_Address(t *testing.T) {
+	testCases := []struct {
+		name            string
+		pos             hcl.Pos
+		activeSelfRefs  bool
+		target          Target
+		expectedAddress lang.Address
+	}{
+		{
+			"absolute address and no local address",
+			hcl.InitialPos,
+			false,
+			Target{
+				Addr: lang.Address{
+					lang.RootStep{Name: "aws_instance"},
+					lang.AttrStep{Name: "instance_size"},
+				},
+			},
+			lang.Address{
+				lang.RootStep{Name: "aws_instance"},
+				lang.AttrStep{Name: "instance_size"},
+			},
+		},
+		{
+			"local address and no absolute address",
+			hcl.InitialPos,
+			false,
+			Target{
+				LocalAddr: lang.Address{
+					lang.RootStep{Name: "count"},
+					lang.AttrStep{Name: "index"},
+				},
+			},
+			lang.Address{
+				lang.RootStep{Name: "count"},
+				lang.AttrStep{Name: "index"},
+			},
+		},
+		{
+			"self address with active self and matching range",
+			hcl.Pos{Line: 2, Column: 2, Byte: 2},
+			true,
+			Target{
+				Addr: lang.Address{
+					lang.RootStep{Name: "aws_instance"},
+					lang.AttrStep{Name: "instance_size"},
+				},
+				LocalAddr: lang.Address{
+					lang.RootStep{Name: "self"},
+					lang.AttrStep{Name: "instance_size"},
+				},
+				TargetableFromRangePtr: &hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+					End:      hcl.Pos{Line: 3, Column: 1, Byte: 10},
+				},
+			},
+			lang.Address{
+				lang.RootStep{Name: "self"},
+				lang.AttrStep{Name: "instance_size"},
+			},
+		},
+		{
+			"self address without active self but matching range",
+			hcl.Pos{Line: 2, Column: 2, Byte: 2},
+			false,
+			Target{
+				Addr: lang.Address{
+					lang.RootStep{Name: "aws_instance"},
+					lang.AttrStep{Name: "instance_size"},
+				},
+				LocalAddr: lang.Address{
+					lang.RootStep{Name: "self"},
+					lang.AttrStep{Name: "instance_size"},
+				},
+				TargetableFromRangePtr: &hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+					End:      hcl.Pos{Line: 3, Column: 1, Byte: 10},
+				},
+			},
+			lang.Address{
+				lang.RootStep{Name: "aws_instance"},
+				lang.AttrStep{Name: "instance_size"},
+			},
+		},
+		{
+			"self address with active self but no matching range",
+			hcl.Pos{Line: 5, Column: 2, Byte: 15},
+			true,
+			Target{
+				Addr: lang.Address{
+					lang.RootStep{Name: "aws_instance"},
+					lang.AttrStep{Name: "instance_size"},
+				},
+				LocalAddr: lang.Address{
+					lang.RootStep{Name: "self"},
+					lang.AttrStep{Name: "instance_size"},
+				},
+				TargetableFromRangePtr: &hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+					End:      hcl.Pos{Line: 3, Column: 1, Byte: 10},
+				},
+			},
+			lang.Address{
+				lang.RootStep{Name: "aws_instance"},
+				lang.AttrStep{Name: "instance_size"},
+			},
+		},
+		{
+			"self address with active self and missing targetable",
+			hcl.Pos{Line: 5, Column: 2, Byte: 15},
+			true,
+			Target{
+				Addr: lang.Address{
+					lang.RootStep{Name: "aws_instance"},
+					lang.AttrStep{Name: "instance_size"},
+				},
+				LocalAddr: lang.Address{
+					lang.RootStep{Name: "self"},
+					lang.AttrStep{Name: "instance_size"},
+				},
+			},
+			lang.Address{
+				lang.RootStep{Name: "aws_instance"},
+				lang.AttrStep{Name: "instance_size"},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {
+			ctx := context.Background()
+
+			if tc.activeSelfRefs {
+				ctx = schema.WithActiveSelfRefs(ctx)
+			}
+
+			address := tc.target.Address(ctx, tc.pos)
+			if diff := cmp.Diff(tc.expectedAddress, address, ctydebug.CmpOptions); diff != "" {
+				t.Fatalf("mismatch of address: %s", diff)
+			}
+		})
+	}
+}

--- a/reference/targets.go
+++ b/reference/targets.go
@@ -87,6 +87,11 @@ func (refs Targets) MatchWalk(ctx context.Context, te schema.TraversalExpr, pref
 
 func localTargetMatches(ctx context.Context, target Target, te schema.TraversalExpr, prefix string, outermostBodyRng, originRng hcl.Range) bool {
 	if len(target.LocalAddr) > 0 && strings.HasPrefix(target.LocalAddr.String(), prefix) {
+		// reject self references if not enabled
+		if !schema.ActiveSelfRefsFromContext(ctx) && target.LocalAddr[0].String() == "self" {
+			return false
+		}
+
 		hasNestedMatches := target.NestedTargets.containsMatch(ctx, te, prefix, outermostBodyRng, originRng)
 
 		// Avoid suggesting cyclical reference to the same attribute

--- a/reference/targets_test.go
+++ b/reference/targets_test.go
@@ -881,6 +881,7 @@ func TestTargets_MatchWalk_localRefs(t *testing.T) {
 		prefix           string
 		outermostBodyRng hcl.Range
 		originRng        hcl.Range
+		activeSelfRefs   bool
 		expectedTargets  Targets
 	}{
 		{
@@ -898,6 +899,7 @@ func TestTargets_MatchWalk_localRefs(t *testing.T) {
 				Start:    hcl.InitialPos,
 				End:      hcl.InitialPos,
 			},
+			false,
 			Targets{},
 		},
 		{
@@ -928,6 +930,7 @@ func TestTargets_MatchWalk_localRefs(t *testing.T) {
 				Start:    hcl.InitialPos,
 				End:      hcl.InitialPos,
 			},
+			false,
 			Targets{
 				{
 					LocalAddr: lang.Address{
@@ -978,6 +981,7 @@ func TestTargets_MatchWalk_localRefs(t *testing.T) {
 				Start:    hcl.InitialPos,
 				End:      hcl.InitialPos,
 			},
+			false,
 			Targets{
 				{
 					LocalAddr: lang.Address{
@@ -1044,6 +1048,7 @@ func TestTargets_MatchWalk_localRefs(t *testing.T) {
 				Start:    hcl.Pos{Line: 5, Column: 1, Byte: 25},
 				End:      hcl.Pos{Line: 5, Column: 10, Byte: 35},
 			},
+			false,
 			Targets{
 				{
 					LocalAddr: lang.Address{
@@ -1099,6 +1104,7 @@ func TestTargets_MatchWalk_localRefs(t *testing.T) {
 				Start:    hcl.Pos{Line: 2, Column: 11, Byte: 38},
 				End:      hcl.Pos{Line: 2, Column: 11, Byte: 38},
 			},
+			false,
 			Targets{},
 		},
 		{
@@ -1158,6 +1164,172 @@ func TestTargets_MatchWalk_localRefs(t *testing.T) {
 				Start:    hcl.Pos{Line: 2, Column: 9, Byte: 36},
 				End:      hcl.Pos{Line: 2, Column: 9, Byte: 36},
 			},
+			true,
+			Targets{},
+		},
+		{
+			"self only matches when enabled",
+			Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "aws_alb"},
+						lang.AttrStep{Name: "test"},
+					},
+					LocalAddr: lang.Address{
+						lang.RootStep{Name: "self"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 28, Byte: 27},
+						End:      hcl.Pos{Line: 4, Column: 1, Byte: 37},
+					},
+					TargetableFromRangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 28, Byte: 27},
+						End:      hcl.Pos{Line: 4, Column: 1, Byte: 37},
+					},
+					NestedTargets: Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "aws_alb"},
+								lang.AttrStep{Name: "test"},
+								lang.AttrStep{Name: "bar"},
+							},
+							LocalAddr: lang.Address{
+								lang.RootStep{Name: "self"},
+								lang.AttrStep{Name: "bar"},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start:    hcl.Pos{Line: 2, Column: 1, Byte: 30},
+								End:      hcl.Pos{Line: 2, Column: 20, Byte: 35},
+							},
+							TargetableFromRangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start:    hcl.Pos{Line: 1, Column: 28, Byte: 27},
+								End:      hcl.Pos{Line: 4, Column: 1, Byte: 37},
+							},
+						},
+					},
+				},
+			},
+			schema.TraversalExpr{},
+			"",
+			hcl.Range{ // outermost body range
+				Filename: "test.tf",
+				Start:    hcl.Pos{Line: 1, Column: 28, Byte: 27},
+				End:      hcl.Pos{Line: 3, Column: 1, Byte: 37},
+			},
+			hcl.Range{ // origin range
+				Filename: "test.tf",
+				Start:    hcl.Pos{Line: 3, Column: 2, Byte: 36},
+				End:      hcl.Pos{Line: 3, Column: 2, Byte: 36},
+			},
+			true,
+			Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "aws_alb"},
+						lang.AttrStep{Name: "test"},
+					},
+					LocalAddr: lang.Address{
+						lang.RootStep{Name: "self"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 28, Byte: 27},
+						End:      hcl.Pos{Line: 4, Column: 1, Byte: 37},
+					},
+					TargetableFromRangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 28, Byte: 27},
+						End:      hcl.Pos{Line: 4, Column: 1, Byte: 37},
+					},
+					NestedTargets: Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "aws_alb"},
+								lang.AttrStep{Name: "test"},
+								lang.AttrStep{Name: "bar"},
+							},
+							LocalAddr: lang.Address{
+								lang.RootStep{Name: "self"},
+								lang.AttrStep{Name: "bar"},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start:    hcl.Pos{Line: 2, Column: 1, Byte: 30},
+								End:      hcl.Pos{Line: 2, Column: 20, Byte: 35},
+							},
+							TargetableFromRangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start:    hcl.Pos{Line: 1, Column: 28, Byte: 27},
+								End:      hcl.Pos{Line: 4, Column: 1, Byte: 37},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"self doesn't match when disabled",
+			Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "aws_alb"},
+						lang.AttrStep{Name: "test"},
+					},
+					LocalAddr: lang.Address{
+						lang.RootStep{Name: "self"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 28, Byte: 27},
+						End:      hcl.Pos{Line: 4, Column: 1, Byte: 37},
+					},
+					TargetableFromRangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 28, Byte: 27},
+						End:      hcl.Pos{Line: 4, Column: 1, Byte: 37},
+					},
+					NestedTargets: Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "aws_alb"},
+								lang.AttrStep{Name: "test"},
+								lang.AttrStep{Name: "bar"},
+							},
+							LocalAddr: lang.Address{
+								lang.RootStep{Name: "self"},
+								lang.AttrStep{Name: "bar"},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start:    hcl.Pos{Line: 2, Column: 1, Byte: 30},
+								End:      hcl.Pos{Line: 2, Column: 20, Byte: 35},
+							},
+							TargetableFromRangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start:    hcl.Pos{Line: 1, Column: 28, Byte: 27},
+								End:      hcl.Pos{Line: 4, Column: 1, Byte: 37},
+							},
+						},
+					},
+				},
+			},
+			schema.TraversalExpr{},
+			"",
+			hcl.Range{ // outermost body range
+				Filename: "test.tf",
+				Start:    hcl.Pos{Line: 1, Column: 28, Byte: 27},
+				End:      hcl.Pos{Line: 3, Column: 1, Byte: 37},
+			},
+			hcl.Range{ // origin range
+				Filename: "test.tf",
+				Start:    hcl.Pos{Line: 3, Column: 2, Byte: 36},
+				End:      hcl.Pos{Line: 3, Column: 2, Byte: 36},
+			},
+			false,
 			Targets{},
 		},
 	}
@@ -1166,6 +1338,9 @@ func TestTargets_MatchWalk_localRefs(t *testing.T) {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {
 			targets := make(Targets, 0)
 			ctx := context.Background()
+			if tc.activeSelfRefs {
+				ctx = schema.WithActiveSelfRefs(ctx)
+			}
 			tc.targets.MatchWalk(ctx, tc.traversalConst, tc.prefix, tc.outermostBodyRng, tc.originRng, func(t Target) error {
 				targets = append(targets, t)
 				return nil

--- a/reference/traversal.go
+++ b/reference/traversal.go
@@ -6,9 +6,16 @@ import (
 	"github.com/hashicorp/hcl/v2"
 )
 
-func TraversalsToLocalOrigins(traversals []hcl.Traversal, tes schema.TraversalExprs) Origins {
+func TraversalsToLocalOrigins(traversals []hcl.Traversal, tes schema.TraversalExprs, allowSelfRefs bool) Origins {
 	origins := make(Origins, 0)
 	for _, traversal := range traversals {
+		// traversal should not be relative here, since the input to this
+		// function `expr.Variables()` only returns absolute traversals
+		if !traversal.IsRelative() && traversal.RootName() == "self" && !allowSelfRefs {
+			// Only if a block allows the usage of self.* we create a origin,
+			// else just continue
+			continue
+		}
 		origin, err := TraversalToLocalOrigin(traversal, tes)
 		if err != nil {
 			continue

--- a/reference/traversal_test.go
+++ b/reference/traversal_test.go
@@ -98,3 +98,81 @@ func TestTraversalToOrigin(t *testing.T) {
 		})
 	}
 }
+
+func TestTraversalsToOrigin(t *testing.T) {
+	testCases := []struct {
+		testName        string
+		rawTraversals   []string
+		traversalExprs  schema.TraversalExprs
+		allowSelfRefs   bool
+		expectedOrigins Origins
+	}{
+		{
+			"origin collection without self refs",
+			[]string{"foo.bar", "self.bar"},
+			schema.TraversalExprs{},
+			false,
+			Origins{
+				LocalOrigin{
+					Addr: lang.Address{
+						lang.RootStep{Name: "foo"},
+						lang.AttrStep{Name: "bar"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					},
+				},
+			},
+		},
+		{
+			"origin collection with self refs",
+			[]string{"foo.bar", "self.bar"},
+			schema.TraversalExprs{},
+			true,
+			Origins{
+				LocalOrigin{
+					Addr: lang.Address{
+						lang.RootStep{Name: "foo"},
+						lang.AttrStep{Name: "bar"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					},
+				},
+				LocalOrigin{
+					Addr: lang.Address{
+						lang.RootStep{Name: "self"},
+						lang.AttrStep{Name: "bar"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 9, Byte: 8},
+					},
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+			traversals := make([]hcl.Traversal, 0)
+			for _, rawTraversal := range tc.rawTraversals {
+				traversal, diags := hclsyntax.ParseTraversalAbs([]byte(rawTraversal), "test.tf", hcl.InitialPos)
+				if len(diags) > 0 {
+					t.Fatal(diags)
+				}
+				traversals = append(traversals, traversal)
+			}
+
+			origins := TraversalsToLocalOrigins(traversals, tc.traversalExprs, tc.allowSelfRefs)
+			if diff := cmp.Diff(tc.expectedOrigins, origins, ctydebug.CmpOptions); diff != "" {
+				t.Fatalf("origin mismatch: %s", diff)
+			}
+		})
+	}
+}

--- a/schema/block_schema.go
+++ b/schema/block_schema.go
@@ -69,6 +69,16 @@ type BlockAddrSchema struct {
 	// blocks and attributes are also walked
 	// and their addresses inferred as data
 	InferDependentBody bool
+
+	// DependentBodySelfRef instructs collection of reference
+	// targets with an additional self.* LocalAddr and
+	// makes those targetable by origins within the block body
+	// via reference.Target.TargetableFromRangePtr.
+	//
+	// The targetting (matching w/ origins) is further limited by
+	// BodySchema.Extensions.SelfRef, where only self.* origins
+	// within a body w/ SelfRef:true will be collected.
+	DependentBodySelfRef bool
 }
 
 type BlockAsTypeOf struct {
@@ -99,6 +109,10 @@ func (bas *BlockAddrSchema) Validate() error {
 		return errors.New("InferDependentBody requires DependentBodyAsData")
 	}
 
+	if bas.DependentBodySelfRef && !bas.InferDependentBody {
+		return errors.New("DependentBodySelfRef requires InferDependentBody")
+	}
+
 	return nil
 }
 
@@ -108,15 +122,16 @@ func (bas *BlockAddrSchema) Copy() *BlockAddrSchema {
 	}
 
 	newBas := &BlockAddrSchema{
-		FriendlyName:        bas.FriendlyName,
-		ScopeId:             bas.ScopeId,
-		AsReference:         bas.AsReference,
-		AsTypeOf:            bas.AsTypeOf.Copy(),
-		BodyAsData:          bas.BodyAsData,
-		InferBody:           bas.InferBody,
-		DependentBodyAsData: bas.DependentBodyAsData,
-		InferDependentBody:  bas.InferDependentBody,
-		Steps:               bas.Steps.Copy(),
+		FriendlyName:         bas.FriendlyName,
+		ScopeId:              bas.ScopeId,
+		AsReference:          bas.AsReference,
+		AsTypeOf:             bas.AsTypeOf.Copy(),
+		BodyAsData:           bas.BodyAsData,
+		InferBody:            bas.InferBody,
+		DependentBodyAsData:  bas.DependentBodyAsData,
+		InferDependentBody:   bas.InferDependentBody,
+		DependentBodySelfRef: bas.DependentBodySelfRef,
+		Steps:                bas.Steps.Copy(),
 	}
 
 	return newBas

--- a/schema/body_schema.go
+++ b/schema/body_schema.go
@@ -54,6 +54,7 @@ type BodyExtensions struct {
 	Count         bool // count attribute + count.index refs
 	ForEach       bool // for_each attribute + each.* refs
 	DynamicBlocks bool // dynamic "block-name" w/ content & for_each inside
+	SelfRefs      bool // self.* refs
 }
 
 func (be *BodyExtensions) Copy() *BodyExtensions {
@@ -65,6 +66,7 @@ func (be *BodyExtensions) Copy() *BodyExtensions {
 		Count:         be.Count,
 		ForEach:       be.ForEach,
 		DynamicBlocks: be.DynamicBlocks,
+		SelfRefs:      be.SelfRefs,
 	}
 }
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -33,6 +33,16 @@ func ActiveForEachFromContext(ctx context.Context) bool {
 	return ctx.Value(bodyActiveForEachCtxKey{}) != nil
 }
 
+type bodyActiveSelfRefsCtxKey struct{}
+
+func WithActiveSelfRefs(ctx context.Context) context.Context {
+	return context.WithValue(ctx, bodyActiveSelfRefsCtxKey{}, true)
+}
+
+func ActiveSelfRefsFromContext(ctx context.Context) bool {
+	return ctx.Value(bodyActiveSelfRefsCtxKey{}) != nil
+}
+
 type bodyActiveDynamicBlockCtxKey struct{}
 
 func WithActiveDynamicBlock(ctx context.Context) context.Context {


### PR DESCRIPTION
## Architecture Background

### One vs Two schema flags (targets vs origins)

Originally the hope/plan was to have just a single "flag" in the schema under the `Extensions` - `SelfRef: true`, just like we have for Count and ForEach and will have for dynamic blocks. However, it turns out that isn't most practical. This is because we collect reference targets with the appropriate addresses separately from origins and because we would have to traverse through the rest of a potentially deeply nested and long block, to find out whether a particular target needs a local `self` address or not.

So we instead introduce the additional `DependentBodySelfRef: true` which implies that any attributes and blocks within the body will be collected as a target with an additional `self.*` local address. This will then be enabled for Terraform within the `resource` and `data` blocks and allows us to do the target collection without knowing whether that address is needed or not in the rest of the block.

### Contextual Address

Since reference targets can now have both local (`LocalAddr`) and "absolute" (`Addr`) address, this needs to be considered when rendering the address in completion, hover and elsewhere. In Terraform, `self.*` addresses are relevant under `provisioner`, `connection` and some other blocks, and the assumption is that these refer to the outermost block/body, i.e. `resource` block.

## UX Impact

### Completion

![2022-11-24 12 45 19](https://user-images.githubusercontent.com/287584/203787925-1b2192f3-21c9-4b51-94eb-cf7f61a840fc.gif)

### Hover

![Screenshot 2022-11-24 at 12 45 54](https://user-images.githubusercontent.com/287584/203787892-d8ae3d7a-4f66-44f6-9f0e-e85394c56014.png)

### Go-to-*

![2022-11-24 12 47 20](https://user-images.githubusercontent.com/287584/203788279-8ebdf097-0396-4acb-87dc-e424e06ec674.gif)

### Semantic Token Highlighting

![Screenshot 2022-11-24 at 12 48 22](https://user-images.githubusercontent.com/287584/203788440-df1db06c-9fae-45e9-9130-43ca25c93096.png)
