### PR TITLE
Refactor `NewExpression` to allow access to path context

### DIFF
--- a/decoder/expr_any.go
+++ b/decoder/expr_any.go
@@ -1,0 +1,41 @@
+package decoder
+
+import (
+	"context"
+
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/reference"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+)
+
+type Any struct {
+	expr    hcl.Expression
+	cons    schema.AnyExpression
+	pathCtx *PathContext
+}
+
+func (a Any) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate {
+	// TODO
+	return nil
+}
+
+func (a Any) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData {
+	// TODO
+	return nil
+}
+
+func (a Any) SemanticTokens(ctx context.Context) []lang.SemanticToken {
+	// TODO
+	return nil
+}
+
+func (a Any) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {
+	// TODO
+	return nil
+}
+
+func (a Any) ReferenceTargets(ctx context.Context, attrAddr *schema.AttributeAddrSchema) reference.Targets {
+	// TODO
+	return nil
+}

--- a/decoder/expression.go
+++ b/decoder/expression.go
@@ -19,7 +19,7 @@ type Expression interface {
 	ReferenceTargets(ctx context.Context, attrAddr *schema.AttributeAddrSchema) reference.Targets
 }
 
-func NewExpression(expr hcl.Expression, cons schema.Constraint) Expression {
+func (d *PathDecoder) newExpression(expr hcl.Expression, cons schema.Constraint) Expression {
 	switch c := cons.(type) {
 	case schema.LiteralType:
 		return LiteralType{expr: expr, cons: c}

--- a/decoder/expression.go
+++ b/decoder/expression.go
@@ -21,6 +21,8 @@ type Expression interface {
 
 func (d *PathDecoder) newExpression(expr hcl.Expression, cons schema.Constraint) Expression {
 	switch c := cons.(type) {
+	case schema.AnyExpression:
+		return Any{expr: expr, cons: c, pathCtx: d.pathCtx}
 	case schema.LiteralType:
 		return LiteralType{expr: expr, cons: c}
 	case schema.Reference:

--- a/decoder/expression_candidates.go
+++ b/decoder/expression_candidates.go
@@ -27,7 +27,7 @@ func (d *PathDecoder) attrValueCandidatesAtPos(ctx context.Context, attr *hclsyn
 
 	if schema.Constraint != nil {
 		if uint(count) < d.maxCandidates {
-			expr := NewExpression(attr.Expr, schema.Constraint)
+			expr := d.newExpression(attr.Expr, schema.Constraint)
 			for _, candidate := range expr.CompletionAtPos(ctx, pos) {
 				if uint(count) >= d.maxCandidates {
 					return candidates, nil

--- a/decoder/expression_test.go
+++ b/decoder/expression_test.go
@@ -1,6 +1,7 @@
 package decoder
 
 var (
+	_ Expression = Any{}
 	_ Expression = Keyword{}
 	_ Expression = List{}
 	_ Expression = LiteralType{}

--- a/decoder/hover.go
+++ b/decoder/hover.go
@@ -79,7 +79,7 @@ func (d *PathDecoder) hoverAtPos(ctx context.Context, body *hclsyntax.Body, body
 
 			if attr.Expr.Range().ContainsPos(pos) {
 				if aSchema.Constraint != nil {
-					return NewExpression(attr.Expr, aSchema.Constraint).HoverAtPos(ctx, pos), nil
+					return d.newExpression(attr.Expr, aSchema.Constraint).HoverAtPos(ctx, pos), nil
 				}
 
 				exprCons := ExprConstraints(aSchema.Expr)

--- a/decoder/reference_origins.go
+++ b/decoder/reference_origins.go
@@ -171,7 +171,7 @@ func (d *PathDecoder) referenceOriginsInBody(body hcl.Body, bodySchema *schema.B
 			allowSelfRefs = true
 		}
 		if aSchema.Constraint != nil {
-			origins = append(origins, NewExpression(attr.Expr, aSchema.Constraint).ReferenceOrigins(ctx, allowSelfRefs)...)
+			origins = append(origins, d.newExpression(attr.Expr, aSchema.Constraint).ReferenceOrigins(ctx, allowSelfRefs)...)
 		} else {
 			origins = append(origins, d.legacyFindOriginsInExpression(attr.Expr, aSchema.Expr, allowSelfRefs)...)
 		}

--- a/decoder/reference_targets.go
+++ b/decoder/reference_targets.go
@@ -127,7 +127,7 @@ func (d *PathDecoder) decodeReferenceTargetsForBody(body hcl.Body, parentBlock *
 			attrSchema = bodySchema.AnyAttribute
 		}
 
-		refs = append(refs, decodeReferenceTargetsForAttribute(attr, attrSchema)...)
+		refs = append(refs, d.decodeReferenceTargetsForAttribute(attr, attrSchema)...)
 	}
 
 	for _, blk := range content.Blocks {
@@ -266,13 +266,13 @@ func decodeTargetableBody(body hcl.Body, parentBlock *blockContent, tt *schema.T
 	return target
 }
 
-func decodeReferenceTargetsForAttribute(attr *hcl.Attribute, attrSchema *schema.AttributeSchema) reference.Targets {
+func (d *PathDecoder) decodeReferenceTargetsForAttribute(attr *hcl.Attribute, attrSchema *schema.AttributeSchema) reference.Targets {
 	refs := make(reference.Targets, 0)
 
 	ctx := context.Background()
 
 	if attrSchema.Constraint != nil {
-		refs = append(refs, NewExpression(attr.Expr, attrSchema.Constraint).ReferenceTargets(ctx, attrSchema.Address)...)
+		refs = append(refs, d.newExpression(attr.Expr, attrSchema.Constraint).ReferenceTargets(ctx, attrSchema.Address)...)
 	} else {
 		if attrSchema.Address != nil {
 			attrAddr, ok := resolveAttributeAddress(attr, attrSchema.Address.Steps)

--- a/decoder/semantic_tokens.go
+++ b/decoder/semantic_tokens.go
@@ -78,7 +78,7 @@ func (d *PathDecoder) tokensForBody(ctx context.Context, body *hclsyntax.Body, b
 		})
 
 		if attrSchema.Constraint != nil {
-			tokens = append(tokens, NewExpression(attr.Expr, attrSchema.Constraint).SemanticTokens(ctx)...)
+			tokens = append(tokens, d.newExpression(attr.Expr, attrSchema.Constraint).SemanticTokens(ctx)...)
 		} else {
 			ec := ExprConstraints(attrSchema.Expr)
 			tokens = append(tokens, d.tokensForExpression(ctx, attr.Expr, ec)...)

--- a/schema/constraint_any_expression.go
+++ b/schema/constraint_any_expression.go
@@ -4,9 +4,13 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-// AnyExpression TODO
+// AnyExpression represents any expression type convertible
+// to the given data type (OfType).
+//
+// For example function call returning cty.String complies with
+// AnyExpression{OfType: cty.String}.
 type AnyExpression struct {
-	// OfType defines the type of a type-aware reference
+	// OfType defines the type which the outermost expression is constrained to
 	OfType cty.Type
 }
 

--- a/schema/constraint_any_expression.go
+++ b/schema/constraint_any_expression.go
@@ -1,0 +1,30 @@
+package schema
+
+import (
+	"github.com/zclconf/go-cty/cty"
+)
+
+// AnyExpression TODO
+type AnyExpression struct {
+	// OfType defines the type of a type-aware reference
+	OfType cty.Type
+}
+
+func (AnyExpression) isConstraintImpl() constraintSigil {
+	return constraintSigil{}
+}
+
+func (ae AnyExpression) FriendlyName() string {
+	return ae.OfType.FriendlyNameForConstraint()
+}
+
+func (ae AnyExpression) Copy() Constraint {
+	return AnyExpression{
+		OfType: ae.OfType,
+	}
+}
+
+func (ae AnyExpression) EmptyCompletionData(nextPlaceholder int) CompletionData {
+	// TODO
+	return CompletionData{}
+}

--- a/schema/constraint_test.go
+++ b/schema/constraint_test.go
@@ -1,6 +1,7 @@
 package schema
 
 var (
+	_ Constraint = AnyExpression{}
 	_ Constraint = Keyword{}
 	_ Constraint = List{}
 	_ Constraint = LiteralType{}


### PR DESCRIPTION
This is a small update to #177 and enables access to path context, which is required for working with functions, references and origins.