### PR TITLE
schema: Make Elem(s) optional for list/set/map constraint

### DIFF
--- a/schema/constraint_list.go
+++ b/schema/constraint_list.go
@@ -28,16 +28,19 @@ func (List) isConstraintImpl() constraintSigil {
 }
 
 func (l List) FriendlyName() string {
-	elemName := l.Elem.FriendlyName()
-	if elemName != "" {
-		return fmt.Sprintf("list of %s", elemName)
+	if l.Elem != nil && l.Elem.FriendlyName() != "" {
+		return fmt.Sprintf("list of %s", l.Elem.FriendlyName())
 	}
 	return "list"
 }
 
 func (l List) Copy() Constraint {
+	var elem Constraint
+	if l.Elem != nil {
+		elem = l.Elem.Copy()
+	}
 	return List{
-		Elem:        l.Elem.Copy(),
+		Elem:        elem,
 		Description: l.Description,
 		MinItems:    l.MinItems,
 		MaxItems:    l.MaxItems,

--- a/schema/constraint_map.go
+++ b/schema/constraint_map.go
@@ -32,9 +32,8 @@ func (Map) isConstraintImpl() constraintSigil {
 
 func (m Map) FriendlyName() string {
 	if m.Name == "" {
-		elemName := m.Elem.FriendlyName()
-		if elemName != "" {
-			return fmt.Sprintf("map of %s", elemName)
+		if m.Elem != nil && m.Elem.FriendlyName() != "" {
+			return fmt.Sprintf("map of %s", m.Elem.FriendlyName())
 		}
 		return "map"
 	}
@@ -42,8 +41,12 @@ func (m Map) FriendlyName() string {
 }
 
 func (m Map) Copy() Constraint {
+	var elem Constraint
+	if m.Elem != nil {
+		elem = m.Elem.Copy()
+	}
 	return Map{
-		Elem:        m.Elem.Copy(),
+		Elem:        elem,
 		Name:        m.Name,
 		Description: m.Description,
 		MinItems:    m.MinItems,

--- a/schema/constraint_set.go
+++ b/schema/constraint_set.go
@@ -28,16 +28,19 @@ func (Set) isConstraintImpl() constraintSigil {
 }
 
 func (s Set) FriendlyName() string {
-	elemName := s.Elem.FriendlyName()
-	if elemName != "" {
-		return fmt.Sprintf("set of %s", elemName)
+	if s.Elem != nil && s.Elem.FriendlyName() != "" {
+		return fmt.Sprintf("set of %s", s.Elem.FriendlyName())
 	}
 	return "set"
 }
 
 func (s Set) Copy() Constraint {
+	var elem Constraint
+	if s.Elem != nil {
+		elem = s.Elem.Copy()
+	}
 	return Set{
-		Elem:        s.Elem.Copy(),
+		Elem:        elem,
 		Description: s.Description,
 		MinItems:    s.MinItems,
 		MaxItems:    s.MaxItems,


### PR DESCRIPTION
I noticed while testing https://github.com/hashicorp/hcl-lang/pull/184 that the current implementation of `List`, `Set` and `Map` constraints does not allow for elements to be undefined - i.e. it would currently cause a crash.

We could theoretically enforce non-empty `Elem`s via static validation, but in practice we actually have a limited use case - `ignore_changes` under Terraform's `resource` for undefined `Elem`s:

https://github.com/hashicorp/terraform-schema/pull/174/commits/442c5c891f5798d4a345f8ff55ba1ccb90fec129#diff-f602b672b44eda05c025b0990196bf105681dc20c7db03ff3fd18dd15fcb1b04R103-R107