### PR TITLE
Fix missing hover for `count` and `for_each` expression

### DIFF
--- a/decoder/reference_origins.go
+++ b/decoder/reference_origins.go
@@ -122,13 +122,21 @@ func (d *PathDecoder) referenceOriginsInBody(body hcl.Body, bodySchema *schema.B
 	content := decodeBody(body, bodySchema)
 
 	for _, attr := range content.Attributes {
-		aSchema, ok := bodySchema.Attributes[attr.Name]
-		if !ok {
-			if bodySchema.AnyAttribute == nil {
-				// skip unknown attribute
-				continue
+		var aSchema *schema.AttributeSchema
+		if bodySchema.Extensions != nil && bodySchema.Extensions.Count && attr.Name == "count" {
+			aSchema = countAttributeSchema()
+		} else if bodySchema.Extensions != nil && bodySchema.Extensions.ForEach && attr.Name == "for_each" {
+			aSchema = forEachAttributeSchema()
+		} else {
+			var ok bool
+			aSchema, ok = bodySchema.Attributes[attr.Name]
+			if !ok {
+				if bodySchema.AnyAttribute == nil {
+					// skip unknown attribute
+					continue
+				}
+				aSchema = bodySchema.AnyAttribute
 			}
-			aSchema = bodySchema.AnyAttribute
 		}
 
 		if aSchema.OriginForTarget != nil {


### PR DESCRIPTION
This PR adds the extension-based schema changes for `count` and `for_each` during reference origin collection. This error occurred because we collected no origins for `var.name`.

## Before
![CleanShot 2022-11-28 at 16 51 30@2x](https://user-images.githubusercontent.com/45985/204322467-33ed98f4-2e35-42e6-8d9f-706138637c8f.png)

![CleanShot 2022-11-28 at 16 51 02@2x](https://user-images.githubusercontent.com/45985/204322485-e8f6150b-1a2c-4de7-8112-aac60c240f27.png)

## After
<img width="312" alt="CleanShot 2022-11-30 at 11 14 48@2x" src="https://user-images.githubusercontent.com/45985/204770093-7801029f-6186-4456-8a7d-adc0664e0323.png">

<img width="265" alt="CleanShot 2022-11-30 at 11 15 31@2x" src="https://user-images.githubusercontent.com/45985/204770106-5e34c6ec-ccdc-41d2-a372-b338492cb30b.png">

