### PR TITLE
Support for nested expressions - 1st stage

### DIFF
--- a/decoder/attribute_candidates_legacy_test.go
+++ b/decoder/attribute_candidates_legacy_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-func TestSnippetForAttribute(t *testing.T) {
+func TestLegacyDecoder_CompletionAtPos_EmptyCompletionData(t *testing.T) {
 	testCases := []struct {
 		testName           string
 		attrName           string

--- a/decoder/attribute_candidates_test.go
+++ b/decoder/attribute_candidates_test.go
@@ -1,20 +1,24 @@
 package decoder
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/zclconf/go-cty/cty"
 )
 
 func TestSnippetForAttribute(t *testing.T) {
 	testCases := []struct {
-		testName        string
-		attrName        string
-		attrSchema      *schema.AttributeSchema
-		expectedSnippet string
+		testName           string
+		attrName           string
+		attrSchema         *schema.AttributeSchema
+		expectedCandidates lang.Candidates
 	}{
 		{
 			"primitive type",
@@ -22,7 +26,22 @@ func TestSnippetForAttribute(t *testing.T) {
 			&schema.AttributeSchema{
 				Expr: schema.LiteralTypeOnly(cty.String),
 			},
-			`primitive = "${1:value}"`,
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "primitive",
+					Detail: "string",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.InitialPos,
+							End:      hcl.InitialPos,
+						},
+						NewText: "primitive",
+						Snippet: `primitive = "${1:value}"`,
+					},
+					Kind: lang.AttributeCandidateKind,
+				},
+			}),
 		},
 		{
 			"map of strings",
@@ -30,9 +49,24 @@ func TestSnippetForAttribute(t *testing.T) {
 			&schema.AttributeSchema{
 				Expr: schema.LiteralTypeOnly(cty.Map(cty.String)),
 			},
-			`mymap = {
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "mymap",
+					Detail: "map of string",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.InitialPos,
+							End:      hcl.InitialPos,
+						},
+						NewText: "mymap",
+						Snippet: `mymap = {
   "${1:key}" = "${2:value}"
 }`,
+					},
+					Kind: lang.AttributeCandidateKind,
+				},
+			}),
 		},
 		{
 			"map of numbers",
@@ -40,9 +74,24 @@ func TestSnippetForAttribute(t *testing.T) {
 			&schema.AttributeSchema{
 				Expr: schema.LiteralTypeOnly(cty.Map(cty.Number)),
 			},
-			`mymap = {
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "mymap",
+					Detail: "map of number",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.InitialPos,
+							End:      hcl.InitialPos,
+						},
+						NewText: "mymap",
+						Snippet: `mymap = {
   "${1:key}" = ${2:1}
 }`,
+					},
+					Kind: lang.AttributeCandidateKind,
+				},
+			}),
 		},
 		{
 			"list of numbers",
@@ -50,7 +99,22 @@ func TestSnippetForAttribute(t *testing.T) {
 			&schema.AttributeSchema{
 				Expr: schema.LiteralTypeOnly(cty.List(cty.Number)),
 			},
-			`mylist = [ ${1:1} ]`,
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "mylist",
+					Detail: "list of number",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.InitialPos,
+							End:      hcl.InitialPos,
+						},
+						NewText: "mylist",
+						Snippet: `mylist = [ ${1:1} ]`,
+					},
+					Kind: lang.AttributeCandidateKind,
+				},
+			}),
 		},
 		{
 			"list of objects",
@@ -61,10 +125,25 @@ func TestSnippetForAttribute(t *testing.T) {
 					"second": cty.Number,
 				}))),
 			},
-			`mylistobj = [ {
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "mylistobj",
+					Detail: "list of object",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.InitialPos,
+							End:      hcl.InitialPos,
+						},
+						NewText: "mylistobj",
+						Snippet: `mylistobj = [ {
   first = "${1:value}"
   second = ${2:1}
 } ]`,
+					},
+					Kind: lang.AttributeCandidateKind,
+				},
+			}),
 		},
 		{
 			"set of numbers",
@@ -72,7 +151,22 @@ func TestSnippetForAttribute(t *testing.T) {
 			&schema.AttributeSchema{
 				Expr: schema.LiteralTypeOnly(cty.Set(cty.Number)),
 			},
-			`myset = [ ${1:1} ]`,
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "myset",
+					Detail: "set of number",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.InitialPos,
+							End:      hcl.InitialPos,
+						},
+						NewText: "myset",
+						Snippet: `myset = [ ${1:1} ]`,
+					},
+					Kind: lang.AttributeCandidateKind,
+				},
+			}),
 		},
 		{
 			"object",
@@ -84,11 +178,26 @@ func TestSnippetForAttribute(t *testing.T) {
 					"keybool": cty.Bool,
 				})),
 			},
-			`myobj = {
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "myobj",
+					Detail: "object",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.InitialPos,
+							End:      hcl.InitialPos,
+						},
+						NewText: "myobj",
+						Snippet: `myobj = {
   keybool = ${1:false}
   keynum = ${2:1}
   keystr = "${3:value}"
 }`,
+					},
+					Kind: lang.AttributeCandidateKind,
+				},
+			}),
 		},
 		{
 			"unknown type",
@@ -96,7 +205,22 @@ func TestSnippetForAttribute(t *testing.T) {
 			&schema.AttributeSchema{
 				Expr: schema.LiteralTypeOnly(cty.DynamicPseudoType),
 			},
-			`mynil = ${1}`,
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "mynil",
+					Detail: "any type",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.InitialPos,
+							End:      hcl.InitialPos,
+						},
+						NewText: "mynil",
+						Snippet: `mynil = ${1}`,
+					},
+					Kind: lang.AttributeCandidateKind,
+				},
+			}),
 		},
 		{
 			"nested object",
@@ -110,21 +234,53 @@ func TestSnippetForAttribute(t *testing.T) {
 					}),
 				})),
 			},
-			`myobj = {
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "myobj",
+					Detail: "object",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.InitialPos,
+							End:      hcl.InitialPos,
+						},
+						NewText: "myobj",
+						Snippet: `myobj = {
   another = {
     nested_number = ${1:1}
     nestedstr = "${2:value}"
   }
   keystr = "${3:value}"
 }`,
+					},
+					Kind: lang.AttributeCandidateKind,
+				},
+			}),
 		},
 	}
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
-			snippet := snippetForAttribute(tc.attrName, tc.attrSchema)
-			if diff := cmp.Diff(tc.expectedSnippet, snippet); diff != "" {
-				t.Fatalf("unexpected snippet: %s", diff)
+			f, _ := hclsyntax.ParseConfig([]byte("\n"), "test.tf", hcl.InitialPos)
+			d := testPathDecoder(t, &PathContext{
+				Schema: &schema.BodySchema{
+					Attributes: map[string]*schema.AttributeSchema{
+						tc.attrName: tc.attrSchema,
+					},
+				},
+				Files: map[string]*hcl.File{
+					"test.tf": f,
+				},
+			})
+
+			ctx := context.Background()
+			candidates, err := d.CandidatesAtPos(ctx, "test.tf", hcl.InitialPos)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedCandidates, candidates); diff != "" {
+				t.Fatalf("unexpected candidates: %s", diff)
 			}
 		})
 	}

--- a/decoder/expr_keyword.go
+++ b/decoder/expr_keyword.go
@@ -29,12 +29,12 @@ func (kw Keyword) SemanticTokens(ctx context.Context) []lang.SemanticToken {
 	return nil
 }
 
-func (kw Keyword) ReferenceOrigins(allowSelfRefs bool) reference.Origins {
+func (kw Keyword) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {
 	// TODO
 	return nil
 }
 
-func (kw Keyword) ReferenceTargets(attrAddr *schema.AttributeAddrSchema) reference.Targets {
+func (kw Keyword) ReferenceTargets(ctx context.Context, attrAddr *schema.AttributeAddrSchema) reference.Targets {
 	// TODO
 	return nil
 }

--- a/decoder/expr_keyword.go
+++ b/decoder/expr_keyword.go
@@ -1,0 +1,40 @@
+package decoder
+
+import (
+	"context"
+
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/reference"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+)
+
+type Keyword struct {
+	expr hcl.Expression
+	cons schema.Keyword
+}
+
+func (kw Keyword) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate {
+	// TODO
+	return nil
+}
+
+func (kw Keyword) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData {
+	// TODO
+	return nil
+}
+
+func (kw Keyword) SemanticTokens(ctx context.Context) []lang.SemanticToken {
+	// TODO
+	return nil
+}
+
+func (kw Keyword) ReferenceOrigins(allowSelfRefs bool) reference.Origins {
+	// TODO
+	return nil
+}
+
+func (kw Keyword) ReferenceTargets(attrAddr *schema.AttributeAddrSchema) reference.Targets {
+	// TODO
+	return nil
+}

--- a/decoder/expr_list.go
+++ b/decoder/expr_list.go
@@ -29,12 +29,12 @@ func (l List) SemanticTokens(ctx context.Context) []lang.SemanticToken {
 	return nil
 }
 
-func (l List) ReferenceOrigins(allowSelfRefs bool) reference.Origins {
+func (l List) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {
 	// TODO
 	return nil
 }
 
-func (l List) ReferenceTargets(attrAddr *schema.AttributeAddrSchema) reference.Targets {
+func (l List) ReferenceTargets(ctx context.Context, attrAddr *schema.AttributeAddrSchema) reference.Targets {
 	// TODO
 	return nil
 }

--- a/decoder/expr_list.go
+++ b/decoder/expr_list.go
@@ -1,0 +1,40 @@
+package decoder
+
+import (
+	"context"
+
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/reference"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+)
+
+type List struct {
+	expr hcl.Expression
+	cons schema.List
+}
+
+func (l List) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate {
+	// TODO
+	return nil
+}
+
+func (l List) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData {
+	// TODO
+	return nil
+}
+
+func (l List) SemanticTokens(ctx context.Context) []lang.SemanticToken {
+	// TODO
+	return nil
+}
+
+func (l List) ReferenceOrigins(allowSelfRefs bool) reference.Origins {
+	// TODO
+	return nil
+}
+
+func (l List) ReferenceTargets(attrAddr *schema.AttributeAddrSchema) reference.Targets {
+	// TODO
+	return nil
+}

--- a/decoder/expr_literal_type.go
+++ b/decoder/expr_literal_type.go
@@ -1,0 +1,40 @@
+package decoder
+
+import (
+	"context"
+
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/reference"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+)
+
+type LiteralType struct {
+	expr hcl.Expression
+	cons schema.LiteralType
+}
+
+func (lt LiteralType) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate {
+	// TODO
+	return nil
+}
+
+func (lt LiteralType) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData {
+	// TODO
+	return nil
+}
+
+func (lt LiteralType) SemanticTokens(ctx context.Context) []lang.SemanticToken {
+	// TODO
+	return nil
+}
+
+func (lt LiteralType) ReferenceOrigins(allowSelfRefs bool) reference.Origins {
+	// TODO
+	return nil
+}
+
+func (lt LiteralType) ReferenceTargets(attrAddr *schema.AttributeAddrSchema) reference.Targets {
+	// TODO
+	return nil
+}

--- a/decoder/expr_literal_type.go
+++ b/decoder/expr_literal_type.go
@@ -29,12 +29,12 @@ func (lt LiteralType) SemanticTokens(ctx context.Context) []lang.SemanticToken {
 	return nil
 }
 
-func (lt LiteralType) ReferenceOrigins(allowSelfRefs bool) reference.Origins {
+func (lt LiteralType) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {
 	// TODO
 	return nil
 }
 
-func (lt LiteralType) ReferenceTargets(attrAddr *schema.AttributeAddrSchema) reference.Targets {
+func (lt LiteralType) ReferenceTargets(ctx context.Context, attrAddr *schema.AttributeAddrSchema) reference.Targets {
 	// TODO
 	return nil
 }

--- a/decoder/expr_literal_value.go
+++ b/decoder/expr_literal_value.go
@@ -1,0 +1,40 @@
+package decoder
+
+import (
+	"context"
+
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/reference"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+)
+
+type LiteralValue struct {
+	expr hcl.Expression
+	cons schema.LiteralValue
+}
+
+func (lv LiteralValue) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate {
+	// TODO
+	return nil
+}
+
+func (lv LiteralValue) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData {
+	// TODO
+	return nil
+}
+
+func (lv LiteralValue) SemanticTokens(ctx context.Context) []lang.SemanticToken {
+	// TODO
+	return nil
+}
+
+func (lv LiteralValue) ReferenceOrigins(allowSelfRefs bool) reference.Origins {
+	// TODO
+	return nil
+}
+
+func (lv LiteralValue) ReferenceTargets(attrAddr *schema.AttributeAddrSchema) reference.Targets {
+	// TODO
+	return nil
+}

--- a/decoder/expr_literal_value.go
+++ b/decoder/expr_literal_value.go
@@ -29,12 +29,12 @@ func (lv LiteralValue) SemanticTokens(ctx context.Context) []lang.SemanticToken 
 	return nil
 }
 
-func (lv LiteralValue) ReferenceOrigins(allowSelfRefs bool) reference.Origins {
+func (lv LiteralValue) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {
 	// TODO
 	return nil
 }
 
-func (lv LiteralValue) ReferenceTargets(attrAddr *schema.AttributeAddrSchema) reference.Targets {
+func (lv LiteralValue) ReferenceTargets(ctx context.Context, attrAddr *schema.AttributeAddrSchema) reference.Targets {
 	// TODO
 	return nil
 }

--- a/decoder/expr_map.go
+++ b/decoder/expr_map.go
@@ -29,12 +29,12 @@ func (m Map) SemanticTokens(ctx context.Context) []lang.SemanticToken {
 	return nil
 }
 
-func (m Map) ReferenceOrigins(allowSelfRefs bool) reference.Origins {
+func (m Map) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {
 	// TODO
 	return nil
 }
 
-func (m Map) ReferenceTargets(attrAddr *schema.AttributeAddrSchema) reference.Targets {
+func (m Map) ReferenceTargets(ctx context.Context, attrAddr *schema.AttributeAddrSchema) reference.Targets {
 	// TODO
 	return nil
 }

--- a/decoder/expr_map.go
+++ b/decoder/expr_map.go
@@ -1,0 +1,40 @@
+package decoder
+
+import (
+	"context"
+
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/reference"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+)
+
+type Map struct {
+	expr hcl.Expression
+	cons schema.Map
+}
+
+func (m Map) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate {
+	// TODO
+	return nil
+}
+
+func (m Map) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData {
+	// TODO
+	return nil
+}
+
+func (m Map) SemanticTokens(ctx context.Context) []lang.SemanticToken {
+	// TODO
+	return nil
+}
+
+func (m Map) ReferenceOrigins(allowSelfRefs bool) reference.Origins {
+	// TODO
+	return nil
+}
+
+func (m Map) ReferenceTargets(attrAddr *schema.AttributeAddrSchema) reference.Targets {
+	// TODO
+	return nil
+}

--- a/decoder/expr_object.go
+++ b/decoder/expr_object.go
@@ -1,0 +1,70 @@
+package decoder
+
+import (
+	"context"
+
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/reference"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+)
+
+type Object struct {
+	expr hcl.Expression
+	cons schema.Object
+}
+
+func (obj Object) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate {
+	// TODO
+	return nil
+}
+
+func (obj Object) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData {
+	// TODO
+	return nil
+}
+
+func (obj Object) SemanticTokens(ctx context.Context) []lang.SemanticToken {
+	// TODO
+	return nil
+}
+
+func (obj Object) ReferenceOrigins(allowSelfRefs bool) reference.Origins {
+	// TODO
+	return nil
+}
+
+func (obj Object) ReferenceTargets(attrAddr *schema.AttributeAddrSchema) reference.Targets {
+	// TODO
+	return nil
+}
+
+type ObjectAttributes struct {
+	expr hcl.Expression
+	cons schema.ObjectAttributes
+}
+
+func (oa ObjectAttributes) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate {
+	// TODO
+	return nil
+}
+
+func (oa ObjectAttributes) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData {
+	// TODO
+	return nil
+}
+
+func (oa ObjectAttributes) SemanticTokens(ctx context.Context) []lang.SemanticToken {
+	// TODO
+	return nil
+}
+
+func (oa ObjectAttributes) ReferenceOrigins(allowSelfRefs bool) reference.Origins {
+	// TODO
+	return nil
+}
+
+func (oa ObjectAttributes) ReferenceTargets(attrAddr *schema.AttributeAddrSchema) reference.Targets {
+	// TODO
+	return nil
+}

--- a/decoder/expr_object.go
+++ b/decoder/expr_object.go
@@ -29,12 +29,12 @@ func (obj Object) SemanticTokens(ctx context.Context) []lang.SemanticToken {
 	return nil
 }
 
-func (obj Object) ReferenceOrigins(allowSelfRefs bool) reference.Origins {
+func (obj Object) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {
 	// TODO
 	return nil
 }
 
-func (obj Object) ReferenceTargets(attrAddr *schema.AttributeAddrSchema) reference.Targets {
+func (obj Object) ReferenceTargets(ctx context.Context, attrAddr *schema.AttributeAddrSchema) reference.Targets {
 	// TODO
 	return nil
 }
@@ -59,12 +59,12 @@ func (oa ObjectAttributes) SemanticTokens(ctx context.Context) []lang.SemanticTo
 	return nil
 }
 
-func (oa ObjectAttributes) ReferenceOrigins(allowSelfRefs bool) reference.Origins {
+func (oa ObjectAttributes) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {
 	// TODO
 	return nil
 }
 
-func (oa ObjectAttributes) ReferenceTargets(attrAddr *schema.AttributeAddrSchema) reference.Targets {
+func (oa ObjectAttributes) ReferenceTargets(ctx context.Context, attrAddr *schema.AttributeAddrSchema) reference.Targets {
 	// TODO
 	return nil
 }

--- a/decoder/expr_one_of.go
+++ b/decoder/expr_one_of.go
@@ -29,12 +29,12 @@ func (oo OneOf) SemanticTokens(ctx context.Context) []lang.SemanticToken {
 	return nil
 }
 
-func (oo OneOf) ReferenceOrigins(allowSelfRefs bool) reference.Origins {
+func (oo OneOf) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {
 	// TODO
 	return nil
 }
 
-func (oo OneOf) ReferenceTargets(attrAddr *schema.AttributeAddrSchema) reference.Targets {
+func (oo OneOf) ReferenceTargets(ctx context.Context, attrAddr *schema.AttributeAddrSchema) reference.Targets {
 	// TODO
 	return nil
 }

--- a/decoder/expr_one_of.go
+++ b/decoder/expr_one_of.go
@@ -1,0 +1,40 @@
+package decoder
+
+import (
+	"context"
+
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/reference"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+)
+
+type OneOf struct {
+	expr hcl.Expression
+	cons schema.OneOf
+}
+
+func (oo OneOf) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate {
+	// TODO
+	return nil
+}
+
+func (oo OneOf) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData {
+	// TODO
+	return nil
+}
+
+func (oo OneOf) SemanticTokens(ctx context.Context) []lang.SemanticToken {
+	// TODO
+	return nil
+}
+
+func (oo OneOf) ReferenceOrigins(allowSelfRefs bool) reference.Origins {
+	// TODO
+	return nil
+}
+
+func (oo OneOf) ReferenceTargets(attrAddr *schema.AttributeAddrSchema) reference.Targets {
+	// TODO
+	return nil
+}

--- a/decoder/expr_reference.go
+++ b/decoder/expr_reference.go
@@ -1,0 +1,40 @@
+package decoder
+
+import (
+	"context"
+
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/reference"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+)
+
+type Reference struct {
+	expr hcl.Expression
+	cons schema.Reference
+}
+
+func (ref Reference) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate {
+	// TODO
+	return nil
+}
+
+func (ref Reference) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData {
+	// TODO
+	return nil
+}
+
+func (ref Reference) SemanticTokens(ctx context.Context) []lang.SemanticToken {
+	// TODO
+	return nil
+}
+
+func (ref Reference) ReferenceOrigins(allowSelfRefs bool) reference.Origins {
+	// TODO
+	return nil
+}
+
+func (ref Reference) ReferenceTargets(attrAddr *schema.AttributeAddrSchema) reference.Targets {
+	// TODO
+	return nil
+}

--- a/decoder/expr_reference.go
+++ b/decoder/expr_reference.go
@@ -29,12 +29,12 @@ func (ref Reference) SemanticTokens(ctx context.Context) []lang.SemanticToken {
 	return nil
 }
 
-func (ref Reference) ReferenceOrigins(allowSelfRefs bool) reference.Origins {
+func (ref Reference) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {
 	// TODO
 	return nil
 }
 
-func (ref Reference) ReferenceTargets(attrAddr *schema.AttributeAddrSchema) reference.Targets {
+func (ref Reference) ReferenceTargets(ctx context.Context, attrAddr *schema.AttributeAddrSchema) reference.Targets {
 	// TODO
 	return nil
 }

--- a/decoder/expr_set.go
+++ b/decoder/expr_set.go
@@ -29,12 +29,12 @@ func (s Set) SemanticTokens(ctx context.Context) []lang.SemanticToken {
 	return nil
 }
 
-func (s Set) ReferenceOrigins(allowSelfRefs bool) reference.Origins {
+func (s Set) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {
 	// TODO
 	return nil
 }
 
-func (s Set) ReferenceTargets(attrAddr *schema.AttributeAddrSchema) reference.Targets {
+func (s Set) ReferenceTargets(ctx context.Context, attrAddr *schema.AttributeAddrSchema) reference.Targets {
 	// TODO
 	return nil
 }

--- a/decoder/expr_set.go
+++ b/decoder/expr_set.go
@@ -1,0 +1,40 @@
+package decoder
+
+import (
+	"context"
+
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/reference"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+)
+
+type Set struct {
+	expr hcl.Expression
+	cons schema.Set
+}
+
+func (s Set) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate {
+	// TODO
+	return nil
+}
+
+func (s Set) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData {
+	// TODO
+	return nil
+}
+
+func (s Set) SemanticTokens(ctx context.Context) []lang.SemanticToken {
+	// TODO
+	return nil
+}
+
+func (s Set) ReferenceOrigins(allowSelfRefs bool) reference.Origins {
+	// TODO
+	return nil
+}
+
+func (s Set) ReferenceTargets(attrAddr *schema.AttributeAddrSchema) reference.Targets {
+	// TODO
+	return nil
+}

--- a/decoder/expr_tuple.go
+++ b/decoder/expr_tuple.go
@@ -1,0 +1,40 @@
+package decoder
+
+import (
+	"context"
+
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/reference"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+)
+
+type Tuple struct {
+	expr hcl.Expression
+	cons schema.Tuple
+}
+
+func (t Tuple) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate {
+	// TODO
+	return nil
+}
+
+func (t Tuple) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData {
+	// TODO
+	return nil
+}
+
+func (t Tuple) SemanticTokens(ctx context.Context) []lang.SemanticToken {
+	// TODO
+	return nil
+}
+
+func (t Tuple) ReferenceOrigins(allowSelfRefs bool) reference.Origins {
+	// TODO
+	return nil
+}
+
+func (t Tuple) ReferenceTargets(attrAddr *schema.AttributeAddrSchema) reference.Targets {
+	// TODO
+	return nil
+}

--- a/decoder/expr_tuple.go
+++ b/decoder/expr_tuple.go
@@ -29,12 +29,12 @@ func (t Tuple) SemanticTokens(ctx context.Context) []lang.SemanticToken {
 	return nil
 }
 
-func (t Tuple) ReferenceOrigins(allowSelfRefs bool) reference.Origins {
+func (t Tuple) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {
 	// TODO
 	return nil
 }
 
-func (t Tuple) ReferenceTargets(attrAddr *schema.AttributeAddrSchema) reference.Targets {
+func (t Tuple) ReferenceTargets(ctx context.Context, attrAddr *schema.AttributeAddrSchema) reference.Targets {
 	// TODO
 	return nil
 }

--- a/decoder/expr_type_declaration.go
+++ b/decoder/expr_type_declaration.go
@@ -1,0 +1,40 @@
+package decoder
+
+import (
+	"context"
+
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/reference"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+)
+
+type TypeDeclaration struct {
+	expr hcl.Expression
+	cons schema.TypeDeclaration
+}
+
+func (td TypeDeclaration) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate {
+	// TODO
+	return nil
+}
+
+func (td TypeDeclaration) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData {
+	// TODO
+	return nil
+}
+
+func (td TypeDeclaration) SemanticTokens(ctx context.Context) []lang.SemanticToken {
+	// TODO
+	return nil
+}
+
+func (td TypeDeclaration) ReferenceOrigins(allowSelfRefs bool) reference.Origins {
+	// TODO
+	return nil
+}
+
+func (td TypeDeclaration) ReferenceTargets(attrAddr *schema.AttributeAddrSchema) reference.Targets {
+	// TODO
+	return nil
+}

--- a/decoder/expr_type_declaration.go
+++ b/decoder/expr_type_declaration.go
@@ -29,12 +29,12 @@ func (td TypeDeclaration) SemanticTokens(ctx context.Context) []lang.SemanticTok
 	return nil
 }
 
-func (td TypeDeclaration) ReferenceOrigins(allowSelfRefs bool) reference.Origins {
+func (td TypeDeclaration) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {
 	// TODO
 	return nil
 }
 
-func (td TypeDeclaration) ReferenceTargets(attrAddr *schema.AttributeAddrSchema) reference.Targets {
+func (td TypeDeclaration) ReferenceTargets(ctx context.Context, attrAddr *schema.AttributeAddrSchema) reference.Targets {
 	// TODO
 	return nil
 }

--- a/decoder/expr_unknown.go
+++ b/decoder/expr_unknown.go
@@ -1,0 +1,32 @@
+package decoder
+
+import (
+	"context"
+
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/reference"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+)
+
+type unknownExpression struct{}
+
+func (oo unknownExpression) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate {
+	return []lang.Candidate{}
+}
+
+func (oo unknownExpression) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData {
+	return nil
+}
+
+func (oo unknownExpression) SemanticTokens(ctx context.Context) []lang.SemanticToken {
+	return []lang.SemanticToken{}
+}
+
+func (oo unknownExpression) ReferenceOrigins(allowSelfRefs bool) reference.Origins {
+	return reference.Origins{}
+}
+
+func (oo unknownExpression) ReferenceTargets(attrAddr *schema.AttributeAddrSchema) reference.Targets {
+	return reference.Targets{}
+}

--- a/decoder/expr_unknown.go
+++ b/decoder/expr_unknown.go
@@ -23,10 +23,10 @@ func (oo unknownExpression) SemanticTokens(ctx context.Context) []lang.SemanticT
 	return []lang.SemanticToken{}
 }
 
-func (oo unknownExpression) ReferenceOrigins(allowSelfRefs bool) reference.Origins {
+func (oo unknownExpression) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {
 	return reference.Origins{}
 }
 
-func (oo unknownExpression) ReferenceTargets(attrAddr *schema.AttributeAddrSchema) reference.Targets {
+func (oo unknownExpression) ReferenceTargets(ctx context.Context, attrAddr *schema.AttributeAddrSchema) reference.Targets {
 	return reference.Targets{}
 }

--- a/decoder/expression.go
+++ b/decoder/expression.go
@@ -15,8 +15,8 @@ type Expression interface {
 	CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate
 	HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData
 	SemanticTokens(ctx context.Context) []lang.SemanticToken
-	ReferenceOrigins(allowSelfRefs bool) reference.Origins
-	ReferenceTargets(attrAddr *schema.AttributeAddrSchema) reference.Targets
+	ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins
+	ReferenceTargets(ctx context.Context, attrAddr *schema.AttributeAddrSchema) reference.Targets
 }
 
 func NewExpression(expr hcl.Expression, cons schema.Constraint) Expression {

--- a/decoder/expression.go
+++ b/decoder/expression.go
@@ -20,6 +20,30 @@ type Expression interface {
 }
 
 func NewExpression(expr hcl.Expression, cons schema.Constraint) Expression {
-	// TODO
-	return nil
+	switch c := cons.(type) {
+	case schema.LiteralType:
+		return LiteralType{expr: expr, cons: c}
+	case schema.Reference:
+		return Reference{expr: expr, cons: c}
+	case schema.TypeDeclaration:
+		return TypeDeclaration{expr: expr, cons: c}
+	case schema.Keyword:
+		return Keyword{expr: expr, cons: c}
+	case schema.List:
+		return List{expr: expr, cons: c}
+	case schema.Set:
+		return Set{expr: expr, cons: c}
+	case schema.Tuple:
+		return Tuple{expr: expr, cons: c}
+	case schema.Object:
+		return Object{expr: expr, cons: c}
+	case schema.Map:
+		return Map{expr: expr, cons: c}
+	case schema.OneOf:
+		return OneOf{expr: expr, cons: c}
+	case schema.LiteralValue:
+		return LiteralValue{expr: expr, cons: c}
+	}
+
+	return unknownExpression{}
 }

--- a/decoder/expression.go
+++ b/decoder/expression.go
@@ -1,0 +1,25 @@
+package decoder
+
+import (
+	"context"
+
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/reference"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+)
+
+// Expression represents an expression capable of providing
+// various LSP features for given hcl.Expression and schema.Constraint.
+type Expression interface {
+	CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate
+	HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData
+	SemanticTokens(ctx context.Context) []lang.SemanticToken
+	ReferenceOrigins(allowSelfRefs bool) reference.Origins
+	ReferenceTargets(attrAddr *schema.AttributeAddrSchema) reference.Targets
+}
+
+func NewExpression(expr hcl.Expression, cons schema.Constraint) Expression {
+	// TODO
+	return nil
+}

--- a/decoder/expression_candidates.go
+++ b/decoder/expression_candidates.go
@@ -253,7 +253,8 @@ func isMultilineTemplateExpr(expr hclsyntax.Expression) bool {
 func (d *PathDecoder) candidatesFromHooks(ctx context.Context, attr *hclsyntax.Attribute, aSchema *schema.AttributeSchema, outerBodyRng hcl.Range, pos hcl.Pos) []lang.Candidate {
 	candidates := make([]lang.Candidate, 0)
 	if aSchema.Constraint != nil {
-		if con, ok := aSchema.Constraint.(schema.Conformable); ok && con.Conforms(cty.String) {
+		con, ok := aSchema.Constraint.(schema.Comparable)
+		if !ok || !con.IsCompatible(cty.String) {
 			// Return early as we only support string values for now
 			return candidates
 		}

--- a/decoder/expression_candidates.go
+++ b/decoder/expression_candidates.go
@@ -302,7 +302,7 @@ func (d *PathDecoder) constraintToCandidates(ctx context.Context, constraint sch
 	switch c := constraint.(type) {
 	case schema.LiteralTypeExpr:
 		candidates = append(candidates, typeToCandidates(c.Type, editRng)...)
-	case schema.LiteralValue:
+	case schema.LegacyLiteralValue:
 		if c, ok := valueToCandidate(c.Val, c.Description, c.IsDeprecated, editRng); ok {
 			candidates = append(candidates, c)
 		}
@@ -481,7 +481,7 @@ func newTextForConstraints(cons schema.ExprConstraints, isNested bool) string {
 		switch c := constraint.(type) {
 		case schema.LiteralTypeExpr:
 			return newTextForLiteralType(c.Type)
-		case schema.LiteralValue:
+		case schema.LegacyLiteralValue:
 			return newTextForLiteralValue(c.Val)
 		case schema.KeywordExpr:
 			return c.Keyword
@@ -531,7 +531,7 @@ func snippetForConstraints(placeholder uint, cons schema.ExprConstraints, isNest
 		switch c := constraint.(type) {
 		case schema.LiteralTypeExpr:
 			return snippetForLiteralType(placeholder, c.Type)
-		case schema.LiteralValue:
+		case schema.LegacyLiteralValue:
 			return snippetForLiteralValue(placeholder, c.Val)
 		case schema.KeywordExpr:
 			return fmt.Sprintf("${%d:%s}", placeholder, c.Keyword)
@@ -592,7 +592,7 @@ func labelsForConstraints(cons schema.ExprConstraints) labelSet {
 		switch c := constraint.(type) {
 		case schema.LiteralTypeExpr:
 			ls = ls.AddLabelIfNotPresent(labelForLiteralType(c.Type))
-		case schema.LiteralValue:
+		case schema.LegacyLiteralValue:
 			continue
 		case schema.KeywordExpr:
 			ls = ls.AddLabelIfNotPresent(c.FriendlyName())
@@ -721,7 +721,7 @@ func triggerSuggestForExprConstraints(ec schema.ExprConstraints) bool {
 			if et.Type == cty.Bool {
 				return true
 			}
-		case schema.LiteralValue:
+		case schema.LegacyLiteralValue:
 			if len(ec) > 1 {
 				return true
 			}
@@ -755,7 +755,7 @@ func snippetForExprContraints(placeholder uint, ec schema.ExprConstraints) strin
 		switch et := expr.(type) {
 		case schema.LiteralTypeExpr:
 			return snippetForLiteralType(placeholder, et.Type)
-		case schema.LiteralValue:
+		case schema.LegacyLiteralValue:
 			if len(ec) == 1 {
 				return snippetForLiteralValue(placeholder, et.Val)
 			}
@@ -798,7 +798,7 @@ func snippetForExprContraint(placeholder uint, ec schema.ExprConstraints) string
 	if t, ok := e.LiteralType(); ok {
 		return snippetForLiteralType(placeholder, t)
 	}
-	// case schema.LiteralValue:
+	// case schema.LegacyLiteralValue:
 	// 	if len(ec) == 1 {
 	// 		return snippetForLiteralValue(placeholder, et.Val)
 	// 	}

--- a/decoder/expression_candidates_legacy_test.go
+++ b/decoder/expression_candidates_legacy_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-func TestDecoder_CandidateAtPos_expressions(t *testing.T) {
+func TestLegacyDecoder_CandidateAtPos_expressions(t *testing.T) {
 	ctx := context.Background()
 	testCases := []struct {
 		testName           string
@@ -1441,7 +1441,7 @@ func TestDecoder_CandidateAtPos_expressions(t *testing.T) {
 	}
 }
 
-func TestDecoder_CandidateAtPos_traversalExpressions(t *testing.T) {
+func TestLegacyDecoder_CandidateAtPos_traversalExpressions(t *testing.T) {
 	ctx := context.Background()
 	testCases := []struct {
 		testName           string
@@ -2480,7 +2480,7 @@ another_block "meh" {
 	}
 }
 
-func TestDecoder_CandidateAtPos_expressions_crossFileTraversal(t *testing.T) {
+func TestLegacyDecoder_CandidateAtPos_expressions_crossFileTraversal(t *testing.T) {
 	ctx := context.Background()
 	f1, _ := hclsyntax.ParseConfig([]byte(`variable "aaa" {}
 variable "bbb" {}
@@ -2659,7 +2659,7 @@ variable "ccc" {}
 	}
 }
 
-func TestDecoder_CandidateAtPos_expressions_Hooks(t *testing.T) {
+func TestLegacyDecoder_CandidateAtPos_expressions_Hooks(t *testing.T) {
 	ctx := context.Background()
 	testCases := []struct {
 		testName           string
@@ -2835,7 +2835,7 @@ func TestDecoder_CandidateAtPos_expressions_Hooks(t *testing.T) {
 	}
 }
 
-func TestDecoder_CandidateAtPos_maxCandidates(t *testing.T) {
+func TestLegacyDecoder_CandidateAtPos_maxCandidates(t *testing.T) {
 	ctx := context.Background()
 	bodySchema := &schema.BodySchema{
 		Attributes: map[string]*schema.AttributeSchema{

--- a/decoder/expression_candidates_test.go
+++ b/decoder/expression_candidates_test.go
@@ -41,7 +41,7 @@ func TestDecoder_CandidateAtPos_expressions(t *testing.T) {
 			map[string]*schema.AttributeSchema{
 				"attr": {
 					Expr: schema.ExprConstraints{
-						schema.LiteralValue{
+						schema.LegacyLiteralValue{
 							Val: cty.ObjectVal(map[string]cty.Value{
 								"first":  cty.StringVal("blah"),
 								"second": cty.NumberIntVal(2345),
@@ -350,7 +350,7 @@ func TestDecoder_CandidateAtPos_expressions(t *testing.T) {
 			map[string]*schema.AttributeSchema{
 				"attr": {
 					Expr: schema.ExprConstraints{
-						schema.LiteralValue{
+						schema.LegacyLiteralValue{
 							Val: cty.ListVal([]cty.Value{
 								cty.StringVal("foo"),
 								cty.StringVal("bar"),
@@ -431,7 +431,7 @@ func TestDecoder_CandidateAtPos_expressions(t *testing.T) {
 			map[string]*schema.AttributeSchema{
 				"attr": {
 					Expr: schema.ExprConstraints{
-						schema.LiteralValue{
+						schema.LegacyLiteralValue{
 							Val: cty.MapVal(map[string]cty.Value{
 								"foo": cty.StringVal("moo"),
 								"bar": cty.StringVal("boo"),
@@ -536,9 +536,9 @@ func TestDecoder_CandidateAtPos_expressions(t *testing.T) {
 			map[string]*schema.AttributeSchema{
 				"attr": {
 					Expr: schema.ExprConstraints{
-						schema.LiteralValue{Val: cty.StringVal("first")},
-						schema.LiteralValue{Val: cty.StringVal("second")},
-						schema.LiteralValue{Val: cty.StringVal("third")},
+						schema.LegacyLiteralValue{Val: cty.StringVal("first")},
+						schema.LegacyLiteralValue{Val: cty.StringVal("second")},
+						schema.LegacyLiteralValue{Val: cty.StringVal("third")},
 					},
 				},
 			},
@@ -616,8 +616,8 @@ func TestDecoder_CandidateAtPos_expressions(t *testing.T) {
 			map[string]*schema.AttributeSchema{
 				"attr": {
 					Expr: schema.ExprConstraints{
-						schema.LiteralValue{Val: cty.StringVal("first")},
-						schema.LiteralValue{Val: cty.StringVal("second"), IsDeprecated: true},
+						schema.LegacyLiteralValue{Val: cty.StringVal("first")},
+						schema.LegacyLiteralValue{Val: cty.StringVal("second"), IsDeprecated: true},
 					},
 				},
 			},

--- a/decoder/expression_constraints.go
+++ b/decoder/expression_constraints.go
@@ -105,20 +105,20 @@ func (ec ExprConstraints) LiteralType() (cty.Type, bool) {
 
 func (ec ExprConstraints) HasLiteralValueOf(val cty.Value) bool {
 	for _, c := range ec {
-		if lv, ok := c.(schema.LiteralValue); ok && lv.Val.RawEquals(val) {
+		if lv, ok := c.(schema.LegacyLiteralValue); ok && lv.Val.RawEquals(val) {
 			return true
 		}
 	}
 	return false
 }
 
-func (ec ExprConstraints) LiteralValueOf(val cty.Value) (schema.LiteralValue, bool) {
+func (ec ExprConstraints) LiteralValueOf(val cty.Value) (schema.LegacyLiteralValue, bool) {
 	for _, c := range ec {
-		if lv, ok := c.(schema.LiteralValue); ok && lv.Val.RawEquals(val) {
+		if lv, ok := c.(schema.LegacyLiteralValue); ok && lv.Val.RawEquals(val) {
 			return lv, true
 		}
 	}
-	return schema.LiteralValue{}, false
+	return schema.LegacyLiteralValue{}, false
 }
 
 func (ec ExprConstraints) LiteralTypeOfTupleExpr() (schema.LiteralTypeExpr, bool) {
@@ -152,18 +152,18 @@ func (ec ExprConstraints) LiteralTypeOfObjectConsExpr() (schema.LiteralTypeExpr,
 	return schema.LiteralTypeExpr{}, false
 }
 
-func (ec ExprConstraints) LiteralValueOfTupleExpr(expr *hclsyntax.TupleConsExpr) (schema.LiteralValue, bool) {
+func (ec ExprConstraints) LiteralValueOfTupleExpr(expr *hclsyntax.TupleConsExpr) (schema.LegacyLiteralValue, bool) {
 	exprValues := make([]cty.Value, len(expr.Exprs))
 	for i, e := range expr.Exprs {
 		val, _ := e.Value(nil)
 		if !val.IsWhollyKnown() || val.IsNull() {
-			return schema.LiteralValue{}, false
+			return schema.LegacyLiteralValue{}, false
 		}
 		exprValues[i] = val
 	}
 
 	for _, c := range ec {
-		if lv, ok := c.(schema.LiteralValue); ok {
+		if lv, ok := c.(schema.LegacyLiteralValue); ok {
 			valType := lv.Val.Type()
 			if valType.IsListType() && lv.Val.RawEquals(cty.ListVal(exprValues)) {
 				return lv, true
@@ -177,29 +177,29 @@ func (ec ExprConstraints) LiteralValueOfTupleExpr(expr *hclsyntax.TupleConsExpr)
 		}
 	}
 
-	return schema.LiteralValue{}, false
+	return schema.LegacyLiteralValue{}, false
 }
 
-func (ec ExprConstraints) LiteralValueOfObjectConsExpr(expr *hclsyntax.ObjectConsExpr) (schema.LiteralValue, bool) {
+func (ec ExprConstraints) LiteralValueOfObjectConsExpr(expr *hclsyntax.ObjectConsExpr) (schema.LegacyLiteralValue, bool) {
 	exprValues := make(map[string]cty.Value)
 	for _, item := range expr.Items {
 		key, _ := item.KeyExpr.Value(nil)
 		if key.IsNull() || !key.IsWhollyKnown() || key.Type() != cty.String {
 			// Avoid building incomplete object with keys
 			// that can't be interpolated without further context
-			return schema.LiteralValue{}, false
+			return schema.LegacyLiteralValue{}, false
 		}
 
 		val, _ := item.ValueExpr.Value(nil)
 		if !val.IsWhollyKnown() || val.IsNull() {
-			return schema.LiteralValue{}, false
+			return schema.LegacyLiteralValue{}, false
 		}
 
 		exprValues[key.AsString()] = val
 	}
 
 	for _, c := range ec {
-		if lv, ok := c.(schema.LiteralValue); ok {
+		if lv, ok := c.(schema.LegacyLiteralValue); ok {
 			valType := lv.Val.Type()
 			if valType.IsMapType() && lv.Val.RawEquals(cty.MapVal(exprValues)) {
 				return lv, true
@@ -210,7 +210,7 @@ func (ec ExprConstraints) LiteralValueOfObjectConsExpr(expr *hclsyntax.ObjectCon
 		}
 	}
 
-	return schema.LiteralValue{}, false
+	return schema.LegacyLiteralValue{}, false
 }
 
 func (ec ExprConstraints) TypeDeclarationExpr() (schema.TypeDeclarationExpr, bool) {

--- a/decoder/expression_test.go
+++ b/decoder/expression_test.go
@@ -1,0 +1,15 @@
+package decoder
+
+var (
+	_ Expression = Keyword{}
+	_ Expression = List{}
+	_ Expression = LiteralType{}
+	_ Expression = LiteralValue{}
+	_ Expression = Map{}
+	_ Expression = ObjectAttributes{}
+	_ Expression = Object{}
+	_ Expression = Set{}
+	_ Expression = Reference{}
+	_ Expression = Tuple{}
+	_ Expression = TypeDeclaration{}
+)

--- a/decoder/hover.go
+++ b/decoder/hover.go
@@ -78,6 +78,10 @@ func (d *PathDecoder) hoverAtPos(ctx context.Context, body *hclsyntax.Body, body
 			}
 
 			if attr.Expr.Range().ContainsPos(pos) {
+				if aSchema.Constraint != nil {
+					return NewExpression(attr.Expr, aSchema.Constraint).HoverAtPos(ctx, pos), nil
+				}
+
 				exprCons := ExprConstraints(aSchema.Expr)
 				data, err := d.hoverDataForExpr(ctx, attr.Expr, exprCons, 0, pos)
 				if err != nil {

--- a/decoder/hover_expressions_legacy_test.go
+++ b/decoder/hover_expressions_legacy_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-func TestDecoder_HoverAtPos_expressions(t *testing.T) {
+func TestLegacyDecoder_HoverAtPos_expressions(t *testing.T) {
 	testCases := []struct {
 		name         string
 		attrSchema   map[string]*schema.AttributeSchema
@@ -1340,7 +1340,7 @@ _object_`),
 	}
 }
 
-func TestDecoder_HoverAtPos_traversalExpressions(t *testing.T) {
+func TestLegacyDecoder_HoverAtPos_traversalExpressions(t *testing.T) {
 	testCases := []struct {
 		name         string
 		attrSchema   map[string]*schema.AttributeSchema

--- a/decoder/hover_expressions_test.go
+++ b/decoder/hover_expressions_test.go
@@ -175,7 +175,7 @@ EOT
 			"string as value",
 			map[string]*schema.AttributeSchema{
 				"lit1": {Expr: schema.ExprConstraints{
-					schema.LiteralValue{Val: cty.StringVal("foo")},
+					schema.LegacyLiteralValue{Val: cty.StringVal("foo")},
 				}},
 			},
 			`lit1 = "foo"`,
@@ -202,7 +202,7 @@ EOT
 			"mismatching literal value",
 			map[string]*schema.AttributeSchema{
 				"lit2": {Expr: schema.ExprConstraints{
-					schema.LiteralValue{Val: cty.StringVal("bar")},
+					schema.LegacyLiteralValue{Val: cty.StringVal("bar")},
 				}},
 			},
 			`lit2 = "baz"`,
@@ -791,7 +791,7 @@ _object_`),
 			"map as value",
 			map[string]*schema.AttributeSchema{
 				"nummap": {Expr: schema.ExprConstraints{
-					schema.LiteralValue{
+					schema.LegacyLiteralValue{
 						Val: cty.MapVal(map[string]cty.Value{
 							"first":  cty.NumberIntVal(12),
 							"second": cty.NumberIntVal(24),
@@ -1120,7 +1120,7 @@ _object_`),
 			"object as value",
 			map[string]*schema.AttributeSchema{
 				"objval": {Expr: schema.ExprConstraints{
-					schema.LiteralValue{
+					schema.LegacyLiteralValue{
 						Val: cty.ObjectVal(map[string]cty.Value{
 							"source": cty.StringVal("blah"),
 							"bool":   cty.True,
@@ -1176,7 +1176,7 @@ _object_`),
 			"list as value",
 			map[string]*schema.AttributeSchema{
 				"listval": {Expr: schema.ExprConstraints{
-					schema.LiteralValue{
+					schema.LegacyLiteralValue{
 						Val: cty.ListVal([]cty.Value{
 							cty.StringVal("first"),
 							cty.StringVal("second"),
@@ -1208,7 +1208,7 @@ _object_`),
 			"set as value",
 			map[string]*schema.AttributeSchema{
 				"setval": {Expr: schema.ExprConstraints{
-					schema.LiteralValue{
+					schema.LegacyLiteralValue{
 						Val: cty.SetVal([]cty.Value{
 							cty.StringVal("west"),
 							cty.StringVal("east"),

--- a/decoder/label_candidates.go
+++ b/decoder/label_candidates.go
@@ -162,8 +162,13 @@ func requiredFieldsSnippet(bodySchema *schema.BodySchema, placeholder int, inden
 			continue
 		}
 
-		valueSnippet := snippetForExprContraint(uint(placeholder), attr.Expr)
-		snippetText += fmt.Sprintf("%s%s = %s", indent, attrName, valueSnippet)
+		var snippet string
+		if attr.Constraint != nil {
+			snippet = attr.Constraint.EmptyCompletionData(placeholder).Snippet
+		} else {
+			snippet = snippetForExprContraint(uint(placeholder), attr.Expr)
+		}
+		snippetText += fmt.Sprintf("%s%s = %s", indent, attrName, snippet)
 
 		// attrCount is used to tell if we are at the end of the list of attributes
 		// so we don't add a trailing newline. this will affect both attribute

--- a/decoder/reference_origins.go
+++ b/decoder/reference_origins.go
@@ -118,6 +118,8 @@ func (d *PathDecoder) referenceOriginsInBody(body hcl.Body, bodySchema *schema.B
 		return origins, impliedOrigins
 	}
 
+	ctx := context.Background()
+
 	impliedOrigins = append(impliedOrigins, bodySchema.ImpliedOrigins...)
 	content := decodeBody(body, bodySchema)
 
@@ -169,7 +171,7 @@ func (d *PathDecoder) referenceOriginsInBody(body hcl.Body, bodySchema *schema.B
 			allowSelfRefs = true
 		}
 		if aSchema.Constraint != nil {
-			origins = append(origins, NewExpression(attr.Expr, aSchema.Constraint).ReferenceOrigins(allowSelfRefs)...)
+			origins = append(origins, NewExpression(attr.Expr, aSchema.Constraint).ReferenceOrigins(ctx, allowSelfRefs)...)
 		} else {
 			origins = append(origins, d.legacyFindOriginsInExpression(attr.Expr, aSchema.Expr, allowSelfRefs)...)
 		}

--- a/decoder/reference_origins.go
+++ b/decoder/reference_origins.go
@@ -292,13 +292,3 @@ func (d *PathDecoder) legacyFindOriginsInExpression(expr hcl.Expression, ec sche
 
 	return origins
 }
-
-func (d *PathDecoder) traversalAtPos(expr hclsyntax.Expression, pos hcl.Pos) (hcl.Traversal, bool) {
-	for _, traversal := range expr.Variables() {
-		if traversal.SourceRange().ContainsPos(pos) {
-			return traversal, true
-		}
-	}
-
-	return nil, false
-}

--- a/decoder/reference_targets.go
+++ b/decoder/reference_targets.go
@@ -2,6 +2,7 @@ package decoder
 
 import (
 	"bytes"
+	"context"
 	"sort"
 
 	"github.com/hashicorp/hcl-lang/lang"
@@ -268,8 +269,10 @@ func decodeTargetableBody(body hcl.Body, parentBlock *blockContent, tt *schema.T
 func decodeReferenceTargetsForAttribute(attr *hcl.Attribute, attrSchema *schema.AttributeSchema) reference.Targets {
 	refs := make(reference.Targets, 0)
 
+	ctx := context.Background()
+
 	if attrSchema.Constraint != nil {
-		refs = append(refs, NewExpression(attr.Expr, attrSchema.Constraint).ReferenceTargets(attrSchema.Address)...)
+		refs = append(refs, NewExpression(attr.Expr, attrSchema.Constraint).ReferenceTargets(ctx, attrSchema.Address)...)
 	} else {
 		if attrSchema.Address != nil {
 			attrAddr, ok := resolveAttributeAddress(attr, attrSchema.Address.Steps)

--- a/decoder/reference_targets.go
+++ b/decoder/reference_targets.go
@@ -268,55 +268,60 @@ func decodeTargetableBody(body hcl.Body, parentBlock *blockContent, tt *schema.T
 func decodeReferenceTargetsForAttribute(attr *hcl.Attribute, attrSchema *schema.AttributeSchema) reference.Targets {
 	refs := make(reference.Targets, 0)
 
-	if attrSchema.Address != nil {
-		attrAddr, ok := resolveAttributeAddress(attr, attrSchema.Address.Steps)
-		if ok {
-			if attrSchema.Address.AsReference {
-				ref := reference.Target{
-					Addr:        attrAddr,
-					ScopeId:     attrSchema.Address.ScopeId,
-					DefRangePtr: &attr.NameRange,
-					RangePtr:    attr.Range.Ptr(),
-					Name:        attrSchema.Address.FriendlyName,
-				}
-				refs = append(refs, ref)
-			}
-
-			if attrSchema.Address.AsExprType {
-				t, ok := exprConstraintToDataType(attrSchema.Expr)
-				if ok {
-					if t == cty.DynamicPseudoType && attr.Expr != nil {
-						// attempt to make the type more specific
-						exprVal, diags := attr.Expr.Value(nil)
-						if !diags.HasErrors() {
-							t = exprVal.Type()
-						}
-					}
-
-					scopeId := attrSchema.Address.ScopeId
-
+	if attrSchema.Constraint != nil {
+		refs = append(refs, NewExpression(attr.Expr, attrSchema.Constraint).ReferenceTargets(attrSchema.Address)...)
+	} else {
+		if attrSchema.Address != nil {
+			attrAddr, ok := resolveAttributeAddress(attr, attrSchema.Address.Steps)
+			if ok {
+				if attrSchema.Address.AsReference {
 					ref := reference.Target{
 						Addr:        attrAddr,
-						Type:        t,
-						ScopeId:     scopeId,
-						DefRangePtr: attr.NameRange.Ptr(),
+						ScopeId:     attrSchema.Address.ScopeId,
+						DefRangePtr: &attr.NameRange,
 						RangePtr:    attr.Range.Ptr(),
 						Name:        attrSchema.Address.FriendlyName,
 					}
-
-					if attr.Expr != nil && !t.IsPrimitiveType() {
-						ref.NestedTargets = make(reference.Targets, 0)
-						ref.NestedTargets = append(ref.NestedTargets, decodeReferenceTargetsForComplexTypeExpr(attrAddr, attr.Expr, t, scopeId)...)
-					}
-
 					refs = append(refs, ref)
+				}
+
+				if attrSchema.Address.AsExprType {
+					t, ok := exprConstraintToDataType(attrSchema.Expr)
+					if ok {
+						if t == cty.DynamicPseudoType && attr.Expr != nil {
+							// attempt to make the type more specific
+							exprVal, diags := attr.Expr.Value(nil)
+							if !diags.HasErrors() {
+								t = exprVal.Type()
+							}
+						}
+
+						scopeId := attrSchema.Address.ScopeId
+
+						ref := reference.Target{
+							Addr:        attrAddr,
+							Type:        t,
+							ScopeId:     scopeId,
+							DefRangePtr: attr.NameRange.Ptr(),
+							RangePtr:    attr.Range.Ptr(),
+							Name:        attrSchema.Address.FriendlyName,
+						}
+
+						if attr.Expr != nil && !t.IsPrimitiveType() {
+							ref.NestedTargets = make(reference.Targets, 0)
+							ref.NestedTargets = append(ref.NestedTargets, decodeReferenceTargetsForComplexTypeExpr(attrAddr, attr.Expr, t, scopeId)...)
+						}
+
+						refs = append(refs, ref)
+					}
 				}
 			}
 		}
+
+		ec := ExprConstraints(attrSchema.Expr)
+		refs = append(refs, referenceTargetsForExpr(attr.Expr, ec)...)
 	}
 
-	ec := ExprConstraints(attrSchema.Expr)
-	refs = append(refs, referenceTargetsForExpr(attr.Expr, ec)...)
 	return refs
 }
 

--- a/decoder/semantic_tokens.go
+++ b/decoder/semantic_tokens.go
@@ -77,8 +77,12 @@ func (d *PathDecoder) tokensForBody(ctx context.Context, body *hclsyntax.Body, b
 			Range:     attr.NameRange,
 		})
 
-		ec := ExprConstraints(attrSchema.Expr)
-		tokens = append(tokens, d.tokensForExpression(ctx, attr.Expr, ec)...)
+		if attrSchema.Constraint != nil {
+			tokens = append(tokens, NewExpression(attr.Expr, attrSchema.Constraint).SemanticTokens(ctx)...)
+		} else {
+			ec := ExprConstraints(attrSchema.Expr)
+			tokens = append(tokens, d.tokensForExpression(ctx, attr.Expr, ec)...)
+		}
 	}
 
 	for _, block := range body.Blocks {

--- a/decoder/semantic_tokens_expr_legacy_test.go
+++ b/decoder/semantic_tokens_expr_legacy_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-func TestDecoder_SemanticTokensInFile_expressions(t *testing.T) {
+func TestLegacyDecoder_SemanticTokensInFile_expressions(t *testing.T) {
 	testCases := []struct {
 		name           string
 		attrSchema     map[string]*schema.AttributeSchema
@@ -1401,7 +1401,7 @@ EOT
 	}
 }
 
-func TestDecoder_SemanticTokensInFile_traversalExpression(t *testing.T) {
+func TestLegacyDecoder_SemanticTokensInFile_traversalExpression(t *testing.T) {
 	testCases := []struct {
 		name           string
 		attrSchema     map[string]*schema.AttributeSchema
@@ -2079,7 +2079,7 @@ func TestDecoder_SemanticTokensInFile_traversalExpression(t *testing.T) {
 	}
 }
 
-func TestDecoder_SemanticTokensInFile_typeDeclaration(t *testing.T) {
+func TestLegacyDecoder_SemanticTokensInFile_typeDeclaration(t *testing.T) {
 	testCases := []struct {
 		name           string
 		attrSchema     map[string]*schema.AttributeSchema

--- a/decoder/semantic_tokens_expr_test.go
+++ b/decoder/semantic_tokens_expr_test.go
@@ -26,7 +26,7 @@ func TestDecoder_SemanticTokensInFile_expressions(t *testing.T) {
 			map[string]*schema.AttributeSchema{
 				"str": {
 					Expr: schema.ExprConstraints{
-						schema.LiteralValue{
+						schema.LegacyLiteralValue{
 							Val: cty.StringVal("blablah"),
 						},
 					},
@@ -123,7 +123,7 @@ EOT
 			map[string]*schema.AttributeSchema{
 				"str": {
 					Expr: schema.ExprConstraints{
-						schema.LiteralValue{
+						schema.LegacyLiteralValue{
 							Val: cty.StringVal("blablah"),
 						},
 					},
@@ -155,7 +155,7 @@ EOT
 			map[string]*schema.AttributeSchema{
 				"obj": {
 					Expr: schema.ExprConstraints{
-						schema.LiteralValue{
+						schema.LegacyLiteralValue{
 							Val: cty.ObjectVal(map[string]cty.Value{
 								"first":  cty.NumberIntVal(42),
 								"second": cty.StringVal("boo"),
@@ -261,7 +261,7 @@ EOT
 			map[string]*schema.AttributeSchema{
 				"obj": {
 					Expr: schema.ExprConstraints{
-						schema.LiteralValue{
+						schema.LegacyLiteralValue{
 							Val: cty.ObjectVal(map[string]cty.Value{
 								"knownkey": cty.NumberIntVal(43),
 							}),
@@ -1237,7 +1237,7 @@ EOT
 			map[string]*schema.AttributeSchema{
 				"attr": {
 					Expr: schema.ExprConstraints{
-						schema.LiteralValue{
+						schema.LegacyLiteralValue{
 							Val: cty.ListVal([]cty.Value{
 								cty.StringVal("one"),
 								cty.StringVal("two"),

--- a/schema/attribute_schema.go
+++ b/schema/attribute_schema.go
@@ -20,6 +20,10 @@ type AttributeSchema struct {
 	// expressions are expected for the attribute
 	Expr ExprConstraints
 
+	// Constraint represents expression constraint e.g. what types of
+	// expressions are expected for the attribute
+	Constraint Constraint
+
 	// IsDepKey describes whether to use this attribute (and its value)
 	// as key when looking up dependent schema
 	IsDepKey bool
@@ -96,7 +100,15 @@ func (as *AttributeSchema) Validate() error {
 		}
 	}
 
-	return as.Expr.Validate()
+	if as.Constraint != nil {
+		if con, ok := as.Constraint.(Validatable); ok {
+			return con.Validate()
+		}
+	} else {
+		return as.Expr.Validate()
+	}
+
+	return nil
 }
 
 func (as *AttributeSchema) Copy() *AttributeSchema {
@@ -117,6 +129,10 @@ func (as *AttributeSchema) Copy() *AttributeSchema {
 		OriginForTarget:        as.OriginForTarget.Copy(),
 		SemanticTokenModifiers: as.SemanticTokenModifiers.Copy(),
 		CompletionHooks:        as.CompletionHooks.Copy(),
+	}
+
+	if as.Constraint != nil {
+		newAs.Constraint = as.Constraint.Copy()
 	}
 
 	return newAs

--- a/schema/attribute_schema_legacy_test.go
+++ b/schema/attribute_schema_legacy_test.go
@@ -1,0 +1,189 @@
+package schema
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestLegacyAttributeSchema_Validate(t *testing.T) {
+	testCases := []struct {
+		schema      *AttributeSchema
+		expectedErr error
+	}{
+		{
+			&AttributeSchema{
+				Expr: LiteralTypeOnly(cty.String),
+			},
+			errors.New("one of IsRequired, IsOptional, or IsComputed must be set"),
+		},
+		{
+			&AttributeSchema{
+				Expr: ExprConstraints{
+					LiteralTypeExpr{Type: cty.String},
+					LiteralTypeExpr{Type: cty.Number},
+				},
+				IsComputed: true,
+			},
+			nil,
+		},
+		{
+			&AttributeSchema{
+				Expr:       LiteralTypeOnly(cty.String),
+				IsRequired: true,
+				IsOptional: true,
+			},
+			errors.New("IsOptional or IsRequired must be set, not both"),
+		},
+		{
+			&AttributeSchema{
+				Expr:       LiteralTypeOnly(cty.String),
+				IsRequired: true,
+				IsComputed: true,
+			},
+			errors.New("cannot be both IsRequired and IsComputed"),
+		},
+		{
+			&AttributeSchema{
+				Expr:       LiteralTypeOnly(cty.String),
+				IsOptional: true,
+				IsComputed: true,
+			},
+			nil,
+		},
+		{
+			&AttributeSchema{
+				Expr: ExprConstraints{
+					TraversalExpr{OfType: cty.String},
+				},
+				IsOptional: true,
+			},
+			nil,
+		},
+		{
+			&AttributeSchema{
+				Expr: ExprConstraints{
+					TraversalExpr{OfScopeId: lang.ScopeId("blah")},
+				},
+				IsOptional: true,
+			},
+			nil,
+		},
+		{
+			&AttributeSchema{
+				Expr: ExprConstraints{
+					TraversalExpr{OfType: cty.Number, OfScopeId: lang.ScopeId("blah")},
+				},
+				IsOptional: true,
+			},
+			nil,
+		},
+		{
+			&AttributeSchema{
+				Expr: ExprConstraints{
+					TraversalExpr{OfType: cty.Number, Address: &TraversalAddrSchema{
+						ScopeId: lang.ScopeId("test"),
+					}},
+				},
+				IsOptional: true,
+			},
+			errors.New("(0: schema.TraversalExpr) cannot be have both Address and OfType/OfScopeId set"),
+		},
+		{
+			&AttributeSchema{
+				Expr: ExprConstraints{
+					TraversalExpr{Address: &TraversalAddrSchema{}},
+				},
+				IsOptional: true,
+			},
+			errors.New("(0: schema.TraversalExpr) Address requires non-emmpty ScopeId"),
+		},
+		{
+			&AttributeSchema{
+				Expr: ExprConstraints{
+					TraversalExpr{Address: &TraversalAddrSchema{
+						ScopeId: lang.ScopeId("blah"),
+					}},
+				},
+				IsOptional: true,
+			},
+			nil,
+		},
+		{
+			&AttributeSchema{
+				Address: &AttributeAddrSchema{
+					Steps: []AddrStep{
+						LabelStep{Index: 0},
+					},
+					AsReference: true,
+				},
+				IsOptional: true,
+			},
+			errors.New("Address[0]: LabelStep is not valid for attribute"),
+		},
+		{
+			&AttributeSchema{
+				Address: &AttributeAddrSchema{
+					Steps: []AddrStep{
+						AttrValueStep{Name: "unknown"},
+					},
+					AsReference: true,
+				},
+				IsOptional: true,
+			},
+			errors.New("Address[0]: AttrValueStep is not implemented for attribute"),
+		},
+		{
+			&AttributeSchema{
+				Address: &AttributeAddrSchema{
+					Steps: []AddrStep{
+						AttrNameStep{},
+					},
+				},
+				IsOptional: true,
+			},
+			errors.New("Address: at least one of AsExprType or AsReference must be set"),
+		},
+		{
+			&AttributeSchema{
+				Address: &AttributeAddrSchema{
+					Steps: []AddrStep{
+						AttrNameStep{},
+					},
+					AsReference: true,
+					AsExprType:  true,
+				},
+				IsOptional: true,
+			},
+			nil,
+		},
+		{
+			&AttributeSchema{
+				Expr: ExprConstraints{
+					TraversalExpr{OfType: cty.Number, OfScopeId: lang.ScopeId("blah")},
+				},
+				IsRequired:  true,
+				IsSensitive: true,
+			},
+			nil,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			err := tc.schema.Validate()
+			if tc.expectedErr == nil && err != nil {
+				t.Fatal(err)
+			}
+			if tc.expectedErr != nil && err == nil {
+				t.Fatalf("expected error: %q, none given", tc.expectedErr.Error())
+			}
+			if tc.expectedErr != nil && tc.expectedErr.Error() != err.Error() {
+				t.Fatalf("error mismatch,\nexpected: %q\ngiven: %q", tc.expectedErr.Error(), err.Error())
+			}
+		})
+	}
+}

--- a/schema/attribute_schema_test.go
+++ b/schema/attribute_schema_test.go
@@ -16,15 +16,15 @@ func TestAttributeSchema_Validate(t *testing.T) {
 	}{
 		{
 			&AttributeSchema{
-				Expr: LiteralTypeOnly(cty.String),
+				Constraint: LiteralType{Type: cty.String},
 			},
 			errors.New("one of IsRequired, IsOptional, or IsComputed must be set"),
 		},
 		{
 			&AttributeSchema{
-				Expr: ExprConstraints{
-					LiteralTypeExpr{Type: cty.String},
-					LiteralTypeExpr{Type: cty.Number},
+				Constraint: OneOf{
+					LiteralType{Type: cty.String},
+					LiteralType{Type: cty.Number},
 				},
 				IsComputed: true,
 			},
@@ -32,7 +32,7 @@ func TestAttributeSchema_Validate(t *testing.T) {
 		},
 		{
 			&AttributeSchema{
-				Expr:       LiteralTypeOnly(cty.String),
+				Constraint: LiteralType{Type: cty.String},
 				IsRequired: true,
 				IsOptional: true,
 			},
@@ -40,7 +40,7 @@ func TestAttributeSchema_Validate(t *testing.T) {
 		},
 		{
 			&AttributeSchema{
-				Expr:       LiteralTypeOnly(cty.String),
+				Constraint: LiteralType{Type: cty.String},
 				IsRequired: true,
 				IsComputed: true,
 			},
@@ -48,7 +48,7 @@ func TestAttributeSchema_Validate(t *testing.T) {
 		},
 		{
 			&AttributeSchema{
-				Expr:       LiteralTypeOnly(cty.String),
+				Constraint: LiteralType{Type: cty.String},
 				IsOptional: true,
 				IsComputed: true,
 			},
@@ -56,58 +56,42 @@ func TestAttributeSchema_Validate(t *testing.T) {
 		},
 		{
 			&AttributeSchema{
-				Expr: ExprConstraints{
-					TraversalExpr{OfType: cty.String},
-				},
+				Constraint: Reference{OfType: cty.String},
 				IsOptional: true,
 			},
 			nil,
 		},
 		{
 			&AttributeSchema{
-				Expr: ExprConstraints{
-					TraversalExpr{OfScopeId: lang.ScopeId("blah")},
-				},
+				Constraint: Reference{OfScopeId: lang.ScopeId("blah")},
 				IsOptional: true,
 			},
 			nil,
 		},
 		{
 			&AttributeSchema{
-				Expr: ExprConstraints{
-					TraversalExpr{OfType: cty.Number, OfScopeId: lang.ScopeId("blah")},
-				},
+				Constraint: Reference{OfType: cty.Number, OfScopeId: lang.ScopeId("blah")},
 				IsOptional: true,
 			},
 			nil,
 		},
 		{
 			&AttributeSchema{
-				Expr: ExprConstraints{
-					TraversalExpr{OfType: cty.Number, Address: &TraversalAddrSchema{
-						ScopeId: lang.ScopeId("test"),
-					}},
-				},
+				Constraint: Reference{OfType: cty.Number, Address: &ReferenceAddrSchema{ScopeId: lang.ScopeId("test")}},
 				IsOptional: true,
 			},
-			errors.New("(0: schema.TraversalExpr) cannot be have both Address and OfType/OfScopeId set"),
+			errors.New("cannot have both Address and OfType/OfScopeId set"),
 		},
 		{
 			&AttributeSchema{
-				Expr: ExprConstraints{
-					TraversalExpr{Address: &TraversalAddrSchema{}},
-				},
+				Constraint: Reference{Address: &ReferenceAddrSchema{}},
 				IsOptional: true,
 			},
-			errors.New("(0: schema.TraversalExpr) Address requires non-emmpty ScopeId"),
+			errors.New("Address requires non-emmpty ScopeId"),
 		},
 		{
 			&AttributeSchema{
-				Expr: ExprConstraints{
-					TraversalExpr{Address: &TraversalAddrSchema{
-						ScopeId: lang.ScopeId("blah"),
-					}},
-				},
+				Constraint: Reference{Address: &ReferenceAddrSchema{ScopeId: lang.ScopeId("blah")}},
 				IsOptional: true,
 			},
 			nil,
@@ -162,9 +146,7 @@ func TestAttributeSchema_Validate(t *testing.T) {
 		},
 		{
 			&AttributeSchema{
-				Expr: ExprConstraints{
-					TraversalExpr{OfType: cty.Number, OfScopeId: lang.ScopeId("blah")},
-				},
+				Constraint:  Reference{OfType: cty.Number, OfScopeId: lang.ScopeId("blah")},
 				IsRequired:  true,
 				IsSensitive: true,
 			},

--- a/schema/constraint.go
+++ b/schema/constraint.go
@@ -20,11 +20,12 @@ type Validatable interface {
 	Validate() error
 }
 
-// Conformable represents a constraint which is type-aware,
-// making it possible to test a given type for conformity.
+// Comparable represents a constraint which is type-aware,
+// making it possible to compare a given type for conformity.
+//
 // This can affect completion hooks.
-type Conformable interface {
-	Conforms(typ cty.Type) bool
+type Comparable interface {
+	IsCompatible(typ cty.Type) bool
 }
 
 type CompletionData struct {

--- a/schema/constraint.go
+++ b/schema/constraint.go
@@ -6,8 +6,21 @@ type Constraint interface {
 	isConstraintImpl() constraintSigil
 	FriendlyName() string
 	Copy() Constraint
+	// EmptyCompletionData provides completion data (to be used in text edits),
+	// with snippet placeholder identifiers such as ${4} (if any) starting
+	// from given nextPlaceholder.
+	// 1 is the most appropriate placeholder, if none were yet assigned prior
+	// to rendering completion data for this constraint (e.g. map key).
+	EmptyCompletionData(nextPlaceholder int) CompletionData
 }
 
 type Validatable interface {
 	Validate() error
+}
+
+type CompletionData struct {
+	NewText         string
+	Snippet         string
+	TriggerSuggest  bool
+	LastPlaceholder int
 }

--- a/schema/constraint.go
+++ b/schema/constraint.go
@@ -1,5 +1,7 @@
 package schema
 
+import "github.com/zclconf/go-cty/cty"
+
 type constraintSigil struct{}
 
 type Constraint interface {
@@ -16,6 +18,13 @@ type Constraint interface {
 
 type Validatable interface {
 	Validate() error
+}
+
+// Conformable represents a constraint which is type-aware,
+// making it possible to test a given type for conformity.
+// This can affect completion hooks.
+type Conformable interface {
+	Conforms(typ cty.Type) bool
 }
 
 type CompletionData struct {

--- a/schema/constraint.go
+++ b/schema/constraint.go
@@ -7,3 +7,7 @@ type Constraint interface {
 	FriendlyName() string
 	Copy() Constraint
 }
+
+type Validatable interface {
+	Validate() error
+}

--- a/schema/constraint.go
+++ b/schema/constraint.go
@@ -1,0 +1,9 @@
+package schema
+
+type constraintSigil struct{}
+
+type Constraint interface {
+	isConstraintImpl() constraintSigil
+	FriendlyName() string
+	Copy() Constraint
+}

--- a/schema/constraint_keyword.go
+++ b/schema/constraint_keyword.go
@@ -1,6 +1,8 @@
 package schema
 
-import "github.com/hashicorp/hcl-lang/lang"
+import (
+	"github.com/hashicorp/hcl-lang/lang"
+)
 
 // Keyword represents a keyword, represented as hcl.Traversal
 // of a single segment.
@@ -32,4 +34,9 @@ func (k Keyword) Copy() Constraint {
 		Name:        k.Name,
 		Description: k.Description,
 	}
+}
+
+func (k Keyword) EmptyCompletionData(nextPlaceholder int) CompletionData {
+	// TODO
+	return CompletionData{}
 }

--- a/schema/constraint_keyword.go
+++ b/schema/constraint_keyword.go
@@ -1,0 +1,35 @@
+package schema
+
+import "github.com/hashicorp/hcl-lang/lang"
+
+// Keyword represents a keyword, represented as hcl.Traversal
+// of a single segment.
+type Keyword struct {
+	// Keyword defines the literal keyword
+	Keyword string
+
+	// Name overrides friendly name of the constraint
+	Name string
+
+	// Description defines description of the keyword
+	Description lang.MarkupContent
+}
+
+func (Keyword) isConstraintImpl() constraintSigil {
+	return constraintSigil{}
+}
+
+func (k Keyword) FriendlyName() string {
+	if k.Name == "" {
+		return "keyword"
+	}
+	return k.Name
+}
+
+func (k Keyword) Copy() Constraint {
+	return Keyword{
+		Keyword:     k.Keyword,
+		Name:        k.Name,
+		Description: k.Description,
+	}
+}

--- a/schema/constraint_list.go
+++ b/schema/constraint_list.go
@@ -43,3 +43,8 @@ func (l List) Copy() Constraint {
 		MaxItems:    l.MaxItems,
 	}
 }
+
+func (l List) EmptyCompletionData(nextPlaceholder int) CompletionData {
+	// TODO
+	return CompletionData{}
+}

--- a/schema/constraint_list.go
+++ b/schema/constraint_list.go
@@ -1,0 +1,45 @@
+package schema
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl-lang/lang"
+)
+
+// List represents a list, equivalent of hclsyntax.TupleConsExpr
+// interpreted as list, i.e. ordering of item (which are all
+// of the same type) matters.
+type List struct {
+	// Elem defines constraint to apply to each item
+	Elem Constraint
+
+	// Description defines description of the whole list (affects hover)
+	Description lang.MarkupContent
+
+	// MinItems defines minimum number of items (affects completion)
+	MinItems uint64
+
+	// MaxItems defines maximum number of items (affects completion)
+	MaxItems uint64
+}
+
+func (List) isConstraintImpl() constraintSigil {
+	return constraintSigil{}
+}
+
+func (l List) FriendlyName() string {
+	elemName := l.Elem.FriendlyName()
+	if elemName != "" {
+		return fmt.Sprintf("list of %s", elemName)
+	}
+	return "list"
+}
+
+func (l List) Copy() Constraint {
+	return List{
+		Elem:        l.Elem.Copy(),
+		Description: l.Description,
+		MinItems:    l.MinItems,
+		MaxItems:    l.MaxItems,
+	}
+}

--- a/schema/constraint_literal_type.go
+++ b/schema/constraint_literal_type.go
@@ -1,0 +1,31 @@
+package schema
+
+import "github.com/zclconf/go-cty/cty"
+
+// LiteralType represents literal type constraint
+// e.g. any literal string ("foo"), number (42), etc.
+//
+// Non-literal expressions (even if these evaluate to the given
+// type) are excluded.
+//
+// Complex types are supported, but dedicated List,
+// Set, Map and other types are preferred, as these can
+// convey more details, such as description, unlike
+// e.g. LiteralType{Type: cty.List(...)}.
+type LiteralType struct {
+	Type cty.Type
+}
+
+func (LiteralType) isConstraintImpl() constraintSigil {
+	return constraintSigil{}
+}
+
+func (lt LiteralType) FriendlyName() string {
+	return lt.Type.FriendlyNameForConstraint()
+}
+
+func (lt LiteralType) Copy() Constraint {
+	return LiteralType{
+		Type: lt.Type,
+	}
+}

--- a/schema/constraint_literal_type.go
+++ b/schema/constraint_literal_type.go
@@ -1,6 +1,8 @@
 package schema
 
-import "github.com/zclconf/go-cty/cty"
+import (
+	"github.com/zclconf/go-cty/cty"
+)
 
 // LiteralType represents literal type constraint
 // e.g. any literal string ("foo"), number (42), etc.
@@ -28,4 +30,9 @@ func (lt LiteralType) Copy() Constraint {
 	return LiteralType{
 		Type: lt.Type,
 	}
+}
+
+func (lt LiteralType) EmptyCompletionData(nextPlaceholder int) CompletionData {
+	// TODO
+	return CompletionData{}
 }

--- a/schema/constraint_literal_value.go
+++ b/schema/constraint_literal_value.go
@@ -1,0 +1,34 @@
+package schema
+
+import (
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// LiteralValue represents a literal value, as defined by Value
+// with additional metadata.
+type LiteralValue struct {
+	Value cty.Value
+
+	// IsDeprecated defines whether the value is deprecated
+	IsDeprecated bool
+
+	// Description defines description of the value
+	Description lang.MarkupContent
+}
+
+func (LiteralValue) isConstraintImpl() constraintSigil {
+	return constraintSigil{}
+}
+
+func (lv LiteralValue) FriendlyName() string {
+	return lv.Value.Type().FriendlyNameForConstraint()
+}
+
+func (lv LiteralValue) Copy() Constraint {
+	return LiteralValue{
+		Value:        lv.Value,
+		IsDeprecated: lv.IsDeprecated,
+		Description:  lv.Description,
+	}
+}

--- a/schema/constraint_literal_value.go
+++ b/schema/constraint_literal_value.go
@@ -32,3 +32,8 @@ func (lv LiteralValue) Copy() Constraint {
 		Description:  lv.Description,
 	}
 }
+
+func (lv LiteralValue) EmptyCompletionData(nextPlaceholder int) CompletionData {
+	// TODO
+	return CompletionData{}
+}

--- a/schema/constraint_map.go
+++ b/schema/constraint_map.go
@@ -1,0 +1,52 @@
+package schema
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl-lang/lang"
+)
+
+// Map represents a map, equivalent of hclsyntax.ObjectConsExpr
+// interpreted as map, i.e. with items of unknown keys
+// and same value types.
+type Map struct {
+	// Elem defines constraint to apply to each item of the map
+	Elem Constraint
+
+	// Name overrides friendly name of the constraint
+	Name string
+
+	// Description defines description of the whole map (affects hover)
+	Description lang.MarkupContent
+
+	// MinItems defines minimum number of items (affects completion)
+	MinItems uint64
+
+	// MaxItems defines maximum number of items (affects completion)
+	MaxItems uint64
+}
+
+func (Map) isConstraintImpl() constraintSigil {
+	return constraintSigil{}
+}
+
+func (m Map) FriendlyName() string {
+	if m.Name == "" {
+		elemName := m.Elem.FriendlyName()
+		if elemName != "" {
+			return fmt.Sprintf("map of %s", elemName)
+		}
+		return "map"
+	}
+	return m.Name
+}
+
+func (m Map) Copy() Constraint {
+	return Map{
+		Elem:        m.Elem.Copy(),
+		Name:        m.Name,
+		Description: m.Description,
+		MinItems:    m.MinItems,
+		MaxItems:    m.MaxItems,
+	}
+}

--- a/schema/constraint_map.go
+++ b/schema/constraint_map.go
@@ -50,3 +50,8 @@ func (m Map) Copy() Constraint {
 		MaxItems:    m.MaxItems,
 	}
 }
+
+func (m Map) EmptyCompletionData(nextPlaceholder int) CompletionData {
+	// TODO
+	return CompletionData{}
+}

--- a/schema/constraint_object.go
+++ b/schema/constraint_object.go
@@ -1,0 +1,54 @@
+package schema
+
+import "github.com/hashicorp/hcl-lang/lang"
+
+// Object represents an object, equivalent of hclsyntax.ObjectConsExpr
+// interpreted as object, i.e. with items of known keys
+// and different value types.
+type Object struct {
+	// Attributes defines names and constraints of attributes within the object
+	Attributes ObjectAttributes
+
+	// Name overrides friendly name of the constraint
+	Name string
+
+	// Description defines description of the whole object (affects hover)
+	Description lang.MarkupContent
+}
+
+type ObjectAttributes map[string]*AttributeSchema
+
+func (Object) isConstraintImpl() constraintSigil {
+	return constraintSigil{}
+}
+
+func (o Object) FriendlyName() string {
+	if o.Name == "" {
+		return "object"
+	}
+	return o.Name
+}
+
+func (o Object) Copy() Constraint {
+	return Object{
+		Attributes:  o.Attributes.Copy().(ObjectAttributes),
+		Name:        o.Name,
+		Description: o.Description,
+	}
+}
+
+func (ObjectAttributes) isConstraintImpl() constraintSigil {
+	return constraintSigil{}
+}
+
+func (oa ObjectAttributes) FriendlyName() string {
+	return "attributes"
+}
+
+func (oa ObjectAttributes) Copy() Constraint {
+	m := make(ObjectAttributes, 0)
+	for name, aSchema := range oa {
+		m[name] = aSchema.Copy()
+	}
+	return m
+}

--- a/schema/constraint_object.go
+++ b/schema/constraint_object.go
@@ -1,6 +1,8 @@
 package schema
 
-import "github.com/hashicorp/hcl-lang/lang"
+import (
+	"github.com/hashicorp/hcl-lang/lang"
+)
 
 // Object represents an object, equivalent of hclsyntax.ObjectConsExpr
 // interpreted as object, i.e. with items of known keys
@@ -37,6 +39,10 @@ func (o Object) Copy() Constraint {
 	}
 }
 
+func (o Object) EmptyCompletionData(placeholder int) CompletionData {
+	return CompletionData{}
+}
+
 func (ObjectAttributes) isConstraintImpl() constraintSigil {
 	return constraintSigil{}
 }
@@ -51,4 +57,9 @@ func (oa ObjectAttributes) Copy() Constraint {
 		m[name] = aSchema.Copy()
 	}
 	return m
+}
+
+func (oa ObjectAttributes) EmptyCompletionData(nextPlaceholder int) CompletionData {
+	// TODO
+	return CompletionData{}
 }

--- a/schema/constraint_one_of.go
+++ b/schema/constraint_one_of.go
@@ -1,0 +1,74 @@
+package schema
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+)
+
+// OneOf represents multiple constraints where any one of them is acceptable.
+type OneOf []Constraint
+
+func (OneOf) isConstraintImpl() constraintSigil {
+	return constraintSigil{}
+}
+
+func (o OneOf) FriendlyName() string {
+	names := make([]string, 0)
+	for _, constraint := range o {
+		if name := constraint.FriendlyName(); name != "" &&
+			!namesContain(names, name) {
+			names = append(names, name)
+		}
+	}
+	if len(names) > 0 {
+		return strings.Join(names, " or ")
+	}
+	return ""
+}
+
+func (o OneOf) Copy() Constraint {
+	if o == nil {
+		return make(OneOf, 0)
+	}
+
+	newCons := make(OneOf, len(o))
+	for i, c := range o {
+		newCons[i] = c.Copy()
+	}
+
+	return newCons
+}
+
+func (o OneOf) Validate() error {
+	if len(o) == 0 {
+		return nil
+	}
+
+	var errs *multierror.Error
+
+	for i, constraint := range o {
+		if c, ok := constraint.(Validatable); ok {
+			err := c.Validate()
+			if err != nil {
+				errs = multierror.Append(errs, fmt.Errorf("(%d: %T) %w", i, constraint, err))
+			}
+		}
+	}
+
+	if errs != nil && len(errs.Errors) == 1 {
+		return errs.Errors[0]
+	}
+
+	return errs.ErrorOrNil()
+}
+
+func namesContain(names []string, name string) bool {
+	for _, n := range names {
+		if n == name {
+			return true
+		}
+	}
+	return false
+}

--- a/schema/constraint_one_of.go
+++ b/schema/constraint_one_of.go
@@ -72,3 +72,8 @@ func namesContain(names []string, name string) bool {
 	}
 	return false
 }
+
+func (o OneOf) EmptyCompletionData(nextPlaceholder int) CompletionData {
+	// TODO
+	return CompletionData{}
+}

--- a/schema/constraint_reference.go
+++ b/schema/constraint_reference.go
@@ -65,6 +65,11 @@ func (ref Reference) Copy() Constraint {
 	}
 }
 
+func (ref Reference) EmptyCompletionData(nextPlaceholder int) CompletionData {
+	// TODO
+	return CompletionData{}
+}
+
 func (ref Reference) Validate() error {
 	if ref.Address != nil && (ref.OfType != cty.NilType || ref.OfScopeId != "") {
 		return errors.New("cannot have both Address and OfType/OfScopeId set")

--- a/schema/constraint_reference.go
+++ b/schema/constraint_reference.go
@@ -1,0 +1,76 @@
+package schema
+
+import (
+	"errors"
+
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// Reference represents a reference (equivalent of hcl.Traversal),
+// i.e. the dot-separated address such as var.foobar
+// of a given scope (type-less) or type (type-aware).
+type Reference struct {
+	// OfScopeId defines scope of a type-less reference
+	OfScopeId lang.ScopeId
+
+	// OfType defines the type of a type-aware reference
+	OfType cty.Type
+
+	// Name overrides friendly name of the constraint
+	Name string
+
+	// Address (if not nil) makes the reference
+	// itself addressable and provides scope
+	// for the decoded reference.
+	//
+	// Only one of Address or OfScopeId/OfType can be declared
+	Address *ReferenceAddrSchema
+}
+
+type ReferenceAddrSchema struct {
+	ScopeId lang.ScopeId
+}
+
+func (ras *ReferenceAddrSchema) Copy() *ReferenceAddrSchema {
+	if ras == nil {
+		return nil
+	}
+	return &ReferenceAddrSchema{
+		ScopeId: ras.ScopeId,
+	}
+}
+
+func (Reference) isConstraintImpl() constraintSigil {
+	return constraintSigil{}
+}
+
+func (ref Reference) FriendlyName() string {
+	if ref.Name != "" {
+		return ref.Name
+	}
+	if ref.OfType != cty.NilType {
+		return ref.OfType.FriendlyNameForConstraint()
+	}
+
+	return "reference"
+}
+
+func (ref Reference) Copy() Constraint {
+	return Reference{
+		OfScopeId: ref.OfScopeId,
+		OfType:    ref.OfType,
+		Name:      ref.Name,
+		Address:   ref.Address.Copy(),
+	}
+}
+
+func (ref Reference) Validate() error {
+	if ref.Address != nil && (ref.OfType != cty.NilType || ref.OfScopeId != "") {
+		return errors.New("cannot be have both Address and OfType/OfScopeId set")
+	}
+	if ref.Address != nil && ref.Address.ScopeId == "" {
+		return errors.New("Address requires non-emmpty ScopeId")
+	}
+	return nil
+}

--- a/schema/constraint_reference.go
+++ b/schema/constraint_reference.go
@@ -67,7 +67,7 @@ func (ref Reference) Copy() Constraint {
 
 func (ref Reference) Validate() error {
 	if ref.Address != nil && (ref.OfType != cty.NilType || ref.OfScopeId != "") {
-		return errors.New("cannot be have both Address and OfType/OfScopeId set")
+		return errors.New("cannot have both Address and OfType/OfScopeId set")
 	}
 	if ref.Address != nil && ref.Address.ScopeId == "" {
 		return errors.New("Address requires non-emmpty ScopeId")

--- a/schema/constraint_set.go
+++ b/schema/constraint_set.go
@@ -43,3 +43,8 @@ func (s Set) Copy() Constraint {
 		MaxItems:    s.MaxItems,
 	}
 }
+
+func (s Set) EmptyCompletionData(nextPlaceholder int) CompletionData {
+	// TODO
+	return CompletionData{}
+}

--- a/schema/constraint_set.go
+++ b/schema/constraint_set.go
@@ -1,0 +1,45 @@
+package schema
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl-lang/lang"
+)
+
+// Set represents a set, equivalent of hclsyntax.TupleConsExpr
+// interpreted as set, i.e. ordering of items (which are all
+// of the same type) does not matter.
+type Set struct {
+	// Elem defines constraint to apply to each item
+	Elem Constraint
+
+	// Description defines description of the whole list (affects hover)
+	Description lang.MarkupContent
+
+	// MinItems defines minimum number of items (affects completion)
+	MinItems uint64
+
+	// MaxItems defines maximum number of items (affects completion)
+	MaxItems uint64
+}
+
+func (Set) isConstraintImpl() constraintSigil {
+	return constraintSigil{}
+}
+
+func (s Set) FriendlyName() string {
+	elemName := s.Elem.FriendlyName()
+	if elemName != "" {
+		return fmt.Sprintf("set of %s", elemName)
+	}
+	return "set"
+}
+
+func (s Set) Copy() Constraint {
+	return Set{
+		Elem:        s.Elem.Copy(),
+		Description: s.Description,
+		MinItems:    s.MinItems,
+		MaxItems:    s.MaxItems,
+	}
+}

--- a/schema/constraint_test.go
+++ b/schema/constraint_test.go
@@ -1,0 +1,14 @@
+package schema
+
+var (
+	_ Constraint = Keyword{}
+	_ Constraint = List{}
+	_ Constraint = LiteralType{}
+	_ Constraint = Map{}
+	_ Constraint = ObjectAttributes{}
+	_ Constraint = Object{}
+	_ Constraint = Set{}
+	_ Constraint = Reference{}
+	_ Constraint = Tuple{}
+	_ Constraint = TypeDeclaration{}
+)

--- a/schema/constraint_test.go
+++ b/schema/constraint_test.go
@@ -4,6 +4,7 @@ var (
 	_ Constraint = Keyword{}
 	_ Constraint = List{}
 	_ Constraint = LiteralType{}
+	_ Constraint = LiteralValue{}
 	_ Constraint = Map{}
 	_ Constraint = ObjectAttributes{}
 	_ Constraint = Object{}

--- a/schema/constraint_tuple.go
+++ b/schema/constraint_tuple.go
@@ -1,0 +1,36 @@
+package schema
+
+import "github.com/hashicorp/hcl-lang/lang"
+
+// Tuple represents a tuple, equivalent of hclsyntax.TupleConsExpr
+// interpreted as tuple, i.e. collection of items where
+// each one is of different type.
+type Tuple struct {
+	// Elems defines constraints to apply to each individual item
+	// in the same order they would appear in the tuple
+	Elems []Constraint
+
+	// Description defines description of the whole tuple (affects hover)
+	Description lang.MarkupContent
+}
+
+func (Tuple) isConstraintImpl() constraintSigil {
+	return constraintSigil{}
+}
+
+func (t Tuple) FriendlyName() string {
+	return "tuple"
+}
+
+func (t Tuple) Copy() Constraint {
+	newTuple := Tuple{
+		Description: t.Description,
+	}
+	if len(t.Elems) > 0 {
+		newTuple.Elems = make([]Constraint, len(t.Elems))
+		for i, elem := range t.Elems {
+			newTuple.Elems[i] = elem.Copy()
+		}
+	}
+	return newTuple
+}

--- a/schema/constraint_tuple.go
+++ b/schema/constraint_tuple.go
@@ -1,6 +1,8 @@
 package schema
 
-import "github.com/hashicorp/hcl-lang/lang"
+import (
+	"github.com/hashicorp/hcl-lang/lang"
+)
 
 // Tuple represents a tuple, equivalent of hclsyntax.TupleConsExpr
 // interpreted as tuple, i.e. collection of items where
@@ -33,4 +35,9 @@ func (t Tuple) Copy() Constraint {
 		}
 	}
 	return newTuple
+}
+
+func (t Tuple) EmptyCompletionData(nextPlaceholder int) CompletionData {
+	// TODO
+	return CompletionData{}
 }

--- a/schema/constraint_type_declaration.go
+++ b/schema/constraint_type_declaration.go
@@ -16,3 +16,8 @@ func (td TypeDeclaration) FriendlyName() string {
 func (td TypeDeclaration) Copy() Constraint {
 	return TypeDeclaration{}
 }
+
+func (td TypeDeclaration) EmptyCompletionData(nextPlaceholder int) CompletionData {
+	// TODO
+	return CompletionData{}
+}

--- a/schema/constraint_type_declaration.go
+++ b/schema/constraint_type_declaration.go
@@ -1,0 +1,18 @@
+package schema
+
+// TypeDeclaration represents a type declaration as
+// interpreted by HCL's ext/typeexpr package,
+// i.e. declaration of cty.Type in HCL
+type TypeDeclaration struct{}
+
+func (TypeDeclaration) isConstraintImpl() constraintSigil {
+	return constraintSigil{}
+}
+
+func (td TypeDeclaration) FriendlyName() string {
+	return "type"
+}
+
+func (td TypeDeclaration) Copy() Constraint {
+	return TypeDeclaration{}
+}

--- a/schema/expressions.go
+++ b/schema/expressions.go
@@ -65,15 +65,6 @@ func (ec ExprConstraints) Validate() error {
 	return errs.ErrorOrNil()
 }
 
-func namesContain(names []string, name string) bool {
-	for _, n := range names {
-		if n == name {
-			return true
-		}
-	}
-	return false
-}
-
 type exprConstrSigil struct{}
 
 type ExprConstraint interface {

--- a/schema/expressions.go
+++ b/schema/expressions.go
@@ -101,22 +101,22 @@ func (lt LiteralTypeExpr) Copy() ExprConstraint {
 	}
 }
 
-type LiteralValue struct {
+type LegacyLiteralValue struct {
 	Val          cty.Value
 	IsDeprecated bool
 	Description  lang.MarkupContent
 }
 
-func (LiteralValue) isExprConstraintImpl() exprConstrSigil {
+func (LegacyLiteralValue) isExprConstraintImpl() exprConstrSigil {
 	return exprConstrSigil{}
 }
 
-func (lv LiteralValue) FriendlyName() string {
+func (lv LegacyLiteralValue) FriendlyName() string {
 	return lv.Val.Type().FriendlyNameForConstraint()
 }
 
-func (lv LiteralValue) Copy() ExprConstraint {
-	return LiteralValue{
+func (lv LegacyLiteralValue) Copy() ExprConstraint {
+	return LegacyLiteralValue{
 		// cty.Value is immutable by design
 		Val:          lv.Val,
 		IsDeprecated: lv.IsDeprecated,

--- a/schema/expressions_test.go
+++ b/schema/expressions_test.go
@@ -4,7 +4,7 @@ var (
 	_ ExprConstraint = KeywordExpr{}
 	_ ExprConstraint = ListExpr{}
 	_ ExprConstraint = LiteralTypeExpr{}
-	_ ExprConstraint = LiteralValue{}
+	_ ExprConstraint = LegacyLiteralValue{}
 	_ ExprConstraint = MapExpr{}
 	_ ExprConstraint = MapExpr{}
 	_ ExprConstraint = ObjectExprAttributes{}


### PR DESCRIPTION
## Motivations

One of the common constraints in use is the following:

```go
Attributes: map[string]*schema.AttributeSchema{
	"attr": {
		Expr: schema.ExprConstraints{
			schema.TraversalExpr{OfType: cty.String},
			schema.LiteralTypeExpr{Type: cty.String},
		},
	},
}
```

which expresses either a reference of string type (`attr = var.mystring`), or literal string (`attr = "foo"`). This has a few challenges:

1. It's very verbose for such a common constraint
2. It doesn't account for other expression types (beyond references and literals)
3. It makes it hard to provide reliable completion where there are >= 2 similar constraints. See [hashicorp/hcl-lang#170](https://github.com/hashicorp/hcl-lang/issues/170) for more information.

To address the mentioned challenges, it is proposed to refactor expression constraints to eventually enable the same constraint to be expressed this way:

```go
Attributes: map[string]*schema.AttributeSchema{
	"attr": {
		Constraint: schema.AnyExpression{OfType: cty.String},
	},
}
```

### Name Change: Expr -> Constraint

The new name reflects that constraints in HCL will generally always apply to expressions (certainly in the context of an attribute), and should better convey the purpose of the field and make it easier to "say out loud" while typing.

### Singular Constraint

It is proposed to optimize for singular constraints as that is the common case, and allow multiple constraints via a special constraint type. Hence the top level type (`Expr / Constraint`) will no longer be a slice, but `Constraint` interface.

### New Constraints

Two new constraints are proposed for addition, of which only the first one is part of this PR:

 - `OneOf` - equivalent to the existing default `ExprConstraints`, to be also used as a temporary replacement until `AnyExpression` is implemented
 - `AnyExpression{OfType: cty.Type}` - to represent any expression which is expected to evaluate to a given type

### Convenience Arguments

By using different name, we also gain the benefit of being able to work on this piece by piece, and not having to implement all expressions at the same time and face compilation errors. Adding `Constraint` is effectively a feature toggle.

## Implementation Notes

This is the first step towards implementing https://github.com/hashicorp/terraform-ls/issues/496

The main aim here is to agree on two [new] interfaces, `schema.Constraint` and `decoder.Expression`:

```go
type Constraint interface {
	isConstraintImpl() constraintSigil
	FriendlyName() string
	Copy() Constraint
	// EmptyCompletionData provides completion data (to be used in text edits),
	// with snippet placeholder identifiers such as ${4} (if any) starting
	// from given nextPlaceholder.
	// 1 is the most appropriate placeholder, if none were yet assigned prior
	// to rendering completion data for this constraint (e.g. map key).
	EmptyCompletionData(nextPlaceholder int) CompletionData
}
```

```go
type Expression interface {
	CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate
	HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData
	SemanticTokens(ctx context.Context) []lang.SemanticToken
	ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins
	ReferenceTargets(ctx context.Context, attrAddr *schema.AttributeAddrSchema) reference.Targets
}
```

The PR intentionally leaves out most of the implementation of both interfaces for all expression/constraint types, as the diff is already quite large. It does however implement the simple methods like `Copy()` and `FriendlyName()` for `schema.Constraint`s as these were mostly copy-pasted from the existing implementations.

There is a WIP staging ground for some implementations in https://github.com/hashicorp/hcl-lang/compare/f-expressions-staging-ground

The idea is that we can _then_ raise separate PRs, where each focuses on each individual constraint/expression, or even different aspect of it (completion / hover / semantic tokens / reference origins / reference targets).

This PR is also leaving out addition of the planned new constraint, `schema.AnyExpressionOfType` or similar, which would effectively enable support for nested expressions. It should make adding such a constraint much easier/cleaner however.

## Open Questions

 - ~Should `decoder.Expression.ReferenceOrigins()` accept context as the first argument, like the other methods?~
   - Should we also use that context to pass through "allowSelfRefs" somehow?
   - Should `decoder.PathDecoder.CollectReferenceOrigins()` also accept context, like other similar methods?
 - ~Should `decoder.Expression.ReferenceTargets()` accept context as the first argument, like the other methods?~
   - Should `decoder.PathDecoder.CollectReferenceTargets()` also accept context, like other similar methods?
 - (non-blocking) Should `Conform()` be implemented for constraints other than `LiteralType` and `OneOf`?
   - What would this mean for `Object`? How should optional attributes be treated?
   - What are the possible use cases for that method? Will that remain only completion hooks?
   - Should we (ab)use this method also in https://github.com/hashicorp/terraform-ls/issues/583 ?
 - ~Should we be updating tests, or copying them - i.e. should the old logic remain covered by tests in the meantime?~