### PR TITLE
Change dynamic block type to default

### DIFF
--- a/decoder/body_extensions_test.go
+++ b/decoder/body_extensions_test.go
@@ -1839,7 +1839,7 @@ resource "aws_elastic_beanstalk_environment" "example" {
 						Value: "A dynamic block to produce blocks dynamically by iterating over a given complex value",
 						Kind:  lang.MarkdownKind,
 					},
-					Detail:         "Block, map",
+					Detail:         "Block",
 					Kind:           lang.BlockCandidateKind,
 					TriggerSuggest: true,
 					TextEdit: lang.TextEdit{
@@ -2269,7 +2269,7 @@ resource "aws_elastic_beanstalk_environment" "example" {
 						Value: "A dynamic block to produce blocks dynamically by iterating over a given complex value",
 						Kind:  lang.MarkdownKind,
 					},
-					Detail:         "Block, map",
+					Detail:         "Block",
 					Kind:           lang.BlockCandidateKind,
 					TriggerSuggest: true,
 					TextEdit: lang.TextEdit{
@@ -2435,7 +2435,7 @@ resource "aws_elastic_beanstalk_environment" "example" {
 						Value: "A dynamic block to produce blocks dynamically by iterating over a given complex value",
 						Kind:  lang.MarkdownKind,
 					},
-					Detail:         "Block, map",
+					Detail:         "Block",
 					Kind:           lang.BlockCandidateKind,
 					TriggerSuggest: true,
 					TextEdit: lang.TextEdit{
@@ -2537,7 +2537,7 @@ resource "aws_elastic_beanstalk_environment" "example" {
 						Value: "A dynamic block to produce blocks dynamically by iterating over a given complex value",
 						Kind:  lang.MarkdownKind,
 					},
-					Detail:         "Block, map",
+					Detail:         "Block",
 					Kind:           lang.BlockCandidateKind,
 					TriggerSuggest: true,
 					TextEdit: lang.TextEdit{

--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -228,7 +228,6 @@ func buildDynamicBlockSchema(inputSchema *schema.BodySchema) *schema.BlockSchema
 
 	return &schema.BlockSchema{
 		Description: lang.Markdown("A dynamic block to produce blocks dynamically by iterating over a given complex value"),
-		Type:        schema.BlockTypeMap,
 		Labels: []*schema.LabelSchema{
 			{
 				Name:        "name",

--- a/decoder/hover_test.go
+++ b/decoder/hover_test.go
@@ -1440,7 +1440,7 @@ func TestDecoder_HoverAtPos_extensions_dynamic(t *testing.T) {
 			hcl.Pos{Line: 2, Column: 5, Byte: 26},
 			&lang.HoverData{
 				Content: lang.MarkupContent{
-					Value: "**dynamic** _Block, map_\n\n" +
+					Value: "**dynamic** _Block_\n\n" +
 						"A dynamic block to produce blocks dynamically by iterating over a given complex value",
 					Kind: lang.MarkdownKind,
 				},


### PR DESCRIPTION
This PR removes `schema.BlockTypeMap` from the `dynamic` block