### PR TITLE
decoder: Extract & document `isEmptyExpression()`

### DIFF
--- a/decoder/expression.go
+++ b/decoder/expression.go
@@ -7,6 +7,8 @@ import (
 	"github.com/hashicorp/hcl-lang/reference"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
 )
 
 // Expression represents an expression capable of providing
@@ -48,4 +50,21 @@ func (d *PathDecoder) newExpression(expr hcl.Expression, cons schema.Constraint)
 	}
 
 	return unknownExpression{}
+}
+
+// isEmptyExpression returns true if given expression is suspected
+// to be empty, e.g. newline after equal sign.
+//
+// Because upstream HCL parser doesn't always handle incomplete
+// configuration gracefully, this may not cover all cases.
+func isEmptyExpression(expr hcl.Expression) bool {
+	l, ok := expr.(*hclsyntax.LiteralValueExpr)
+	if !ok {
+		return false
+	}
+	if l.Val != cty.DynamicVal {
+		return false
+	}
+
+	return true
 }

--- a/decoder/expression_candidates.go
+++ b/decoder/expression_candidates.go
@@ -229,19 +229,6 @@ func MaxCandidatesFromContext(ctx context.Context) (uint, bool) {
 	return mc, ok
 }
 
-func isEmptyExpr(expr hclsyntax.Expression) bool {
-	l, ok := expr.(*hclsyntax.LiteralValueExpr)
-	if !ok {
-		return false
-	}
-	if l.Val != cty.DynamicVal {
-		return false
-	}
-	// TODO? more checks
-
-	return true
-}
-
 func isMultilineTemplateExpr(expr hclsyntax.Expression) bool {
 	t, ok := expr.(*hclsyntax.TemplateExpr)
 	if !ok {
@@ -268,7 +255,7 @@ func (d *PathDecoder) candidatesFromHooks(ctx context.Context, attr *hclsyntax.A
 	}
 
 	editRng := attr.Expr.Range()
-	if isEmptyExpr(attr.Expr) || isMultilineTemplateExpr(attr.Expr) {
+	if isEmptyExpression(attr.Expr) || isMultilineTemplateExpr(attr.Expr) {
 		// An empty expression or a string without a closing quote will lead to
 		// an attribute expression spanning multiple lines.
 		// Since text edits only support a single line, we're resetting the End


### PR DESCRIPTION
This helper is expected to be used in completion for most constraints.

I am still not fully confident it covers all cases - as explained in the comment, but I do believe it deserves to be extracted.