### PR TITLE
github: Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @hashicorp/tf-editor-experience-engineers


### PR DESCRIPTION
As per our internal discussions, this helps differentiate between engineers on the team who need to be pinged about reviews and anyone else who does not.