### PR TITLE
decoder: Add support for `LiteralType` as `Constraint`

### DIFF
--- a/decoder/expr_literal_type.go
+++ b/decoder/expr_literal_type.go
@@ -1,9 +1,6 @@
 package decoder
 
 import (
-	"context"
-
-	"github.com/hashicorp/hcl-lang/reference"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
 )
@@ -13,9 +10,4 @@ type LiteralType struct {
 	cons schema.LiteralType
 
 	pathCtx *PathContext
-}
-
-func (lt LiteralType) ReferenceTargets(ctx context.Context, targetCtx *TargetContext) reference.Targets {
-	// TODO
-	return nil
 }

--- a/decoder/expr_literal_type.go
+++ b/decoder/expr_literal_type.go
@@ -15,11 +15,6 @@ type LiteralType struct {
 	pathCtx *PathContext
 }
 
-func (lt LiteralType) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {
-	// TODO
-	return nil
-}
-
 func (lt LiteralType) ReferenceTargets(ctx context.Context, targetCtx *TargetContext) reference.Targets {
 	// TODO
 	return nil

--- a/decoder/expr_literal_type.go
+++ b/decoder/expr_literal_type.go
@@ -3,7 +3,6 @@ package decoder
 import (
 	"context"
 
-	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/reference"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
@@ -14,11 +13,6 @@ type LiteralType struct {
 	cons schema.LiteralType
 
 	pathCtx *PathContext
-}
-
-func (lt LiteralType) SemanticTokens(ctx context.Context) []lang.SemanticToken {
-	// TODO
-	return nil
 }
 
 func (lt LiteralType) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {

--- a/decoder/expr_literal_type.go
+++ b/decoder/expr_literal_type.go
@@ -12,11 +12,8 @@ import (
 type LiteralType struct {
 	expr hcl.Expression
 	cons schema.LiteralType
-}
 
-func (lt LiteralType) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate {
-	// TODO
-	return nil
+	pathCtx *PathContext
 }
 
 func (lt LiteralType) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData {

--- a/decoder/expr_literal_type.go
+++ b/decoder/expr_literal_type.go
@@ -16,11 +16,6 @@ type LiteralType struct {
 	pathCtx *PathContext
 }
 
-func (lt LiteralType) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData {
-	// TODO
-	return nil
-}
-
 func (lt LiteralType) SemanticTokens(ctx context.Context) []lang.SemanticToken {
 	// TODO
 	return nil

--- a/decoder/expr_literal_type_completion.go
+++ b/decoder/expr_literal_type_completion.go
@@ -1,0 +1,204 @@
+package decoder
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func (lt LiteralType) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate {
+	typ := lt.cons.Type
+
+	if isEmptyExpression(lt.expr) {
+		editRange := hcl.Range{
+			Filename: lt.expr.Range().Filename,
+			Start:    pos,
+			End:      pos,
+		}
+
+		if typ.IsPrimitiveType() {
+			if typ == cty.Bool {
+				return boolLiteralCandidates("", editRange)
+			}
+			return []lang.Candidate{}
+		}
+
+		if typ == cty.DynamicPseudoType {
+			return []lang.Candidate{}
+		}
+
+		return []lang.Candidate{
+			{
+				Label:  labelForLiteralType(typ),
+				Detail: typ.FriendlyName(),
+				Kind:   candidateKindForType(typ),
+				TextEdit: lang.TextEdit{
+					Range:   editRange,
+					NewText: newTextForLiteralType(typ),
+					Snippet: snippetForLiteralType(1, typ),
+				},
+			},
+		}
+	}
+
+	if typ == cty.Bool {
+		return lt.completeBoolAtPos(ctx, pos)
+	}
+
+	if typ.IsListType() {
+		expr, ok := lt.expr.(*hclsyntax.TupleConsExpr)
+		if !ok {
+			return []lang.Candidate{}
+		}
+
+		cons := schema.List{
+			Elem: schema.LiteralType{
+				Type: typ.ElementType(),
+			},
+		}
+
+		return newExpression(lt.pathCtx, expr, cons).CompletionAtPos(ctx, pos)
+	}
+
+	if typ.IsSetType() {
+		expr, ok := lt.expr.(*hclsyntax.TupleConsExpr)
+		if !ok {
+			return []lang.Candidate{}
+		}
+
+		cons := schema.Set{
+			Elem: schema.LiteralType{
+				Type: typ.ElementType(),
+			},
+		}
+
+		return newExpression(lt.pathCtx, expr, cons).CompletionAtPos(ctx, pos)
+	}
+
+	if typ.IsTupleType() {
+		expr, ok := lt.expr.(*hclsyntax.TupleConsExpr)
+		if !ok {
+			return []lang.Candidate{}
+		}
+
+		elemTypes := typ.TupleElementTypes()
+		cons := schema.Tuple{
+			Elems: make([]schema.Constraint, len(elemTypes)),
+		}
+		for i, elemType := range elemTypes {
+			cons.Elems[i] = schema.LiteralType{
+				Type: elemType,
+			}
+		}
+
+		return newExpression(lt.pathCtx, expr, cons).CompletionAtPos(ctx, pos)
+	}
+
+	if typ.IsMapType() {
+		expr, ok := lt.expr.(*hclsyntax.ObjectConsExpr)
+		if !ok {
+			return []lang.Candidate{}
+		}
+
+		cons := schema.Map{
+			Elem: schema.LiteralType{
+				Type: typ.ElementType(),
+			},
+		}
+		return newExpression(lt.pathCtx, expr, cons).CompletionAtPos(ctx, pos)
+	}
+
+	if typ.IsObjectType() {
+		expr, ok := lt.expr.(*hclsyntax.ObjectConsExpr)
+		if !ok {
+			return []lang.Candidate{}
+		}
+
+		cons := schema.Object{
+			Attributes: ctyObjectToObjectAttributes(typ),
+		}
+		return newExpression(lt.pathCtx, expr, cons).CompletionAtPos(ctx, pos)
+	}
+
+	return []lang.Candidate{}
+}
+
+func (lt LiteralType) completeBoolAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate {
+	switch eType := lt.expr.(type) {
+
+	case *hclsyntax.ScopeTraversalExpr:
+		prefixLen := pos.Byte - eType.Range().Start.Byte
+		prefix := eType.Traversal.RootName()[0:prefixLen]
+		return boolLiteralCandidates(prefix, eType.Range())
+
+	case *hclsyntax.LiteralValueExpr:
+		if eType.Val.Type() == cty.Bool {
+			value := "false"
+			if eType.Val.True() {
+				value = "true"
+			}
+			prefixLen := pos.Byte - eType.Range().Start.Byte
+			prefix := value[0:prefixLen]
+			return boolLiteralCandidates(prefix, eType.Range())
+		}
+	}
+
+	return []lang.Candidate{}
+}
+
+func boolLiteralCandidates(prefix string, editRange hcl.Range) []lang.Candidate {
+	candidates := make([]lang.Candidate, 0)
+
+	if strings.HasPrefix("false", prefix) {
+		candidates = append(candidates, lang.Candidate{
+			Label:  "false",
+			Detail: cty.Bool.FriendlyNameForConstraint(),
+			Kind:   lang.BoolCandidateKind,
+			TextEdit: lang.TextEdit{
+				NewText: "false",
+				Snippet: "false",
+				Range:   editRange,
+			},
+		})
+	}
+	if strings.HasPrefix("true", prefix) {
+		candidates = append(candidates, lang.Candidate{
+			Label:  "true",
+			Detail: cty.Bool.FriendlyNameForConstraint(),
+			Kind:   lang.BoolCandidateKind,
+			TextEdit: lang.TextEdit{
+				NewText: "true",
+				Snippet: "true",
+				Range:   editRange,
+			},
+		})
+	}
+
+	return candidates
+}
+
+func ctyObjectToObjectAttributes(objType cty.Type) schema.ObjectAttributes {
+	attrTypes := objType.AttributeTypes()
+	objAttributes := make(schema.ObjectAttributes, len(attrTypes))
+
+	for name, attrType := range attrTypes {
+		aSchema := &schema.AttributeSchema{
+			Constraint: schema.LiteralType{
+				Type: attrType,
+			},
+		}
+		if objType.AttributeOptional(name) {
+			aSchema.IsOptional = true
+		} else {
+			aSchema.IsRequired = true
+		}
+		objAttributes[name] = aSchema
+	}
+
+	return objAttributes
+}

--- a/decoder/expr_literal_type_completion_test.go
+++ b/decoder/expr_literal_type_completion_test.go
@@ -1,0 +1,1101 @@
+package decoder
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestCompletionAtPos_exprLiteralType(t *testing.T) {
+	testCases := []struct {
+		testName           string
+		attrSchema         map[string]*schema.AttributeSchema
+		cfg                string
+		pos                hcl.Pos
+		expectedCandidates lang.Candidates
+	}{
+		{
+			"bool",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Bool,
+					},
+				},
+			},
+			`attr = 
+`,
+			hcl.Pos{Line: 1, Column: 8, Byte: 7},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "false",
+					Detail: cty.Bool.FriendlyNameForConstraint(),
+					Kind:   lang.BoolCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "false",
+						Snippet: "false",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+					},
+				},
+				{
+					Label:  "true",
+					Detail: cty.Bool.FriendlyNameForConstraint(),
+					Kind:   lang.BoolCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "true",
+						Snippet: "true",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"bool by prefix",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Bool,
+					},
+				},
+			},
+			`attr = f
+`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "false",
+					Detail: cty.Bool.FriendlyNameForConstraint(),
+					Kind:   lang.BoolCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "false",
+						Snippet: "false",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"string",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.String,
+					},
+				},
+			},
+			`attr = 
+`,
+			hcl.Pos{Line: 1, Column: 8, Byte: 7},
+			lang.CompleteCandidates([]lang.Candidate{}),
+		},
+		{
+			"list of strings",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.List(cty.String),
+					},
+				},
+			},
+			`attr = 
+`,
+			hcl.Pos{Line: 1, Column: 8, Byte: 7},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "[ string ]",
+					Detail: "list of string",
+					Kind:   lang.ListCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: `[ "" ]`,
+						Snippet: `[ "${1:value}" ]`,
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"inside list of bool",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.List(cty.Bool),
+					},
+				},
+			},
+			`attr = [  ]
+`,
+			hcl.Pos{Line: 1, Column: 10, Byte: 9},
+			lang.CompleteCandidates(boolLiteralCandidates("", hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+				End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+			})),
+		},
+		{
+			"inside list of bool multiline",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.List(cty.Bool),
+					},
+				},
+			},
+			`attr = [
+  
+]
+`,
+			hcl.Pos{Line: 2, Column: 3, Byte: 11},
+			lang.CompleteCandidates(boolLiteralCandidates("", hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+				End:      hcl.Pos{Line: 2, Column: 3, Byte: 11},
+			})),
+		},
+		{
+			"inside list next element after space",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.List(cty.Bool),
+					},
+				},
+			},
+			`attr = [ false,  ]
+`,
+			hcl.Pos{Line: 1, Column: 17, Byte: 16},
+			lang.CompleteCandidates(boolLiteralCandidates("", hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.Pos{Line: 1, Column: 17, Byte: 16},
+				End:      hcl.Pos{Line: 1, Column: 17, Byte: 16},
+			})),
+		},
+		{
+			"inside list next element after newline",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.List(cty.Bool),
+					},
+				},
+			},
+			`attr = [
+  false,
+  
+]
+`,
+			hcl.Pos{Line: 3, Column: 3, Byte: 20},
+			lang.CompleteCandidates(boolLiteralCandidates("", hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.Pos{Line: 3, Column: 3, Byte: 20},
+				End:      hcl.Pos{Line: 3, Column: 3, Byte: 20},
+			})),
+		},
+		{
+			"inside list next element after comma",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.List(cty.Bool),
+					},
+				},
+			},
+			`attr = [ false, ]
+`,
+			hcl.Pos{Line: 1, Column: 16, Byte: 15},
+			lang.CompleteCandidates(boolLiteralCandidates("", hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.Pos{Line: 1, Column: 16, Byte: 15},
+				End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+			})),
+		},
+		{
+			"inside list next element near closing bracket",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.List(cty.Bool),
+					},
+				},
+			},
+			`attr = [ false, ]
+`,
+			hcl.Pos{Line: 1, Column: 17, Byte: 16},
+			lang.CompleteCandidates(boolLiteralCandidates("", hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.Pos{Line: 1, Column: 17, Byte: 16},
+				End:      hcl.Pos{Line: 1, Column: 17, Byte: 16},
+			})),
+		},
+		{
+			"completion inside list with prefix",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.List(cty.Bool),
+					},
+				},
+			},
+			`attr = [ f ]
+`,
+			hcl.Pos{Line: 1, Column: 11, Byte: 10},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "false",
+					Detail: cty.Bool.FriendlyNameForConstraint(),
+					Kind:   lang.BoolCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "false",
+						Snippet: "false",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+							End:      hcl.Pos{Line: 1, Column: 11, Byte: 10},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"tuple",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Tuple([]cty.Type{cty.Bool}),
+					},
+				},
+			},
+			`attr = 
+`,
+			hcl.Pos{Line: 1, Column: 8, Byte: 7},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "[ bool ]",
+					Detail: "tuple",
+					Kind:   lang.TupleCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "[ false ]",
+						Snippet: "[ ${1:false} ]",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"inside tuple",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Tuple([]cty.Type{cty.Bool}),
+					},
+				},
+			},
+			`attr = [  ]
+`,
+			hcl.Pos{Line: 1, Column: 10, Byte: 9},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "false",
+					Detail: "bool",
+					Kind:   lang.BoolCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "false",
+						Snippet: "false",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+							End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+						},
+					},
+				},
+				{
+					Label:  "true",
+					Detail: "bool",
+					Kind:   lang.BoolCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "true",
+						Snippet: "true",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+							End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"inside tuple next element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Tuple([]cty.Type{cty.String, cty.Bool}),
+					},
+				},
+			},
+			`attr = [ "",  ]
+`,
+			hcl.Pos{Line: 1, Column: 14, Byte: 13},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "false",
+					Detail: "bool",
+					Kind:   lang.BoolCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "false",
+						Snippet: "false",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 14, Byte: 13},
+							End:      hcl.Pos{Line: 1, Column: 14, Byte: 13},
+						},
+					},
+				},
+				{
+					Label:  "true",
+					Detail: "bool",
+					Kind:   lang.BoolCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "true",
+						Snippet: "true",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 14, Byte: 13},
+							End:      hcl.Pos{Line: 1, Column: 14, Byte: 13},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"inside tuple next element without comma",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Tuple([]cty.Type{cty.String, cty.Bool}),
+					},
+				},
+			},
+			`attr = [ ""  ]
+`,
+			hcl.Pos{Line: 1, Column: 13, Byte: 12},
+			lang.CompleteCandidates([]lang.Candidate{}),
+		},
+		{
+			"inside tuple in space between elements",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Tuple([]cty.Type{cty.String, cty.String, cty.Bool}),
+					},
+				},
+			},
+			`attr = [ "", ""  ]
+`,
+			hcl.Pos{Line: 1, Column: 13, Byte: 12},
+			lang.CompleteCandidates([]lang.Candidate{}),
+		},
+		{
+			"inside tuple next element which does not exist",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Tuple([]cty.Type{cty.String}),
+					},
+				},
+			},
+			`attr = [ "",  ]
+`,
+			hcl.Pos{Line: 1, Column: 14, Byte: 13},
+			lang.CompleteCandidates([]lang.Candidate{}),
+		},
+		{
+			"map",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Map(cty.Bool),
+					},
+				},
+			},
+			`attr = 
+`,
+			hcl.Pos{Line: 1, Column: 8, Byte: 7},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `{ "key" = bool }`,
+					Detail: "map of bool",
+					Kind:   lang.MapCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "{\n  \"key\" = false\n}",
+						Snippet: "{\n  \"${1:key}\" = ${2:false}\n}",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"inside empty map",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Map(cty.Bool),
+					},
+				},
+			},
+			`attr = {
+  
+}
+`,
+			hcl.Pos{Line: 2, Column: 3, Byte: 11},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `"key" = bool`,
+					Detail: "bool",
+					Kind:   lang.AttributeCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "\"key\" = false",
+						Snippet: "\"${1:key}\" = ${2:false}",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+							End:      hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"inside map after first item",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Map(cty.Bool),
+					},
+				},
+			},
+			`attr = {
+  "key" = true
+  
+}
+`,
+			hcl.Pos{Line: 3, Column: 3, Byte: 26},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `"key" = bool`,
+					Detail: "bool",
+					Kind:   lang.AttributeCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "\"key\" = false",
+						Snippet: "\"${1:key}\" = ${2:false}",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 3, Column: 3, Byte: 26},
+							End:      hcl.Pos{Line: 3, Column: 3, Byte: 26},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"inside map between items",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Map(cty.Bool),
+					},
+				},
+			},
+			`attr = {
+  "key" = true
+  
+  "another" = false
+}
+`,
+			hcl.Pos{Line: 3, Column: 3, Byte: 26},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `"key" = bool`,
+					Detail: "bool",
+					Kind:   lang.AttributeCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "\"key\" = false",
+						Snippet: "\"${1:key}\" = ${2:false}",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 3, Column: 3, Byte: 26},
+							End:      hcl.Pos{Line: 3, Column: 3, Byte: 26},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"inside map before item",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Map(cty.Bool),
+					},
+				},
+			},
+			`attr = {
+  "key" = true
+}
+`,
+			hcl.Pos{Line: 2, Column: 2, Byte: 10},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `"key" = bool`,
+					Detail: "bool",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 2, Byte: 10},
+							End:      hcl.Pos{Line: 2, Column: 2, Byte: 10},
+						},
+						NewText: `"key" = false`,
+						Snippet: `"${1:key}" = ${2:false}`,
+					},
+					Kind: lang.AttributeCandidateKind,
+				},
+			}),
+		},
+		{
+			"inside map value empty",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Map(cty.Bool),
+					},
+				},
+			},
+			`attr = {
+  "key" = 
+}
+`,
+			hcl.Pos{Line: 2, Column: 11, Byte: 19},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "false",
+					Detail: "bool",
+					Kind:   lang.BoolCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "false",
+						Snippet: "false",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 11, Byte: 19},
+							End:      hcl.Pos{Line: 2, Column: 11, Byte: 19},
+						},
+					},
+				},
+				{
+					Label:  "true",
+					Detail: "bool",
+					Kind:   lang.BoolCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "true",
+						Snippet: "true",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 11, Byte: 19},
+							End:      hcl.Pos{Line: 2, Column: 11, Byte: 19},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"inside map value with prefix",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Map(cty.Bool),
+					},
+				},
+			},
+			`attr = {
+  "key" = f
+}
+`,
+			hcl.Pos{Line: 2, Column: 12, Byte: 20},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "false",
+					Detail: "bool",
+					Kind:   lang.BoolCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "false",
+						Snippet: "false",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 11, Byte: 19},
+							End:      hcl.Pos{Line: 2, Column: 12, Byte: 20},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"object",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Object(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.Bool,
+							"baz": cty.Number,
+						}),
+					},
+				},
+			},
+			`attr = 
+`,
+			hcl.Pos{Line: 1, Column: 8, Byte: 7},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `{ bar = bool, … }`,
+					Detail: "object",
+					Kind:   lang.ObjectCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "{\n  bar = false\n  baz = 1\n  foo = \"\"\n}",
+						Snippet: "{\n  bar = ${1:false}\n  baz = ${2:1}\n  foo = \"${3:value}\"\n}",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"inside empty object",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Object(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.Bool,
+							"baz": cty.Number,
+						}),
+					},
+				},
+			},
+			`attr = {
+
+}
+`,
+			hcl.Pos{Line: 2, Column: 1, Byte: 9},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `bar`,
+					Detail: "required, bool",
+					Kind:   lang.AttributeCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "bar",
+						Snippet: "bar = ${1:false}",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 1, Byte: 9},
+							End:      hcl.Pos{Line: 2, Column: 1, Byte: 9},
+						},
+					},
+				},
+				{
+					Label:  `baz`,
+					Detail: "required, number",
+					Kind:   lang.AttributeCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "baz",
+						Snippet: "baz = ${1:0}",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 1, Byte: 9},
+							End:      hcl.Pos{Line: 2, Column: 1, Byte: 9},
+						},
+					},
+				},
+				{
+					Label:  `foo`,
+					Detail: "required, string",
+					Kind:   lang.AttributeCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "foo",
+						Snippet: "foo = \"${1:value}\"",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 1, Byte: 9},
+							End:      hcl.Pos{Line: 2, Column: 1, Byte: 9},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"inside object after first item",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Object(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.Bool,
+						}),
+					},
+				},
+			},
+			`attr = {
+  foo = "baz"
+  
+}
+`,
+			hcl.Pos{Line: 3, Column: 3, Byte: 25},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `bar`,
+					Detail: "required, bool",
+					Kind:   lang.AttributeCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "bar",
+						Snippet: "bar = ${1:false}",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 3, Column: 3, Byte: 25},
+							End:      hcl.Pos{Line: 3, Column: 3, Byte: 25},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"inside object between items",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Object(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.Bool,
+							"baz": cty.Number,
+						}),
+					},
+				},
+			},
+			`attr = {
+  foo = "baz"
+  
+  baz = 42
+}
+`,
+			hcl.Pos{Line: 3, Column: 3, Byte: 25},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `bar`,
+					Detail: "required, bool",
+					Kind:   lang.AttributeCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "bar",
+						Snippet: "bar = ${1:false}",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 3, Column: 3, Byte: 25},
+							End:      hcl.Pos{Line: 3, Column: 3, Byte: 25},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"inside object before item",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Object(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.Bool,
+						}),
+					},
+				},
+			},
+			`attr = {
+  foo = "baz"
+}
+`,
+			hcl.Pos{Line: 2, Column: 2, Byte: 10},
+			lang.CompleteCandidates([]lang.Candidate{}),
+		},
+		{
+			"inside object key",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Object(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.Bool,
+							"baz": cty.Number,
+						}),
+					},
+				},
+			},
+			`attr = {
+  bar = true
+}
+`,
+			hcl.Pos{Line: 2, Column: 5, Byte: 13},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `bar`,
+					Detail: "required, bool",
+					Kind:   lang.AttributeCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "bar",
+						Snippet: "bar = ${1:false}",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+							End:      hcl.Pos{Line: 2, Column: 13, Byte: 21},
+						},
+					},
+				},
+				{
+					Label:  `baz`,
+					Detail: "required, number",
+					Kind:   lang.AttributeCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "baz",
+						Snippet: "baz = ${1:0}",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+							End:      hcl.Pos{Line: 2, Column: 13, Byte: 21},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"inside object value",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Object(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.Bool,
+							"baz": cty.Number,
+						}),
+					},
+				},
+			},
+			`attr = {
+  bar = false
+}
+`,
+			hcl.Pos{Line: 2, Column: 10, Byte: 18},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `false`,
+					Detail: "bool",
+					Kind:   lang.BoolCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "false",
+						Snippet: "false",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 9, Byte: 17},
+							End:      hcl.Pos{Line: 2, Column: 14, Byte: 22},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"inside object with incomplete key",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Object(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.Bool,
+							"baz": cty.Number,
+						}),
+					},
+				},
+			},
+			`attr = {
+  ba
+}
+`,
+			hcl.Pos{Line: 2, Column: 5, Byte: 13},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `bar`,
+					Detail: "required, bool",
+					Kind:   lang.AttributeCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "bar",
+						Snippet: "bar = ${1:false}",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+							End:      hcl.Pos{Line: 2, Column: 5, Byte: 13},
+						},
+					},
+				},
+				{
+					Label:  `baz`,
+					Detail: "required, number",
+					Kind:   lang.AttributeCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "baz",
+						Snippet: "baz = ${1:0}",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+							End:      hcl.Pos{Line: 2, Column: 5, Byte: 13},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"inside object with no value",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Object(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.Bool,
+							"baz": cty.Number,
+						}),
+					},
+				},
+			},
+			`attr = {
+  bar = 
+}
+`,
+			hcl.Pos{Line: 2, Column: 9, Byte: 17},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `false`,
+					Detail: "bool",
+					Kind:   lang.BoolCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "false",
+						Snippet: "false",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 9, Byte: 17},
+							End:      hcl.Pos{Line: 2, Column: 9, Byte: 17},
+						},
+					},
+				},
+				{
+					Label:  `true`,
+					Detail: "bool",
+					Kind:   lang.BoolCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "true",
+						Snippet: "true",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 9, Byte: 17},
+							End:      hcl.Pos{Line: 2, Column: 9, Byte: 17},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"inside object with incomplete value",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Object(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.Bool,
+							"baz": cty.Number,
+						}),
+					},
+				},
+			},
+			`attr = {
+  bar = f
+}
+`,
+			hcl.Pos{Line: 2, Column: 10, Byte: 18},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `false`,
+					Detail: "bool",
+					Kind:   lang.BoolCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "false",
+						Snippet: "false",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 9, Byte: 17},
+							End:      hcl.Pos{Line: 2, Column: 10, Byte: 18},
+						},
+					},
+				},
+			}),
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := &schema.BodySchema{
+				Attributes: tc.attrSchema,
+			}
+
+			f, _ := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.tf": f,
+				},
+			})
+
+			ctx := context.Background()
+			candidates, err := d.CandidatesAtPos(ctx, "test.tf", tc.pos)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedCandidates, candidates); diff != "" {
+				t.Fatalf("unexpected candidates: %s", diff)
+			}
+		})
+	}
+}

--- a/decoder/expr_literal_type_hover.go
+++ b/decoder/expr_literal_type_hover.go
@@ -1,0 +1,149 @@
+package decoder
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func (lt LiteralType) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData {
+	typ := lt.cons.Type
+
+	if typ == cty.DynamicPseudoType {
+		val, _ := lt.expr.Value(nil)
+		if val.IsKnown() && !val.IsNull() {
+			typ = val.Type()
+		}
+	}
+
+	// string is a special case as it's always represented like a template
+	// even if there's no templating involved
+	if typ == cty.String {
+		expr, ok := lt.expr.(*hclsyntax.TemplateExpr)
+		if !ok {
+			return nil
+		}
+		if expr.IsStringLiteral() || isMultilineStringLiteral(expr) {
+			return &lang.HoverData{
+				Content: lang.Markdown(fmt.Sprintf(`_%s_`, typ.FriendlyName())),
+				Range:   expr.Range(),
+			}
+		}
+
+		return nil
+	}
+
+	if typ.IsPrimitiveType() {
+		expr, ok := lt.expr.(*hclsyntax.LiteralValueExpr)
+		if !ok {
+			return nil
+		}
+
+		if !lt.cons.Type.Equals(expr.Val.Type()) {
+			return nil
+		}
+
+		return &lang.HoverData{
+			Content: lang.Markdown(fmt.Sprintf(`_%s_`, typ.FriendlyName())),
+			Range:   expr.Range(),
+		}
+	}
+
+	if typ.IsListType() {
+		expr, ok := lt.expr.(*hclsyntax.TupleConsExpr)
+		if !ok {
+			return nil
+		}
+
+		cons := schema.List{
+			Elem: schema.LiteralType{
+				Type: typ.ElementType(),
+			},
+		}
+
+		return newExpression(lt.pathCtx, expr, cons).HoverAtPos(ctx, pos)
+	}
+
+	if typ.IsSetType() {
+		expr, ok := lt.expr.(*hclsyntax.TupleConsExpr)
+		if !ok {
+			return nil
+		}
+
+		cons := schema.Set{
+			Elem: schema.LiteralType{
+				Type: typ.ElementType(),
+			},
+		}
+
+		return newExpression(lt.pathCtx, expr, cons).HoverAtPos(ctx, pos)
+	}
+
+	if typ.IsTupleType() {
+		expr, ok := lt.expr.(*hclsyntax.TupleConsExpr)
+		if !ok {
+			return nil
+		}
+
+		elemTypes := typ.TupleElementTypes()
+		cons := schema.Tuple{
+			Elems: make([]schema.Constraint, len(elemTypes)),
+		}
+		for i, elemType := range elemTypes {
+			cons.Elems[i] = schema.LiteralType{
+				Type: elemType,
+			}
+		}
+
+		return newExpression(lt.pathCtx, expr, cons).HoverAtPos(ctx, pos)
+	}
+
+	if typ.IsMapType() {
+		expr, ok := lt.expr.(*hclsyntax.ObjectConsExpr)
+		if !ok {
+			return nil
+		}
+
+		cons := schema.Map{
+			Elem: schema.LiteralType{
+				Type: typ.ElementType(),
+			},
+		}
+		return newExpression(lt.pathCtx, expr, cons).HoverAtPos(ctx, pos)
+	}
+
+	if typ.IsObjectType() {
+		expr, ok := lt.expr.(*hclsyntax.ObjectConsExpr)
+		if !ok {
+			return nil
+		}
+
+		cons := schema.Object{
+			Attributes: ctyObjectToObjectAttributes(typ),
+		}
+		return newExpression(lt.pathCtx, expr, cons).HoverAtPos(ctx, pos)
+	}
+
+	return nil
+}
+
+func isMultilineStringLiteral(tplExpr *hclsyntax.TemplateExpr) bool {
+	if len(tplExpr.Parts) < 1 {
+		return false
+	}
+	for _, part := range tplExpr.Parts {
+		expr, ok := part.(*hclsyntax.LiteralValueExpr)
+		if !ok {
+			return false
+		}
+		if expr.Val.Type() != cty.String {
+			return false
+		}
+	}
+	return true
+}

--- a/decoder/expr_literal_type_hover.go
+++ b/decoder/expr_literal_type_hover.go
@@ -15,8 +15,8 @@ func (lt LiteralType) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverDa
 	typ := lt.cons.Type
 
 	if typ == cty.DynamicPseudoType {
-		val, _ := lt.expr.Value(nil)
-		if val.IsKnown() && !val.IsNull() {
+		val, diags := lt.expr.Value(nil)
+		if !diags.HasErrors() {
 			typ = val.Type()
 		}
 	}

--- a/decoder/expr_literal_type_hover_test.go
+++ b/decoder/expr_literal_type_hover_test.go
@@ -1,0 +1,1148 @@
+package decoder
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestHoverAtPos_exprLiteralType(t *testing.T) {
+	testCases := []struct {
+		testName          string
+		attrSchema        map[string]*schema.AttributeSchema
+		cfg               string
+		pos               hcl.Pos
+		expectedHoverData *lang.HoverData
+	}{
+		{
+			"any type",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.DynamicPseudoType,
+					},
+					IsOptional: true,
+				},
+			},
+			`attr = "foobar"`,
+			hcl.Pos{Line: 1, Column: 12, Byte: 11},
+			&lang.HoverData{
+				Content: lang.Markdown("_string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+				},
+			},
+		},
+
+		// primitive types
+		{
+			"boolean",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Bool,
+					},
+				},
+			},
+			`attr = false`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			&lang.HoverData{
+				Content: lang.Markdown("_bool_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 13, Byte: 12},
+				},
+			},
+		},
+		{
+			"number whole",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Number,
+					},
+				},
+			},
+			`attr = 4222"`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			&lang.HoverData{
+				Content: lang.Markdown("_number_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 12, Byte: 11},
+				},
+			},
+		},
+		{
+			"number fractional",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Number,
+					},
+				},
+			},
+			`attr = 4.222"`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			&lang.HoverData{
+				Content: lang.Markdown("_number_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 13, Byte: 12},
+				},
+			},
+		},
+		{
+			"string single-line",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.String,
+					},
+				},
+			},
+			`attr = "foo"`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			&lang.HoverData{
+				Content: lang.Markdown("_string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 13, Byte: 12},
+				},
+			},
+		},
+		{
+			"string multi-line",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.String,
+					},
+				},
+			},
+			`attr = <<TEXT
+foo
+bar
+TEXT
+`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			&lang.HoverData{
+				Content: lang.Markdown("_string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 4, Column: 5, Byte: 26},
+				},
+			},
+		},
+		{
+			"string template",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.String,
+					},
+				},
+			},
+			`attr = "foo${bar}"`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			nil,
+		},
+
+		// list
+		{
+			"list with any element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.List(cty.DynamicPseudoType),
+					},
+				},
+			},
+			`attr = []`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			&lang.HoverData{
+				Content: lang.Markdown("_list of any type_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+				},
+			},
+		},
+		{
+			"empty single-line list with element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.List(cty.String),
+					},
+				},
+			},
+			`attr = []`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			&lang.HoverData{
+				Content: lang.Markdown("_list of string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+				},
+			},
+		},
+		{
+			"empty multi-line list with element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.List(cty.String),
+					},
+				},
+			},
+			`attr = [
+  
+]`,
+			hcl.Pos{Line: 2, Column: 2, Byte: 10},
+			&lang.HoverData{
+				Content: lang.Markdown("_list of string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 3, Column: 2, Byte: 13},
+				},
+			},
+		},
+		{
+			"single element single-line list on element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.List(cty.String),
+					},
+				},
+			},
+			`attr = ["fooba"]`,
+			hcl.Pos{Line: 1, Column: 12, Byte: 11},
+			&lang.HoverData{
+				Content: lang.Markdown("_string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+					End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+				},
+			},
+		},
+		{
+			"multi-element single-line list on list",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.List(cty.String),
+					},
+				},
+			},
+			`attr = [ "one", "two" ]`,
+			hcl.Pos{Line: 1, Column: 8, Byte: 7},
+			&lang.HoverData{
+				Content: lang.Markdown("_list of string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start: hcl.Pos{
+						Line:   1,
+						Column: 8,
+						Byte:   7,
+					},
+					End: hcl.Pos{
+						Line:   1,
+						Column: 24,
+						Byte:   23,
+					},
+				},
+			},
+		},
+		{
+			"single element multi-line list on element with custom data",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.List(cty.String),
+					},
+				},
+			},
+			`attr = [
+  "foobar",
+]`,
+			hcl.Pos{Line: 2, Column: 6, Byte: 14},
+			&lang.HoverData{
+				Content: lang.Markdown("_string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+					End:      hcl.Pos{Line: 2, Column: 11, Byte: 19},
+				},
+			},
+		},
+		{
+			"multi-element multi-line list on invalid element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.List(cty.String),
+					},
+				},
+			},
+			`attr = [
+  4223,
+  "foobar",
+]`,
+			hcl.Pos{Line: 2, Column: 6, Byte: 14},
+			nil,
+		},
+		{
+			"multi-element multi-line list on second element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.List(cty.String),
+					},
+				},
+			},
+			`attr = [
+  "foo",
+  "bar",
+]`,
+			hcl.Pos{Line: 3, Column: 4, Byte: 22},
+			&lang.HoverData{
+				Content: lang.Markdown("_string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 3, Column: 3, Byte: 20},
+					End:      hcl.Pos{Line: 3, Column: 8, Byte: 25},
+				},
+			},
+		},
+
+		// set
+		{
+			"set with any element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Set(cty.DynamicPseudoType),
+					},
+				},
+			},
+			`attr = []`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			&lang.HoverData{
+				Content: lang.Markdown("_set of any type_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+				},
+			},
+		},
+		{
+			"empty single-line set with element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Set(cty.String),
+					},
+				},
+			},
+			`attr = []`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			&lang.HoverData{
+				Content: lang.Markdown("_set of string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+				},
+			},
+		},
+		{
+			"empty multi-line set with element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Set(cty.String),
+					},
+				},
+			},
+			`attr = [
+  
+]`,
+			hcl.Pos{Line: 2, Column: 2, Byte: 10},
+			&lang.HoverData{
+				Content: lang.Markdown("_set of string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 3, Column: 2, Byte: 13},
+				},
+			},
+		},
+		{
+			"single element single-line set on element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Set(cty.String),
+					},
+				},
+			},
+			`attr = ["fooba"]`,
+			hcl.Pos{Line: 1, Column: 12, Byte: 11},
+			&lang.HoverData{
+				Content: lang.Markdown("_string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+					End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+				},
+			},
+		},
+		{
+			"multi-element single-line set on set",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Set(cty.String),
+					},
+				},
+			},
+			`attr = [ "one", "two" ]`,
+			hcl.Pos{Line: 1, Column: 8, Byte: 7},
+			&lang.HoverData{
+				Content: lang.Markdown("_set of string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start: hcl.Pos{
+						Line:   1,
+						Column: 8,
+						Byte:   7,
+					},
+					End: hcl.Pos{
+						Line:   1,
+						Column: 24,
+						Byte:   23,
+					},
+				},
+			},
+		},
+		{
+			"multi-element multi-line set on invalid element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Set(cty.String),
+					},
+				},
+			},
+			`attr = [
+  42223,
+  "foobar",
+]`,
+			hcl.Pos{Line: 2, Column: 6, Byte: 14},
+			nil,
+		},
+		{
+			"multi-element multi-line set on second element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Set(cty.String),
+					},
+				},
+			},
+			`attr = [
+  "foo",
+  "bar",
+]`,
+			hcl.Pos{Line: 3, Column: 5, Byte: 22},
+			&lang.HoverData{
+				Content: lang.Markdown("_string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 3, Column: 3, Byte: 20},
+					End:      hcl.Pos{Line: 3, Column: 8, Byte: 25},
+				},
+			},
+		},
+
+		// tuple
+		{
+			"empty single-line tuple without element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Tuple([]cty.Type{}),
+					},
+				},
+			},
+			`attr = []`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			&lang.HoverData{
+				Content: lang.Markdown("_tuple_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+				},
+			},
+		},
+		{
+			"empty multi-line tuple without element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Tuple([]cty.Type{}),
+					},
+				},
+			},
+			`attr = [
+  
+]`,
+			hcl.Pos{Line: 2, Column: 2, Byte: 10},
+			&lang.HoverData{
+				Content: lang.Markdown("_tuple_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 3, Column: 2, Byte: 13},
+				},
+			},
+		},
+		{
+			"empty single-line tuple with one element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Tuple([]cty.Type{
+							cty.String,
+							cty.Number,
+						}),
+					},
+				},
+			},
+			`attr = []`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			&lang.HoverData{
+				Content: lang.Markdown("_tuple_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+				},
+			},
+		},
+		{
+			"empty multi-line tuple with one element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Tuple([]cty.Type{
+							cty.String,
+						}),
+					},
+				},
+			},
+			`attr = [
+  
+]`,
+			hcl.Pos{Line: 2, Column: 2, Byte: 10},
+			&lang.HoverData{
+				Content: lang.Markdown("_tuple_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 3, Column: 2, Byte: 13},
+				},
+			},
+		},
+		{
+			"single element single-line tuple on element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Tuple([]cty.Type{
+							cty.String,
+							cty.Bool,
+						}),
+					},
+				},
+			},
+			`attr = ["fooba"]`,
+			hcl.Pos{Line: 1, Column: 12, Byte: 11},
+			&lang.HoverData{
+				Content: lang.Markdown("_string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+					End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+				},
+			},
+		},
+		{
+			"multi-element single-line tuple on tuple",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Tuple([]cty.Type{
+							cty.String,
+							cty.Number,
+						}),
+					},
+				},
+			},
+			`attr = [ "one", 42234 ]`,
+			hcl.Pos{Line: 1, Column: 8, Byte: 7},
+			&lang.HoverData{
+				Content: lang.Markdown("_tuple_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start: hcl.Pos{
+						Line:   1,
+						Column: 8,
+						Byte:   7,
+					},
+					End: hcl.Pos{
+						Line:   1,
+						Column: 24,
+						Byte:   23,
+					},
+				},
+			},
+		},
+		{
+			"multi-element multi-line tuple on invalid element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Tuple([]cty.Type{
+							cty.Number,
+							cty.String,
+						}),
+					},
+				},
+			},
+			`attr = [
+  "foo",
+  42223,
+]`,
+			hcl.Pos{Line: 2, Column: 6, Byte: 14},
+			nil,
+		},
+		{
+			"multi-element multi-line tuple on second element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Tuple([]cty.Type{
+							cty.String,
+							cty.String,
+						}),
+					},
+				},
+			},
+			`attr = [
+  "foobar",
+  "barfoo",
+]`,
+			hcl.Pos{Line: 3, Column: 6, Byte: 26},
+			&lang.HoverData{
+				Content: lang.Markdown("_string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 3, Column: 3, Byte: 23},
+					End:      hcl.Pos{Line: 3, Column: 11, Byte: 31},
+				},
+			},
+		},
+
+		// map
+		{
+			"empty single-line map with any element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Map(cty.DynamicPseudoType),
+					},
+				},
+			},
+			`attr = {}`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			&lang.HoverData{
+				Content: lang.Markdown("_map of any type_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+				},
+			},
+		},
+		{
+			"empty multi-line map with any element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Map(cty.DynamicPseudoType),
+					},
+				},
+			},
+			`attr = {
+  
+}`,
+			hcl.Pos{Line: 2, Column: 2, Byte: 10},
+			&lang.HoverData{
+				Content: lang.Markdown("_map of any type_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 3, Column: 2, Byte: 13},
+				},
+			},
+		},
+		{
+			"empty single-line map with element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Map(cty.String),
+					},
+				},
+			},
+			`attr = {}`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			&lang.HoverData{
+				Content: lang.Markdown("_map of string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+				},
+			},
+		},
+		{
+			"single item map on key name",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Map(cty.String),
+					},
+				},
+			},
+			`attr = {
+  foo = "bar"
+}`,
+			hcl.Pos{Line: 2, Column: 5, Byte: 13},
+			nil,
+		},
+		{
+			"single item map on invalid key type",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Map(cty.String),
+					},
+				},
+			},
+			`attr = {
+  422 = "bar"
+}`,
+			hcl.Pos{Line: 2, Column: 5, Byte: 13},
+			nil,
+		},
+		{
+			"multi item map on valid key type",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Map(cty.String),
+					},
+				},
+			},
+			`attr = {
+  422 = "foo"
+  bar = "bar"
+  432 = "baz"
+}`,
+			hcl.Pos{Line: 3, Column: 5, Byte: 27},
+			nil,
+		},
+		{
+			"multi item map on matching value",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Map(cty.String),
+					},
+				},
+			},
+			`attr = {
+  foo = invalid
+  bar = "foobar"
+  baz = "foobaz"
+}`,
+			hcl.Pos{Line: 3, Column: 13, Byte: 37},
+			&lang.HoverData{
+				Content: lang.Markdown("_string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 3, Column: 9, Byte: 33},
+					End:      hcl.Pos{Line: 3, Column: 17, Byte: 41},
+				},
+			},
+		},
+		{
+			"multi item map on mismatching value",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Map(cty.String),
+					},
+				},
+			},
+			`attr = {
+  foo = invalid
+  bar = "foobar"
+  baz = "foobaz"
+}`,
+			hcl.Pos{Line: 2, Column: 13, Byte: 21},
+			nil,
+		},
+
+		// object
+		{
+			"empty single-line object without attributes",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Object(map[string]cty.Type{}),
+					},
+				},
+			},
+			`attr = {}`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			&lang.HoverData{
+				Content: lang.Markdown("_object_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+				},
+			},
+		},
+		{
+			"empty multi-line object without attributes",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Object(map[string]cty.Type{}),
+					},
+				},
+			},
+			`attr = {
+  
+}`,
+			hcl.Pos{Line: 2, Column: 2, Byte: 10},
+			&lang.HoverData{
+				Content: lang.Markdown("_object_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 3, Column: 2, Byte: 13},
+				},
+			},
+		},
+		{
+			"empty single-line object with attributes",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+							"foo": cty.String,
+						}, []string{"foo"}),
+					},
+				},
+			},
+			`attr = {}`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			&lang.HoverData{
+				Content: lang.Markdown("```\n{\n  foo = string # optional\n}\n```\n_object_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+				},
+			},
+		},
+		{
+			"empty multi-line object with attributes",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+							"foo": cty.String,
+						}, []string{"foo"}),
+					},
+				},
+			},
+			`attr = {
+  
+}`,
+			hcl.Pos{Line: 2, Column: 2, Byte: 10},
+			&lang.HoverData{
+				Content: lang.Markdown("```\n{\n  foo = string # optional\n}\n```\n_object_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 3, Column: 2, Byte: 13},
+				},
+			},
+		},
+		{
+			"single item object on valid attribute name",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+							"foo": cty.String,
+						}, []string{"foo"}),
+					},
+				},
+			},
+			`attr = {
+  foo = "fooba"
+}`,
+			hcl.Pos{Line: 2, Column: 5, Byte: 13},
+			&lang.HoverData{
+				Content: lang.Markdown("**foo** _optional, string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+					End:      hcl.Pos{Line: 2, Column: 16, Byte: 24},
+				},
+			},
+		},
+		{
+			"single item object on invalid attribute name",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Object(map[string]cty.Type{
+							"foo": cty.String,
+						}),
+					},
+				},
+			},
+			`attr = {
+  bar = "fooba"
+}`,
+			hcl.Pos{Line: 2, Column: 5, Byte: 13},
+			&lang.HoverData{
+				Content: lang.Markdown("```" + `
+{
+  foo = string
+}
+` + "```\n" + `_object_`),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 3, Column: 2, Byte: 26},
+				},
+			},
+		},
+		{
+			"multi item object on valid attribute name",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.String,
+							"baz": cty.String,
+						}, []string{"foo", "baz"}),
+					},
+				},
+			},
+			`attr = {
+  foo = "foo"
+  bar = "bar"
+  baz = "baz"
+}`,
+			hcl.Pos{Line: 3, Column: 5, Byte: 27},
+			&lang.HoverData{
+				Content: lang.Markdown("**bar** _required, string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 3, Column: 3, Byte: 25},
+					End:      hcl.Pos{Line: 3, Column: 14, Byte: 36},
+				},
+			},
+		},
+		{
+			"multi item object on matching value",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.String,
+							"baz": cty.String,
+						}, []string{"foo", "bar", "baz"}),
+					},
+				},
+			},
+			`attr = {
+  foo = invalid
+  bar = "barbar"
+  baz = "bazbaz"
+}`,
+			hcl.Pos{Line: 3, Column: 16, Byte: 40},
+			&lang.HoverData{
+				Content: lang.Markdown("_string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 3, Column: 9, Byte: 33},
+					End:      hcl.Pos{Line: 3, Column: 17, Byte: 41},
+				},
+			},
+		},
+		{
+			"multi item object on mismatching value",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.String,
+							"baz": cty.String,
+						}, []string{"foo", "bar", "baz"}),
+					},
+				},
+			},
+			`attr = {
+  foo = invalid
+  bar = "barbar"
+  baz = "bazbaz"
+}`,
+			hcl.Pos{Line: 2, Column: 13, Byte: 21},
+			nil,
+		},
+		{
+			"multi item object in empty space",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+							"foo": cty.Number,
+							"bar": cty.String,
+							"baz": cty.String,
+						}, []string{"foo", "bar", "baz"}),
+					},
+				},
+			},
+			`attr = {
+  bar = "bar"
+  baz = "baz"
+}`,
+			hcl.Pos{Line: 2, Column: 2, Byte: 10},
+			&lang.HoverData{
+				Content: lang.Markdown("```" + `
+{
+  bar = string # optional
+  baz = string # optional
+  foo = number # optional
+}
+` + "```\n_object_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 4, Column: 2, Byte: 38},
+				},
+			},
+		},
+		{
+			"multi item nested object",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+							"foo": cty.Number,
+							"bar": cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+								"noot":   cty.Bool,
+								"animal": cty.String,
+							}, []string{"animal"}),
+							"baz": cty.String,
+						}, []string{"foo", "bar", "baz"}),
+					},
+				},
+			},
+			`attr = {
+  bar = {}
+  baz = "baz"
+}`,
+			hcl.Pos{Line: 2, Column: 2, Byte: 10},
+			&lang.HoverData{
+				Content: lang.Markdown("```" + `
+{
+  bar = {
+    animal = string # optional
+    noot = bool
+  } # optional
+  baz = string # optional
+  foo = number # optional
+}
+` + "```\n_object_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 4, Column: 2, Byte: 35},
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := &schema.BodySchema{
+				Attributes: tc.attrSchema,
+			}
+
+			f, _ := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.tf": f,
+				},
+			})
+
+			ctx := context.Background()
+			hoverData, err := d.HoverAtPos(ctx, "test.tf", tc.pos)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedHoverData, hoverData); diff != "" {
+				t.Fatalf("unexpected hover data: %s", diff)
+			}
+		})
+	}
+}

--- a/decoder/expr_literal_type_ref_targets.go
+++ b/decoder/expr_literal_type_ref_targets.go
@@ -1,0 +1,114 @@
+package decoder
+
+import (
+	"context"
+
+	"github.com/hashicorp/hcl-lang/reference"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+func (lt LiteralType) ReferenceTargets(ctx context.Context, targetCtx *TargetContext) reference.Targets {
+	typ := lt.cons.Type
+
+	// Primitive types are collected separately on attribute level
+	if typ.IsPrimitiveType() {
+		return reference.Targets{}
+	}
+
+	if typ.IsListType() {
+		expr, ok := lt.expr.(*hclsyntax.TupleConsExpr)
+		if !ok {
+			return nil
+		}
+
+		list := List{
+			cons: schema.List{
+				Elem: schema.LiteralType{
+					Type: typ.ElementType(),
+				},
+			},
+			expr:    expr,
+			pathCtx: lt.pathCtx,
+		}
+		return list.ReferenceTargets(ctx, targetCtx)
+	}
+
+	if typ.IsSetType() {
+		expr, ok := lt.expr.(*hclsyntax.TupleConsExpr)
+		if !ok {
+			return nil
+		}
+
+		set := Set{
+			cons: schema.Set{
+				Elem: schema.LiteralType{
+					Type: typ.ElementType(),
+				},
+			},
+			expr:    expr,
+			pathCtx: lt.pathCtx,
+		}
+		return set.ReferenceTargets(ctx, targetCtx)
+	}
+
+	if typ.IsTupleType() {
+		expr, ok := lt.expr.(*hclsyntax.TupleConsExpr)
+		if !ok {
+			return nil
+		}
+
+		elemTypes := typ.TupleElementTypes()
+		cons := schema.Tuple{
+			Elems: make([]schema.Constraint, len(elemTypes)),
+		}
+		for i, elemType := range elemTypes {
+			cons.Elems[i] = schema.LiteralType{
+				Type: elemType,
+			}
+		}
+		tuple := Tuple{
+			cons:    cons,
+			expr:    expr,
+			pathCtx: lt.pathCtx,
+		}
+
+		return tuple.ReferenceTargets(ctx, targetCtx)
+	}
+
+	if typ.IsMapType() {
+		expr, ok := lt.expr.(*hclsyntax.ObjectConsExpr)
+		if !ok {
+			return nil
+		}
+
+		m := Map{
+			cons: schema.Map{
+				Elem: schema.LiteralType{
+					Type: typ.ElementType(),
+				},
+			},
+			expr:    expr,
+			pathCtx: lt.pathCtx,
+		}
+		return m.ReferenceTargets(ctx, targetCtx)
+	}
+
+	if typ.IsObjectType() {
+		expr, ok := lt.expr.(*hclsyntax.ObjectConsExpr)
+		if !ok {
+			return nil
+		}
+
+		obj := Object{
+			cons: schema.Object{
+				Attributes: ctyObjectToObjectAttributes(typ),
+			},
+			expr:    expr,
+			pathCtx: lt.pathCtx,
+		}
+		return obj.ReferenceTargets(ctx, targetCtx)
+	}
+
+	return reference.Targets{}
+}

--- a/decoder/expr_literal_type_semtok.go
+++ b/decoder/expr_literal_type_semtok.go
@@ -1,0 +1,153 @@
+package decoder
+
+import (
+	"context"
+
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func (lt LiteralType) SemanticTokens(ctx context.Context) []lang.SemanticToken {
+	typ := lt.cons.Type
+
+	if typ == cty.DynamicPseudoType {
+		val, _ := lt.expr.Value(nil)
+		if val.IsKnown() && !val.IsNull() {
+			typ = val.Type()
+		}
+	}
+
+	// string is a special case as it's always represented like a template
+	// even if there's no templating involved
+	if typ == cty.String {
+		expr, ok := lt.expr.(*hclsyntax.TemplateExpr)
+		if !ok {
+			return []lang.SemanticToken{}
+		}
+		if expr.IsStringLiteral() {
+			return []lang.SemanticToken{
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range:     expr.Range(),
+				},
+			}
+		}
+
+		// TODO: report multiline/HEREDOC notation
+
+		return []lang.SemanticToken{}
+	}
+
+	if typ.IsPrimitiveType() {
+		expr, ok := lt.expr.(*hclsyntax.LiteralValueExpr)
+		if !ok {
+			return []lang.SemanticToken{}
+		}
+
+		if !lt.cons.Type.Equals(expr.Val.Type()) {
+			return []lang.SemanticToken{}
+		}
+
+		if typ == cty.Bool {
+			return []lang.SemanticToken{
+				{
+					Type:      lang.TokenBool,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range:     expr.Range(),
+				},
+			}
+		}
+
+		if typ == cty.Number {
+			return []lang.SemanticToken{
+				{
+					Type:      lang.TokenNumber,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range:     expr.Range(),
+				},
+			}
+		}
+
+		return []lang.SemanticToken{}
+	}
+
+	if typ.IsListType() {
+		expr, ok := lt.expr.(*hclsyntax.TupleConsExpr)
+		if !ok {
+			return []lang.SemanticToken{}
+		}
+
+		cons := schema.List{
+			Elem: schema.LiteralType{
+				Type: typ.ElementType(),
+			},
+		}
+
+		return newExpression(lt.pathCtx, expr, cons).SemanticTokens(ctx)
+	}
+
+	if typ.IsSetType() {
+		expr, ok := lt.expr.(*hclsyntax.TupleConsExpr)
+		if !ok {
+			return []lang.SemanticToken{}
+		}
+
+		cons := schema.Set{
+			Elem: schema.LiteralType{
+				Type: typ.ElementType(),
+			},
+		}
+
+		return newExpression(lt.pathCtx, expr, cons).SemanticTokens(ctx)
+	}
+
+	if typ.IsTupleType() {
+		expr, ok := lt.expr.(*hclsyntax.TupleConsExpr)
+		if !ok {
+			return []lang.SemanticToken{}
+		}
+
+		elemTypes := typ.TupleElementTypes()
+		cons := schema.Tuple{
+			Elems: make([]schema.Constraint, len(elemTypes)),
+		}
+		for i, elemType := range elemTypes {
+			cons.Elems[i] = schema.LiteralType{
+				Type: elemType,
+			}
+		}
+
+		return newExpression(lt.pathCtx, expr, cons).SemanticTokens(ctx)
+	}
+
+	if typ.IsMapType() {
+		expr, ok := lt.expr.(*hclsyntax.ObjectConsExpr)
+		if !ok {
+			return []lang.SemanticToken{}
+		}
+
+		cons := schema.Map{
+			Elem: schema.LiteralType{
+				Type: typ.ElementType(),
+			},
+		}
+		return newExpression(lt.pathCtx, expr, cons).SemanticTokens(ctx)
+	}
+
+	if typ.IsObjectType() {
+		expr, ok := lt.expr.(*hclsyntax.ObjectConsExpr)
+		if !ok {
+			return []lang.SemanticToken{}
+		}
+
+		cons := schema.Object{
+			Attributes: ctyObjectToObjectAttributes(typ),
+		}
+		return newExpression(lt.pathCtx, expr, cons).SemanticTokens(ctx)
+	}
+
+	return []lang.SemanticToken{}
+}

--- a/decoder/expr_literal_type_semtok.go
+++ b/decoder/expr_literal_type_semtok.go
@@ -13,8 +13,8 @@ func (lt LiteralType) SemanticTokens(ctx context.Context) []lang.SemanticToken {
 	typ := lt.cons.Type
 
 	if typ == cty.DynamicPseudoType {
-		val, _ := lt.expr.Value(nil)
-		if val.IsKnown() && !val.IsNull() {
+		val, diags := lt.expr.Value(nil)
+		if !diags.HasErrors() {
 			typ = val.Type()
 		}
 	}

--- a/decoder/expr_literal_type_semtok.go
+++ b/decoder/expr_literal_type_semtok.go
@@ -36,7 +36,7 @@ func (lt LiteralType) SemanticTokens(ctx context.Context) []lang.SemanticToken {
 			}
 		}
 
-		// TODO: report multiline/HEREDOC notation
+		// TODO: consider reporting multiline/HEREDOC notation as a different token
 
 		return []lang.SemanticToken{}
 	}

--- a/decoder/expr_literal_type_semtok_test.go
+++ b/decoder/expr_literal_type_semtok_test.go
@@ -1,0 +1,1860 @@
+package decoder
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestSemanticTokens_exprLiteralType(t *testing.T) {
+	testCases := []struct {
+		testName               string
+		attrSchema             map[string]*schema.AttributeSchema
+		cfg                    string
+		expectedSemanticTokens []lang.SemanticToken
+	}{
+		{
+			"any type",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.DynamicPseudoType,
+					},
+				},
+			},
+			`attr = "foobar"`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+					},
+				},
+			},
+		},
+
+		// bool
+		{
+			"boolean",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Bool,
+					},
+				},
+			},
+			`attr = false`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenBool,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						End:      hcl.Pos{Line: 1, Column: 13, Byte: 12},
+					},
+				},
+			},
+		},
+
+		// string
+		{
+			"string",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.String,
+					},
+				},
+			},
+			`attr = "foobar"`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+					},
+				},
+			},
+		},
+
+		// number
+		{
+			"number whole",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Number,
+					},
+				},
+			},
+			`attr = 4223`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenNumber,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						End:      hcl.Pos{Line: 1, Column: 12, Byte: 11},
+					},
+				},
+			},
+		},
+		{
+			"number fractional",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Number,
+					},
+				},
+			},
+			`attr = 4.222`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenNumber,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						End:      hcl.Pos{Line: 1, Column: 13, Byte: 12},
+					},
+				},
+			},
+		},
+
+		// list
+		{
+			"empty list with any element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.List(cty.DynamicPseudoType),
+					},
+				},
+			},
+			`attr = []`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+			},
+		},
+		{
+			"empty list with element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.List(cty.String),
+					},
+				},
+			},
+			`attr = []`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+			},
+		},
+		{
+			"single element list",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.List(cty.String),
+					},
+				},
+			},
+			`attr = ["foobar"]`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						End:      hcl.Pos{Line: 1, Column: 17, Byte: 16},
+					},
+				},
+			},
+		},
+		{
+			"single element multi-line list",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.List(cty.String),
+					},
+				},
+			},
+			`attr = [
+  "foobar",
+]`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						End:      hcl.Pos{Line: 2, Column: 11, Byte: 19},
+					},
+				},
+			},
+		},
+		{
+			"multi-element multi-line list",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.List(cty.String),
+					},
+				},
+			},
+			`attr = [
+  "foobar",
+  "barfoo",
+]`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						End:      hcl.Pos{Line: 2, Column: 11, Byte: 19},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 3, Column: 3, Byte: 23},
+						End:      hcl.Pos{Line: 3, Column: 11, Byte: 31},
+					},
+				},
+			},
+		},
+		{
+			"multi-element multi-line list with invalid element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.List(cty.String),
+					},
+				},
+			},
+			`attr = [
+  "fooba",
+  invalid,
+  "fooba",
+]`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						End:      hcl.Pos{Line: 2, Column: 10, Byte: 18},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 4, Column: 3, Byte: 33},
+						End:      hcl.Pos{Line: 4, Column: 10, Byte: 40},
+					},
+				},
+			},
+		},
+
+		// set
+		{
+			"empty set with any element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Set(cty.DynamicPseudoType),
+					},
+				},
+			},
+			`attr = []`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+			},
+		},
+		{
+			"empty set with element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Set(cty.String),
+					},
+				},
+			},
+			`attr = []`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+			},
+		},
+		{
+			"single element set",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Set(cty.String),
+					},
+				},
+			},
+			`attr = ["fooba"]`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+					},
+				},
+			},
+		},
+		{
+			"single element multi-line set",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Set(cty.String),
+					},
+				},
+			},
+			`attr = [
+  "fooba",
+]`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						End:      hcl.Pos{Line: 2, Column: 10, Byte: 18},
+					},
+				},
+			},
+		},
+		{
+			"multi-element multi-line set",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Set(cty.String),
+					},
+				},
+			},
+			`attr = [
+  "fooba",
+  "fooba",
+]`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						End:      hcl.Pos{Line: 2, Column: 10, Byte: 18},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 3, Column: 3, Byte: 22},
+						End:      hcl.Pos{Line: 3, Column: 10, Byte: 29},
+					},
+				},
+			},
+		},
+		{
+			"multi-element multi-line set with invalid element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Set(cty.String),
+					},
+				},
+			},
+			`attr = [
+  "fooba",
+  invalid,
+  "fooba",
+]`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						End:      hcl.Pos{Line: 2, Column: 10, Byte: 18},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 4, Column: 3, Byte: 33},
+						End:      hcl.Pos{Line: 4, Column: 10, Byte: 40},
+					},
+				},
+			},
+		},
+
+		// tuple
+		{
+			"empty tuple without element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Tuple([]cty.Type{}),
+					},
+				},
+			},
+			`attr = []`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+			},
+		},
+		{
+			"empty tuple with element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Tuple([]cty.Type{
+							cty.String,
+						}),
+					},
+				},
+			},
+			`attr = []`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+			},
+		},
+		{
+			"single element tuple",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Tuple([]cty.Type{
+							cty.String,
+						}),
+					},
+				},
+			},
+			`attr = ["fooba"]`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+					},
+				},
+			},
+		},
+		{
+			"single element multi-line tuple",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Tuple([]cty.Type{
+							cty.String,
+						}),
+					},
+				},
+			},
+			`attr = [
+  "fooba",
+]`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						End:      hcl.Pos{Line: 2, Column: 10, Byte: 18},
+					},
+				},
+			},
+		},
+		{
+			"multi-element multi-line tuple",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Tuple([]cty.Type{
+							cty.String,
+							cty.Number,
+						}),
+					},
+				},
+			},
+			`attr = [
+  "fooba",
+  1234567,
+]`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						End:      hcl.Pos{Line: 2, Column: 10, Byte: 18},
+					},
+				},
+				{
+					Type:      lang.TokenNumber,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 3, Column: 3, Byte: 22},
+						End:      hcl.Pos{Line: 3, Column: 10, Byte: 29},
+					},
+				},
+			},
+		},
+		{
+			"multi-element multi-line tuple with invalid element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Tuple([]cty.Type{
+							cty.String,
+							cty.String,
+							cty.Number,
+						}),
+					},
+				},
+			},
+			`attr = [
+  "fooba",
+  invalid,
+  1234567,
+]`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						End:      hcl.Pos{Line: 2, Column: 10, Byte: 18},
+					},
+				},
+				{
+					Type:      lang.TokenNumber,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 4, Column: 3, Byte: 33},
+						End:      hcl.Pos{Line: 4, Column: 10, Byte: 40},
+					},
+				},
+			},
+		},
+
+		// map
+		{
+			"any element constraint",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Map(cty.DynamicPseudoType),
+					},
+				},
+			},
+			`attr = {}`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+			},
+		},
+		{
+			"single-line with mismatching expression",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Map(cty.String),
+					},
+				},
+			},
+			`attr = [ foobar ]`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+			},
+		},
+		{
+			"single-line with mismatching key type",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Map(cty.String),
+					},
+				},
+			},
+			`attr = { 422 = foobar }`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+			},
+		},
+		{
+			"single-line with valid item",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Map(cty.String),
+					},
+				},
+			},
+			`attr = { foo = "noot" }`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenMapKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+						End:      hcl.Pos{Line: 1, Column: 13, Byte: 12},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 16, Byte: 15},
+						End:      hcl.Pos{Line: 1, Column: 22, Byte: 21},
+					},
+				},
+			},
+		},
+		{
+			"single-line with valid multiple items",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Map(cty.String),
+					},
+				},
+			},
+			`attr = { foo = "noot", bar = "noot" }`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenMapKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+						End:      hcl.Pos{Line: 1, Column: 13, Byte: 12},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 16, Byte: 15},
+						End:      hcl.Pos{Line: 1, Column: 22, Byte: 21},
+					},
+				},
+				{
+					Type:      lang.TokenMapKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 24, Byte: 23},
+						End:      hcl.Pos{Line: 1, Column: 27, Byte: 26},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 30, Byte: 29},
+						End:      hcl.Pos{Line: 1, Column: 36, Byte: 35},
+					},
+				},
+			},
+		},
+		{
+			"single-line with valid multiple items with quoted keys",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Map(cty.String),
+					},
+				},
+			},
+			`attr = { "foo" = "noot", "bar" = "noot" }`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenMapKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+						End:      hcl.Pos{Line: 1, Column: 15, Byte: 14},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 18, Byte: 17},
+						End:      hcl.Pos{Line: 1, Column: 24, Byte: 23},
+					},
+				},
+				{
+					Type:      lang.TokenMapKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 26, Byte: 25},
+						End:      hcl.Pos{Line: 1, Column: 31, Byte: 30},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 34, Byte: 33},
+						End:      hcl.Pos{Line: 1, Column: 40, Byte: 39},
+					},
+				},
+			},
+		},
+		{
+			"single-line with multiple items and one mismatch",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Map(cty.String),
+					},
+				},
+			},
+			`attr = { foo = bar, bar = "noot" }`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenMapKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+						End:      hcl.Pos{Line: 1, Column: 13, Byte: 12},
+					},
+				},
+				{
+					Type:      lang.TokenMapKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 21, Byte: 20},
+						End:      hcl.Pos{Line: 1, Column: 24, Byte: 23},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 27, Byte: 26},
+						End:      hcl.Pos{Line: 1, Column: 33, Byte: 32},
+					},
+				},
+			},
+		},
+		{
+			"multi-line with valid item",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Map(cty.String),
+					},
+				},
+			},
+			`attr = {
+  foo = "noot"
+}`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenMapKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						End:      hcl.Pos{Line: 2, Column: 6, Byte: 14},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 9, Byte: 17},
+						End:      hcl.Pos{Line: 2, Column: 15, Byte: 23},
+					},
+				},
+			},
+		},
+		{
+			"multi-line with valid multiple items",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Map(cty.String),
+					},
+				},
+			},
+			`attr = {
+  foo = "noot"
+  bar = "toot"
+}`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenMapKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						End:      hcl.Pos{Line: 2, Column: 6, Byte: 14},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 9, Byte: 17},
+						End:      hcl.Pos{Line: 2, Column: 15, Byte: 23},
+					},
+				},
+				{
+					Type:      lang.TokenMapKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 3, Column: 3, Byte: 26},
+						End:      hcl.Pos{Line: 3, Column: 6, Byte: 29},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 3, Column: 9, Byte: 32},
+						End:      hcl.Pos{Line: 3, Column: 15, Byte: 38},
+					},
+				},
+			},
+		},
+		{
+			"multi-line with multiple items and one mismatch",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Map(cty.String),
+					},
+				},
+			},
+			`attr = {
+  foo = bar
+  bar = "noot"
+}`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenMapKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						End:      hcl.Pos{Line: 2, Column: 6, Byte: 14},
+					},
+				},
+				{
+					Type:      lang.TokenMapKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 3, Column: 3, Byte: 23},
+						End:      hcl.Pos{Line: 3, Column: 6, Byte: 26},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 3, Column: 9, Byte: 29},
+						End:      hcl.Pos{Line: 3, Column: 15, Byte: 35},
+					},
+				},
+			},
+		},
+
+		// object
+		{
+			"undefined attributes",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Object(map[string]cty.Type{}),
+					},
+				},
+			},
+			`attr = {}`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+			},
+		},
+		{
+			"single-line with mismatching expression",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Object(map[string]cty.Type{
+							"foo": cty.String,
+						}),
+					},
+				},
+			},
+			`attr = [ foobar ]`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+			},
+		},
+		{
+			"single-line with mismatching key type",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Object(map[string]cty.Type{
+							"foo": cty.String,
+						}),
+					},
+				},
+			},
+			`attr = { 422 = "noot" }`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+			},
+		},
+		{
+			"single-line with valid item",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Object(map[string]cty.Type{
+							"foo": cty.String,
+						}),
+					},
+				},
+			},
+			`attr = { foo = "noot" }`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenObjectKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+						End:      hcl.Pos{Line: 1, Column: 13, Byte: 12},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 16, Byte: 15},
+						End:      hcl.Pos{Line: 1, Column: 22, Byte: 21},
+					},
+				},
+			},
+		},
+		{
+			"single-line with valid multiple items",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Object(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.String,
+						}),
+					},
+				},
+			},
+			`attr = { foo = "noot", bar = "toot" }`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenObjectKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+						End:      hcl.Pos{Line: 1, Column: 13, Byte: 12},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 16, Byte: 15},
+						End:      hcl.Pos{Line: 1, Column: 22, Byte: 21},
+					},
+				},
+				{
+					Type:      lang.TokenObjectKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 24, Byte: 23},
+						End:      hcl.Pos{Line: 1, Column: 27, Byte: 26},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 30, Byte: 29},
+						End:      hcl.Pos{Line: 1, Column: 36, Byte: 35},
+					},
+				},
+			},
+		},
+		{
+			"single-line with valid multiple items with valid quoted attributes",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Object(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.String,
+						}),
+					},
+				},
+			},
+			`attr = { "foo" = "noot", "bar" = "toot" }`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenObjectKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+						End:      hcl.Pos{Line: 1, Column: 15, Byte: 14},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 18, Byte: 17},
+						End:      hcl.Pos{Line: 1, Column: 24, Byte: 23},
+					},
+				},
+				{
+					Type:      lang.TokenObjectKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 26, Byte: 25},
+						End:      hcl.Pos{Line: 1, Column: 31, Byte: 30},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 34, Byte: 33},
+						End:      hcl.Pos{Line: 1, Column: 40, Byte: 39},
+					},
+				},
+			},
+		},
+		{
+			"single-line with multiple items with invalid quoted attribute",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Object(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.String,
+						}),
+					},
+				},
+			},
+			`attr = { "foo" = "noot", "baz" = "noot" }`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenObjectKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+						End:      hcl.Pos{Line: 1, Column: 15, Byte: 14},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 18, Byte: 17},
+						End:      hcl.Pos{Line: 1, Column: 24, Byte: 23},
+					},
+				},
+			},
+		},
+		{
+			"single-line with multiple items and one value mismatch",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Object(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.String,
+						}),
+					},
+				},
+			},
+			`attr = { foo = bar, bar = "noot" }`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenObjectKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+						End:      hcl.Pos{Line: 1, Column: 13, Byte: 12},
+					},
+				},
+				{
+					Type:      lang.TokenObjectKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 21, Byte: 20},
+						End:      hcl.Pos{Line: 1, Column: 24, Byte: 23},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 27, Byte: 26},
+						End:      hcl.Pos{Line: 1, Column: 33, Byte: 32},
+					},
+				},
+			},
+		},
+		{
+			"multi-line with valid item",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Object(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.String,
+						}),
+					},
+				},
+			},
+			`attr = {
+  foo = "noot"
+}`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenObjectKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						End:      hcl.Pos{Line: 2, Column: 6, Byte: 14},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 9, Byte: 17},
+						End:      hcl.Pos{Line: 2, Column: 15, Byte: 23},
+					},
+				},
+			},
+		},
+		{
+			"multi-line with valid multiple items",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Object(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.String,
+						}),
+					},
+				},
+			},
+			`attr = {
+  foo = "noot"
+  bar = "toot"
+}`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenObjectKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						End:      hcl.Pos{Line: 2, Column: 6, Byte: 14},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 9, Byte: 17},
+						End:      hcl.Pos{Line: 2, Column: 15, Byte: 23},
+					},
+				},
+				{
+					Type:      lang.TokenObjectKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 3, Column: 3, Byte: 26},
+						End:      hcl.Pos{Line: 3, Column: 6, Byte: 29},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 3, Column: 9, Byte: 32},
+						End:      hcl.Pos{Line: 3, Column: 15, Byte: 38},
+					},
+				},
+			},
+		},
+		{
+			"multi-line with multiple items and one value mismatch",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Object(map[string]cty.Type{
+							"foo": cty.Number,
+							"bar": cty.String,
+						}),
+					},
+				},
+			},
+			`attr = {
+  foo = bar
+  bar = "noot"
+}`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenObjectKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						End:      hcl.Pos{Line: 2, Column: 6, Byte: 14},
+					},
+				},
+				{
+					Type:      lang.TokenObjectKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 3, Column: 3, Byte: 23},
+						End:      hcl.Pos{Line: 3, Column: 6, Byte: 26},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 3, Column: 9, Byte: 29},
+						End:      hcl.Pos{Line: 3, Column: 15, Byte: 35},
+					},
+				},
+			},
+		},
+		{
+			"multi-line with multiple items and one attribute mismatch",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Object(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.String,
+						}),
+					},
+				},
+			},
+			`attr = {
+  foo = "x"
+  baz = "x"
+}`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenObjectKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						End:      hcl.Pos{Line: 2, Column: 6, Byte: 14},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 9, Byte: 17},
+						End:      hcl.Pos{Line: 2, Column: 12, Byte: 20},
+					},
+				},
+			},
+		},
+		{
+			"multi-line with nested object",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Object(map[string]cty.Type{
+							"foo": cty.Object(map[string]cty.Type{
+								"noot": cty.String,
+							}),
+							"bar": cty.String,
+						}),
+					},
+				},
+			},
+			`attr = {
+  foo = {
+    noot = "to"
+  }
+  bar = "noot"
+}`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenObjectKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						End:      hcl.Pos{Line: 2, Column: 6, Byte: 14},
+					},
+				},
+				{
+					Type:      lang.TokenObjectKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 3, Column: 5, Byte: 23},
+						End:      hcl.Pos{Line: 3, Column: 9, Byte: 27},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 3, Column: 12, Byte: 30},
+						End:      hcl.Pos{Line: 3, Column: 16, Byte: 34},
+					},
+				},
+				{
+					Type:      lang.TokenObjectKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 5, Column: 3, Byte: 41},
+						End:      hcl.Pos{Line: 5, Column: 6, Byte: 44},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 5, Column: 9, Byte: 47},
+						End:      hcl.Pos{Line: 5, Column: 15, Byte: 53},
+					},
+				},
+			},
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := &schema.BodySchema{
+				Attributes: tc.attrSchema,
+			}
+
+			f, _ := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.tf": f,
+				},
+			})
+
+			ctx := context.Background()
+			tokens, err := d.SemanticTokensInFile(ctx, "test.tf")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedSemanticTokens, tokens); diff != "" {
+				t.Fatalf("unexpected tokens: %s", diff)
+			}
+		})
+	}
+}

--- a/decoder/expr_literal_type_semtok_test.go
+++ b/decoder/expr_literal_type_semtok_test.go
@@ -87,7 +87,7 @@ func TestSemanticTokens_exprLiteralType(t *testing.T) {
 
 		// string
 		{
-			"string",
+			"single-line string",
 			map[string]*schema.AttributeSchema{
 				"attr": {
 					Constraint: schema.LiteralType{
@@ -113,6 +113,41 @@ func TestSemanticTokens_exprLiteralType(t *testing.T) {
 						Filename: "test.tf",
 						Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
 						End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+					},
+				},
+			},
+		},
+		{
+			"multi-line string",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.String,
+					},
+				},
+			},
+			`attr = <<TEXT
+foo
+bar
+TEXT
+`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						End:      hcl.Pos{Line: 4, Column: 5, Byte: 26},
 					},
 				},
 			},

--- a/decoder/expression.go
+++ b/decoder/expression.go
@@ -105,8 +105,9 @@ func newExpression(pathContext *PathContext, expr hcl.Expression, cons schema.Co
 		}
 	case schema.LiteralType:
 		return LiteralType{
-			expr: expr,
-			cons: c,
+			expr:    expr,
+			cons:    c,
+			pathCtx: pathContext,
 		}
 	case schema.LiteralValue:
 		return LiteralValue{

--- a/decoder/expression_test.go
+++ b/decoder/expression_test.go
@@ -26,7 +26,6 @@ var (
 
 	_ ReferenceOriginsExpression = Any{}
 	_ ReferenceOriginsExpression = List{}
-	_ ReferenceOriginsExpression = LiteralType{}
 	_ ReferenceOriginsExpression = Map{}
 	_ ReferenceOriginsExpression = Object{}
 	_ ReferenceOriginsExpression = Set{}

--- a/decoder/hover.go
+++ b/decoder/hover.go
@@ -560,18 +560,6 @@ func sortedObjectExprAttrNames(attributes schema.ObjectExprAttributes) []string 
 	return names
 }
 
-func isMultilineStringLiteral(tplExpr *hclsyntax.TemplateExpr) bool {
-	if len(tplExpr.Parts) < 1 {
-		return false
-	}
-	for _, part := range tplExpr.Parts {
-		if _, ok := part.(*hclsyntax.LiteralValueExpr); !ok {
-			return false
-		}
-	}
-	return true
-}
-
 func stringValFromTemplateExpr(tplExpr *hclsyntax.TemplateExpr) (cty.Value, bool) {
 	value := ""
 	for _, part := range tplExpr.Parts {

--- a/schema/attribute_schema.go
+++ b/schema/attribute_schema.go
@@ -110,9 +110,17 @@ func (as *AttributeSchema) Validate() error {
 		}
 	}
 
+	if (as.Constraint == nil && len(as.Expr) == 0) ||
+		(as.Constraint != nil && len(as.Expr) > 0) {
+		return errors.New("expected one of Constraint or Expr")
+	}
+
 	if as.Constraint != nil {
 		if con, ok := as.Constraint.(Validatable); ok {
-			return con.Validate()
+			err := con.Validate()
+			if err != nil {
+				return fmt.Errorf("Constraint: %T: %s", as.Constraint, err)
+			}
 		}
 	} else {
 		return as.Expr.Validate()

--- a/schema/attribute_schema_legacy_test.go
+++ b/schema/attribute_schema_legacy_test.go
@@ -114,6 +114,9 @@ func TestLegacyAttributeSchema_Validate(t *testing.T) {
 		},
 		{
 			&AttributeSchema{
+				Expr: ExprConstraints{
+					LiteralTypeExpr{Type: cty.String},
+				},
 				Address: &AttributeAddrSchema{
 					Steps: []AddrStep{
 						LabelStep{Index: 0},
@@ -126,6 +129,9 @@ func TestLegacyAttributeSchema_Validate(t *testing.T) {
 		},
 		{
 			&AttributeSchema{
+				Expr: ExprConstraints{
+					LiteralTypeExpr{Type: cty.String},
+				},
 				Address: &AttributeAddrSchema{
 					Steps: []AddrStep{
 						AttrValueStep{Name: "unknown"},
@@ -138,6 +144,9 @@ func TestLegacyAttributeSchema_Validate(t *testing.T) {
 		},
 		{
 			&AttributeSchema{
+				Expr: ExprConstraints{
+					LiteralTypeExpr{Type: cty.String},
+				},
 				Address: &AttributeAddrSchema{
 					Steps: []AddrStep{
 						AttrNameStep{},
@@ -149,6 +158,9 @@ func TestLegacyAttributeSchema_Validate(t *testing.T) {
 		},
 		{
 			&AttributeSchema{
+				Expr: ExprConstraints{
+					LiteralTypeExpr{Type: cty.String},
+				},
 				Address: &AttributeAddrSchema{
 					Steps: []AddrStep{
 						AttrNameStep{},

--- a/schema/attribute_schema_test.go
+++ b/schema/attribute_schema_test.go
@@ -80,14 +80,14 @@ func TestAttributeSchema_Validate(t *testing.T) {
 				Constraint: Reference{OfType: cty.Number, Address: &ReferenceAddrSchema{ScopeId: lang.ScopeId("test")}},
 				IsOptional: true,
 			},
-			errors.New("cannot have both Address and OfType/OfScopeId set"),
+			errors.New("Constraint: schema.Reference: cannot have both Address and OfType/OfScopeId set"),
 		},
 		{
 			&AttributeSchema{
 				Constraint: Reference{Address: &ReferenceAddrSchema{}},
 				IsOptional: true,
 			},
-			errors.New("Address requires non-emmpty ScopeId"),
+			errors.New("Constraint: schema.Reference: Address requires non-emmpty ScopeId"),
 		},
 		{
 			&AttributeSchema{
@@ -98,6 +98,7 @@ func TestAttributeSchema_Validate(t *testing.T) {
 		},
 		{
 			&AttributeSchema{
+				Constraint: LiteralType{Type: cty.String},
 				Address: &AttributeAddrSchema{
 					Steps: []AddrStep{
 						LabelStep{Index: 0},
@@ -110,6 +111,7 @@ func TestAttributeSchema_Validate(t *testing.T) {
 		},
 		{
 			&AttributeSchema{
+				Constraint: LiteralType{Type: cty.String},
 				Address: &AttributeAddrSchema{
 					Steps: []AddrStep{
 						AttrValueStep{Name: "unknown"},
@@ -122,6 +124,7 @@ func TestAttributeSchema_Validate(t *testing.T) {
 		},
 		{
 			&AttributeSchema{
+				Constraint: LiteralType{Type: cty.String},
 				Address: &AttributeAddrSchema{
 					Steps: []AddrStep{
 						AttrNameStep{},
@@ -133,6 +136,7 @@ func TestAttributeSchema_Validate(t *testing.T) {
 		},
 		{
 			&AttributeSchema{
+				Constraint: LiteralType{Type: cty.String},
 				Address: &AttributeAddrSchema{
 					Steps: []AddrStep{
 						AttrNameStep{},
@@ -151,6 +155,32 @@ func TestAttributeSchema_Validate(t *testing.T) {
 				IsSensitive: true,
 			},
 			nil,
+		},
+		{
+			&AttributeSchema{
+				Constraint:  LiteralType{},
+				IsRequired:  true,
+				IsSensitive: true,
+			},
+			errors.New("Constraint: schema.LiteralType: expected Type not to be nil"),
+		},
+		{
+			&AttributeSchema{
+				IsRequired:  true,
+				IsSensitive: true,
+			},
+			errors.New("expected one of Constraint or Expr"),
+		},
+		{
+			&AttributeSchema{
+				Constraint: LiteralType{Type: cty.String},
+				Expr: ExprConstraints{
+					LiteralTypeExpr{Type: cty.String},
+				},
+				IsRequired:  true,
+				IsSensitive: true,
+			},
+			errors.New("expected one of Constraint or Expr"),
 		},
 	}
 

--- a/schema/constraint_literal_type.go
+++ b/schema/constraint_literal_type.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/hcl-lang/lang"
@@ -35,6 +36,13 @@ func (lt LiteralType) Copy() Constraint {
 	return LiteralType{
 		Type: lt.Type,
 	}
+}
+
+func (lt LiteralType) Validate() error {
+	if lt.Type == cty.NilType {
+		return errors.New("expected Type not to be nil")
+	}
+	return nil
 }
 
 func (lt LiteralType) EmptyCompletionData(ctx context.Context, nextPlaceholder int, nestingLevel int) CompletionData {


### PR DESCRIPTION
Part of https://github.com/hashicorp/terraform-ls/issues/496

--- 

Existing tests were updated as part of https://github.com/hashicorp/hcl-lang/commit/699069384a9c1ef08b7b7a7ab9e8cd6eb8ac739b (not part of this PR) and yield either comparable or better results, except for reference collection, which:

 - we agreed to leave for a separate PR
 - involves other constraints which aren't implemented yet

--- 

## UX

![2023-03-16 20 12 50](https://user-images.githubusercontent.com/287584/225742122-8d7561d7-6f84-442a-93c3-57111e01c02c.gif)

