### PR TITLE
decoder/schema: Add support for `Keyword` as `Constraint`

### DIFF
--- a/decoder/expr_keyword.go
+++ b/decoder/expr_keyword.go
@@ -13,11 +13,6 @@ type Keyword struct {
 	cons schema.Keyword
 }
 
-func (kw Keyword) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData {
-	// TODO
-	return nil
-}
-
 func (kw Keyword) SemanticTokens(ctx context.Context) []lang.SemanticToken {
 	// TODO
 	return nil

--- a/decoder/expr_keyword.go
+++ b/decoder/expr_keyword.go
@@ -1,9 +1,6 @@
 package decoder
 
 import (
-	"context"
-
-	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
 )
@@ -11,9 +8,4 @@ import (
 type Keyword struct {
 	expr hcl.Expression
 	cons schema.Keyword
-}
-
-func (kw Keyword) SemanticTokens(ctx context.Context) []lang.SemanticToken {
-	// TODO
-	return nil
 }

--- a/decoder/expr_keyword.go
+++ b/decoder/expr_keyword.go
@@ -13,11 +13,6 @@ type Keyword struct {
 	cons schema.Keyword
 }
 
-func (kw Keyword) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate {
-	// TODO
-	return nil
-}
-
 func (kw Keyword) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData {
 	// TODO
 	return nil

--- a/decoder/expr_keyword_completion.go
+++ b/decoder/expr_keyword_completion.go
@@ -1,0 +1,62 @@
+package decoder
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+func (kw Keyword) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate {
+	if isEmptyExpression(kw.expr) {
+		return []lang.Candidate{
+			{
+				Label:       kw.cons.Keyword,
+				Detail:      kw.cons.FriendlyName(),
+				Description: kw.cons.Description,
+				Kind:        lang.KeywordCandidateKind,
+				TextEdit: lang.TextEdit{
+					NewText: kw.cons.Keyword,
+					Snippet: kw.cons.Keyword,
+					Range: hcl.Range{
+						Filename: kw.expr.Range().Filename,
+						Start:    pos,
+						End:      pos,
+					},
+				},
+			},
+		}
+	}
+
+	eType, ok := kw.expr.(*hclsyntax.ScopeTraversalExpr)
+	if !ok {
+		return []lang.Candidate{}
+	}
+
+	if len(eType.Traversal) != 1 {
+		return []lang.Candidate{}
+	}
+
+	prefixLen := pos.Byte - eType.Traversal.SourceRange().Start.Byte
+	prefix := eType.Traversal.RootName()[0:prefixLen]
+
+	if strings.HasPrefix(kw.cons.Keyword, prefix) {
+		return []lang.Candidate{
+			{
+				Label:       kw.cons.Keyword,
+				Detail:      kw.cons.FriendlyName(),
+				Description: kw.cons.Description,
+				Kind:        lang.KeywordCandidateKind,
+				TextEdit: lang.TextEdit{
+					NewText: kw.cons.Keyword,
+					Snippet: kw.cons.Keyword,
+					Range:   eType.Range(),
+				},
+			},
+		}
+	}
+
+	return []lang.Candidate{}
+}

--- a/decoder/expr_keyword_completion_test.go
+++ b/decoder/expr_keyword_completion_test.go
@@ -1,0 +1,138 @@
+package decoder
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+func TestCompletionAtPos_exprKeyword(t *testing.T) {
+	testCases := []struct {
+		testName           string
+		attrSchema         map[string]*schema.AttributeSchema
+		cfg                string
+		pos                hcl.Pos
+		expectedCandidates lang.Candidates
+	}{
+		{
+			"no expression",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Keyword{Keyword: "foobar"},
+				},
+			},
+			`attr = `,
+			hcl.Pos{Line: 1, Column: 8, Byte: 7},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "foobar",
+					Detail: "keyword",
+					Kind:   lang.KeywordCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "foobar",
+						Snippet: "foobar",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"matching prefix",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Keyword{Keyword: "foobar"},
+				},
+			},
+			`attr = f`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "foobar",
+					Detail: "keyword",
+					Kind:   lang.KeywordCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "foobar",
+						Snippet: "foobar",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"matching prefix in the middle",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Keyword{Keyword: "foobar"},
+				},
+			},
+			`attr = foo`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "foobar",
+					Detail: "keyword",
+					Kind:   lang.KeywordCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "foobar",
+						Snippet: "foobar",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 11, Byte: 10},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"mismatching prefix",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Keyword{Keyword: "foobar"},
+				},
+			},
+			`attr = x`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			lang.CompleteCandidates([]lang.Candidate{}),
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := &schema.BodySchema{
+				Attributes: tc.attrSchema,
+			}
+
+			f, _ := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.tf": f,
+				},
+			})
+
+			ctx := context.Background()
+			candidates, err := d.CandidatesAtPos(ctx, "test.tf", tc.pos)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedCandidates, candidates); diff != "" {
+				t.Fatalf("unexpected candidates: %s", diff)
+			}
+		})
+	}
+}

--- a/decoder/expr_keyword_hover.go
+++ b/decoder/expr_keyword_hover.go
@@ -1,0 +1,35 @@
+package decoder
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+func (kw Keyword) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData {
+	eType, ok := kw.expr.(*hclsyntax.ScopeTraversalExpr)
+	if !ok {
+		return nil
+	}
+
+	if len(eType.Traversal) != 1 {
+		return nil
+	}
+
+	if eType.Traversal.RootName() == kw.cons.Keyword {
+		content := fmt.Sprintf("`%s` _%s_", kw.cons.Keyword, kw.cons.FriendlyName())
+		if kw.cons.Description.Value != "" {
+			content += "\n\n" + kw.cons.Description.Value
+		}
+
+		return &lang.HoverData{
+			Content: lang.Markdown(content),
+			Range:   eType.SrcRange,
+		}
+	}
+
+	return nil
+}

--- a/decoder/expr_keyword_hover_test.go
+++ b/decoder/expr_keyword_hover_test.go
@@ -1,0 +1,117 @@
+package decoder
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+func TestHoverAtPos_exprKeyword(t *testing.T) {
+	testCases := []struct {
+		testName          string
+		attrSchema        map[string]*schema.AttributeSchema
+		cfg               string
+		pos               hcl.Pos
+		expectedHoverData *lang.HoverData
+	}{
+		{
+			"mismatching expression type",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Keyword{
+						Keyword: "foobar",
+					},
+				},
+			},
+			`attr = "foobar"`,
+			hcl.Pos{Line: 1, Column: 12, Byte: 11},
+			nil,
+		},
+		{
+			"mismatching keyword",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Keyword{
+						Keyword: "foobar",
+					},
+				},
+			},
+			`attr = barfoo`,
+			hcl.Pos{Line: 1, Column: 12, Byte: 11},
+			nil,
+		},
+		{
+			"matching keyword",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Keyword{
+						Keyword: "foobar",
+					},
+				},
+			},
+			`attr = foobar`,
+			hcl.Pos{Line: 1, Column: 12, Byte: 11},
+			&lang.HoverData{
+				Content: lang.Markdown("`foobar` _keyword_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 14, Byte: 13},
+				},
+			},
+		},
+		{
+			"matching keyword with all metadata",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Keyword{
+						Keyword:     "foobar",
+						Name:        "custom name",
+						Description: lang.Markdown("custom _description_"),
+					},
+				},
+			},
+			`attr = foobar`,
+			hcl.Pos{Line: 1, Column: 12, Byte: 11},
+			&lang.HoverData{
+				Content: lang.Markdown("`foobar` _custom name_\n\ncustom _description_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 14, Byte: 13},
+				},
+			},
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := &schema.BodySchema{
+				Attributes: tc.attrSchema,
+			}
+
+			f, _ := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.tf": f,
+				},
+			})
+
+			ctx := context.Background()
+			hoverData, err := d.HoverAtPos(ctx, "test.tf", tc.pos)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedHoverData, hoverData); diff != "" {
+				t.Fatalf("unexpected hover data: %s", diff)
+			}
+		})
+	}
+}

--- a/decoder/expr_keyword_semtok.go
+++ b/decoder/expr_keyword_semtok.go
@@ -1,0 +1,31 @@
+package decoder
+
+import (
+	"context"
+
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+func (kw Keyword) SemanticTokens(ctx context.Context) []lang.SemanticToken {
+	eType, ok := kw.expr.(*hclsyntax.ScopeTraversalExpr)
+	if !ok {
+		return []lang.SemanticToken{}
+	}
+
+	if len(eType.Traversal) != 1 {
+		return []lang.SemanticToken{}
+	}
+
+	if eType.Traversal.RootName() == kw.cons.Keyword {
+		return []lang.SemanticToken{
+			{
+				Type:      lang.TokenKeyword,
+				Modifiers: []lang.SemanticTokenModifier{},
+				Range:     eType.Range(),
+			},
+		}
+	}
+
+	return []lang.SemanticToken{}
+}

--- a/decoder/expr_keyword_semtok_test.go
+++ b/decoder/expr_keyword_semtok_test.go
@@ -1,0 +1,123 @@
+package decoder
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+func TestSemanticTokens_exprKeyword(t *testing.T) {
+	testCases := []struct {
+		testName               string
+		attrSchema             map[string]*schema.AttributeSchema
+		cfg                    string
+		expectedSemanticTokens []lang.SemanticToken
+	}{
+		{
+			"mismatching expression type",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Keyword{
+						Keyword: "foobar",
+					},
+				},
+			},
+			`attr = "foobar"`,
+			[]lang.SemanticToken{
+				{
+					Type:      "hcl-attrName",
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+			},
+		},
+		{
+			"mismatching keyword",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Keyword{
+						Keyword: "foobar",
+					},
+				},
+			},
+			`attr = barfoo`,
+			[]lang.SemanticToken{
+				{
+					Type:      "hcl-attrName",
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+			},
+		},
+		{
+			"matching keyword",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Keyword{
+						Keyword: "foobar",
+					},
+				},
+			},
+			`attr = foobar`,
+			[]lang.SemanticToken{
+				{
+					Type:      "hcl-attrName",
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      "hcl-keyword",
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						End:      hcl.Pos{Line: 1, Column: 14, Byte: 13},
+					},
+				},
+			},
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := &schema.BodySchema{
+				Attributes: tc.attrSchema,
+			}
+
+			f, _ := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.tf": f,
+				},
+			})
+
+			ctx := context.Background()
+			tokens, err := d.SemanticTokensInFile(ctx, "test.tf")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedSemanticTokens, tokens); diff != "" {
+				t.Fatalf("unexpected tokens: %s", diff)
+			}
+		})
+	}
+}

--- a/schema/constraint_keyword.go
+++ b/schema/constraint_keyword.go
@@ -37,6 +37,8 @@ func (k Keyword) Copy() Constraint {
 }
 
 func (k Keyword) EmptyCompletionData(nextPlaceholder int) CompletionData {
-	// TODO
-	return CompletionData{}
+	return CompletionData{
+		TriggerSuggest:  true,
+		LastPlaceholder: nextPlaceholder,
+	}
 }


### PR DESCRIPTION
Part of https://github.com/hashicorp/terraform-ls/issues/496

--- 

https://github.com/hashicorp/terraform-schema/pull/174/commits/442c5c891f5798d4a345f8ff55ba1ccb90fec129 is downstream reflection of this constraint. The examples below leverage that commit. It also however makes it clear that `Keyword` often in schema relies on `OneOf` constraint, so for full support of keywords, that constraint has to be implemented.

## UX Impact

Since keywords aren't nested, this is expected to be no-op for the end-user and essentially just work the same as before.

### Completion

![2023-01-23 19 58 09](https://user-images.githubusercontent.com/287584/214114773-e037e405-ac8f-4dc6-9448-8508532467f7.gif)

### Hover

![2023-01-23 19 58 55](https://user-images.githubusercontent.com/287584/214114816-68a3d891-d740-4fa3-a8d5-6523df7f32c1.gif)

### Semantic Tokens

![2023-01-23 19 59 14](https://user-images.githubusercontent.com/287584/214114855-cd42413d-ba87-4a5a-8624-ede7693fec31.gif)
<img width="523" alt="Screenshot 2023-01-23 at 19 59 47" src="https://user-images.githubusercontent.com/287584/214114900-d0450da5-9836-4b4f-a180-e5f670e32de4.png">

