### PR TITLE
decoder: Refactor `newExpression()` & plumb `PathContext`

### DIFF
--- a/decoder/expr_list.go
+++ b/decoder/expr_list.go
@@ -10,8 +10,9 @@ import (
 )
 
 type List struct {
-	expr hcl.Expression
-	cons schema.List
+	expr    hcl.Expression
+	cons    schema.List
+	pathCtx *PathContext
 }
 
 func (l List) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate {

--- a/decoder/expr_map.go
+++ b/decoder/expr_map.go
@@ -10,8 +10,9 @@ import (
 )
 
 type Map struct {
-	expr hcl.Expression
-	cons schema.Map
+	expr    hcl.Expression
+	cons    schema.Map
+	pathCtx *PathContext
 }
 
 func (m Map) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate {

--- a/decoder/expr_object.go
+++ b/decoder/expr_object.go
@@ -10,8 +10,9 @@ import (
 )
 
 type Object struct {
-	expr hcl.Expression
-	cons schema.Object
+	expr    hcl.Expression
+	cons    schema.Object
+	pathCtx *PathContext
 }
 
 func (obj Object) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate {

--- a/decoder/expr_one_of.go
+++ b/decoder/expr_one_of.go
@@ -10,8 +10,9 @@ import (
 )
 
 type OneOf struct {
-	expr hcl.Expression
-	cons schema.OneOf
+	expr    hcl.Expression
+	cons    schema.OneOf
+	pathCtx *PathContext
 }
 
 func (oo OneOf) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate {

--- a/decoder/expr_set.go
+++ b/decoder/expr_set.go
@@ -10,8 +10,9 @@ import (
 )
 
 type Set struct {
-	expr hcl.Expression
-	cons schema.Set
+	expr    hcl.Expression
+	cons    schema.Set
+	pathCtx *PathContext
 }
 
 func (s Set) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate {

--- a/decoder/expr_tuple.go
+++ b/decoder/expr_tuple.go
@@ -10,8 +10,9 @@ import (
 )
 
 type Tuple struct {
-	expr hcl.Expression
-	cons schema.Tuple
+	expr    hcl.Expression
+	cons    schema.Tuple
+	pathCtx *PathContext
 }
 
 func (t Tuple) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate {

--- a/decoder/expression.go
+++ b/decoder/expression.go
@@ -20,31 +20,79 @@ type Expression interface {
 }
 
 func (d *PathDecoder) newExpression(expr hcl.Expression, cons schema.Constraint) Expression {
+	return newExpression(d.pathCtx, expr, cons)
+}
+
+func newExpression(pathContext *PathContext, expr hcl.Expression, cons schema.Constraint) Expression {
 	switch c := cons.(type) {
 	case schema.AnyExpression:
-		return Any{expr: expr, cons: c, pathCtx: d.pathCtx}
+		return Any{
+			expr:    expr,
+			cons:    c,
+			pathCtx: pathContext,
+		}
 	case schema.LiteralType:
-		return LiteralType{expr: expr, cons: c}
-	case schema.Reference:
-		return Reference{expr: expr, cons: c}
-	case schema.TypeDeclaration:
-		return TypeDeclaration{expr: expr, cons: c}
-	case schema.Keyword:
-		return Keyword{expr: expr, cons: c}
-	case schema.List:
-		return List{expr: expr, cons: c}
-	case schema.Set:
-		return Set{expr: expr, cons: c}
-	case schema.Tuple:
-		return Tuple{expr: expr, cons: c}
-	case schema.Object:
-		return Object{expr: expr, cons: c}
-	case schema.Map:
-		return Map{expr: expr, cons: c}
-	case schema.OneOf:
-		return OneOf{expr: expr, cons: c}
+		return LiteralType{
+			expr: expr,
+			cons: c,
+		}
 	case schema.LiteralValue:
-		return LiteralValue{expr: expr, cons: c}
+		return LiteralValue{
+			expr: expr,
+			cons: c,
+		}
+	case schema.TypeDeclaration:
+		return TypeDeclaration{
+			expr: expr,
+			cons: c,
+		}
+	case schema.Keyword:
+		return Keyword{
+			expr: expr,
+			cons: c,
+		}
+	case schema.Reference:
+		return Reference{
+			expr: expr,
+			cons: c,
+		}
+	case schema.List:
+		return List{
+			expr:    expr,
+			cons:    c,
+			pathCtx: pathContext,
+		}
+	case schema.Set:
+		return Set{
+			expr:    expr,
+			cons:    c,
+			pathCtx: pathContext,
+		}
+	case schema.Tuple:
+		return Tuple{
+			expr:    expr,
+			cons:    c,
+			pathCtx: pathContext,
+		}
+	case schema.Object:
+		return Object{
+			expr:    expr,
+			cons:    c,
+			pathCtx: pathContext,
+		}
+	case schema.Map:
+		return Map{
+			expr:    expr,
+			cons:    c,
+			pathCtx: pathContext,
+		}
+	case schema.OneOf:
+		return OneOf{
+			expr:    expr,
+			cons:    c,
+			pathCtx: pathContext,
+		}
+
 	}
 
 	return unknownExpression{}


### PR DESCRIPTION
This is primarily to make it easier to "hand-over" completion/hover/etc. between different expression types (which do not /need to/ have access to all of `PathDecoder`) and reduce diff conflicts between upcoming PRs where each involves different expression type.

It is expected that all complex types (list, set, tuple, map, object) _may_ contain either `Reference` (hence need `ReferenceTargets`) or `AnyExpression` (hence need future `FunctionsMap` and possibly `ReferenceTargets` too).

I have briefly considered creating a separate type, e.g. `ExpressionContext` or pass these things via `context.Context`, or use the static `newExpression()` in all places where `(*PathDecoder) newExpression()` is now used,  but concluded that it would all be premature optimization at this point.
