### PR TITLE
Avoid completing static block inside a `dynamic` label

### DIFF
--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -50,10 +50,6 @@ func mergeBlockBodySchemas(block *hcl.Block, blockSchema *schema.BlockSchema) (*
 		mergedSchema.ImpliedOrigins = make([]schema.ImpliedOrigin, 0)
 	}
 
-	if mergedSchema.Extensions != nil && mergedSchema.Extensions.DynamicBlocks && len(mergedSchema.Blocks) > 0 {
-		mergedSchema.Blocks["dynamic"] = buildDynamicBlockSchema(mergedSchema)
-	}
-
 	depSchema, _, ok := NewBlockSchema(blockSchema).DependentBodySchema(block)
 	if ok {
 		for name, attr := range depSchema.Attributes {
@@ -96,6 +92,10 @@ func mergeBlockBodySchemas(block *hcl.Block, blockSchema *schema.BlockSchema) (*
 		// (to avoid resetting to nil)
 		if depSchema.Extensions != nil {
 			mergedSchema.Extensions = depSchema.Extensions.Copy()
+		}
+	} else {
+		if mergedSchema.Extensions != nil && mergedSchema.Extensions.DynamicBlocks && len(mergedSchema.Blocks) > 0 {
+			mergedSchema.Blocks["dynamic"] = buildDynamicBlockSchema(mergedSchema)
 		}
 	}
 

--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -93,10 +93,8 @@ func mergeBlockBodySchemas(block *hcl.Block, blockSchema *schema.BlockSchema) (*
 		if depSchema.Extensions != nil {
 			mergedSchema.Extensions = depSchema.Extensions.Copy()
 		}
-	} else {
-		if mergedSchema.Extensions != nil && mergedSchema.Extensions.DynamicBlocks && len(mergedSchema.Blocks) > 0 {
-			mergedSchema.Blocks["dynamic"] = buildDynamicBlockSchema(mergedSchema)
-		}
+	} else if !ok && mergedSchema.Extensions != nil && mergedSchema.Extensions.DynamicBlocks && len(mergedSchema.Blocks) > 0 {
+		mergedSchema.Blocks["dynamic"] = buildDynamicBlockSchema(mergedSchema)
 	}
 
 	return mergedSchema, nil


### PR DESCRIPTION
This PR fixes an error where we're offering static blocks for completion when there are no blocks in the dependent body.

## Before
![Screenshot 2022-11-24 at 15 59 21](https://user-images.githubusercontent.com/45985/204030364-8518c49f-3cff-443f-8d94-3f74c81dfe4f.png)

## After
![CleanShot 2022-11-29 at 17 39 00](https://user-images.githubusercontent.com/45985/204588946-1c440cf8-a398-4989-875b-d91b70d231be.png)
`dynamic` isn't available anymore, because there are no blocks in the dependent body.
