### PR TITLE
decoder: Make reference collection optional for Expression

### DIFF
--- a/decoder/expr_keyword.go
+++ b/decoder/expr_keyword.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/hashicorp/hcl-lang/lang"
-	"github.com/hashicorp/hcl-lang/reference"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
 )
@@ -25,16 +24,6 @@ func (kw Keyword) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData {
 }
 
 func (kw Keyword) SemanticTokens(ctx context.Context) []lang.SemanticToken {
-	// TODO
-	return nil
-}
-
-func (kw Keyword) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {
-	// TODO
-	return nil
-}
-
-func (kw Keyword) ReferenceTargets(ctx context.Context, attrAddr *schema.AttributeAddrSchema) reference.Targets {
 	// TODO
 	return nil
 }

--- a/decoder/expr_literal_value.go
+++ b/decoder/expr_literal_value.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/hashicorp/hcl-lang/lang"
-	"github.com/hashicorp/hcl-lang/reference"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
 )
@@ -25,16 +24,6 @@ func (lv LiteralValue) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverD
 }
 
 func (lv LiteralValue) SemanticTokens(ctx context.Context) []lang.SemanticToken {
-	// TODO
-	return nil
-}
-
-func (lv LiteralValue) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {
-	// TODO
-	return nil
-}
-
-func (lv LiteralValue) ReferenceTargets(ctx context.Context, attrAddr *schema.AttributeAddrSchema) reference.Targets {
 	// TODO
 	return nil
 }

--- a/decoder/expr_type_declaration.go
+++ b/decoder/expr_type_declaration.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/hashicorp/hcl-lang/lang"
-	"github.com/hashicorp/hcl-lang/reference"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
 )
@@ -25,16 +24,6 @@ func (td TypeDeclaration) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.Hov
 }
 
 func (td TypeDeclaration) SemanticTokens(ctx context.Context) []lang.SemanticToken {
-	// TODO
-	return nil
-}
-
-func (td TypeDeclaration) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {
-	// TODO
-	return nil
-}
-
-func (td TypeDeclaration) ReferenceTargets(ctx context.Context, attrAddr *schema.AttributeAddrSchema) reference.Targets {
 	// TODO
 	return nil
 }

--- a/decoder/expr_unknown.go
+++ b/decoder/expr_unknown.go
@@ -4,8 +4,6 @@ import (
 	"context"
 
 	"github.com/hashicorp/hcl-lang/lang"
-	"github.com/hashicorp/hcl-lang/reference"
-	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
 )
 
@@ -21,12 +19,4 @@ func (oo unknownExpression) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.H
 
 func (oo unknownExpression) SemanticTokens(ctx context.Context) []lang.SemanticToken {
 	return []lang.SemanticToken{}
-}
-
-func (oo unknownExpression) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {
-	return reference.Origins{}
-}
-
-func (oo unknownExpression) ReferenceTargets(ctx context.Context, attrAddr *schema.AttributeAddrSchema) reference.Targets {
-	return reference.Targets{}
 }

--- a/decoder/expression.go
+++ b/decoder/expression.go
@@ -17,7 +17,13 @@ type Expression interface {
 	CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate
 	HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData
 	SemanticTokens(ctx context.Context) []lang.SemanticToken
+}
+
+type ReferenceOriginsExpression interface {
 	ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins
+}
+
+type ReferenceTargetsExpression interface {
 	ReferenceTargets(ctx context.Context, attrAddr *schema.AttributeAddrSchema) reference.Targets
 }
 

--- a/decoder/reference_origins.go
+++ b/decoder/reference_origins.go
@@ -171,7 +171,10 @@ func (d *PathDecoder) referenceOriginsInBody(body hcl.Body, bodySchema *schema.B
 			allowSelfRefs = true
 		}
 		if aSchema.Constraint != nil {
-			origins = append(origins, d.newExpression(attr.Expr, aSchema.Constraint).ReferenceOrigins(ctx, allowSelfRefs)...)
+			expr := d.newExpression(attr.Expr, aSchema.Constraint)
+			if eType, ok := expr.(ReferenceOriginsExpression); ok {
+				origins = append(origins, eType.ReferenceOrigins(ctx, allowSelfRefs)...)
+			}
 		} else {
 			origins = append(origins, d.legacyFindOriginsInExpression(attr.Expr, aSchema.Expr, allowSelfRefs)...)
 		}

--- a/decoder/reference_targets.go
+++ b/decoder/reference_targets.go
@@ -272,7 +272,10 @@ func (d *PathDecoder) decodeReferenceTargetsForAttribute(attr *hcl.Attribute, at
 	ctx := context.Background()
 
 	if attrSchema.Constraint != nil {
-		refs = append(refs, d.newExpression(attr.Expr, attrSchema.Constraint).ReferenceTargets(ctx, attrSchema.Address)...)
+		expr := d.newExpression(attr.Expr, attrSchema.Constraint)
+		if eType, ok := expr.(ReferenceTargetsExpression); ok {
+			refs = append(refs, eType.ReferenceTargets(ctx, attrSchema.Address)...)
+		}
 	} else {
 		if attrSchema.Address != nil {
 			attrAddr, ok := resolveAttributeAddress(attr, attrSchema.Address.Steps)


### PR DESCRIPTION
This better aligns with a convention of minimal interfaces in Go, also surfaced as a [Go Proverb](https://go-proverbs.github.io/) ["The bigger the interface, the weaker the abstraction."](https://www.youtube.com/watch?v=PAAkCSZUG1c&t=5m17s) and exemplified throughout the stdlib, e.g. in the [`io/fs.FS`](https://pkg.go.dev/io/fs#FS) interface and [friends](https://pkg.go.dev/io/fs#ReadDirFS).

Another (AFAIK unwritten) convention is to suffix such interface types with `-er` (e.g. `io.Writer`, `io.Reader`), but as shown on the `fs` interfaces, this isn't always practical and IMO wouldn't be in our case.

To my best knowledge all types we have bootstrapped currently _would_ still need to provide completion, hover and semantic tokens, so I'm keeping these in the base interface.