### PR TITLE
decoder/schema: Add support for `OneOf` as `Constraint`

### DIFF
--- a/decoder/expr_one_of.go
+++ b/decoder/expr_one_of.go
@@ -15,11 +15,6 @@ type OneOf struct {
 	pathCtx *PathContext
 }
 
-func (oo OneOf) SemanticTokens(ctx context.Context) []lang.SemanticToken {
-	// TODO
-	return nil
-}
-
 func (oo OneOf) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {
 	// TODO
 	return nil

--- a/decoder/expr_one_of.go
+++ b/decoder/expr_one_of.go
@@ -1,9 +1,6 @@
 package decoder
 
 import (
-	"context"
-
-	"github.com/hashicorp/hcl-lang/reference"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
 )
@@ -12,9 +9,4 @@ type OneOf struct {
 	expr    hcl.Expression
 	cons    schema.OneOf
 	pathCtx *PathContext
-}
-
-func (oo OneOf) ReferenceTargets(ctx context.Context, targetCtx *TargetContext) reference.Targets {
-	// TODO
-	return nil
 }

--- a/decoder/expr_one_of.go
+++ b/decoder/expr_one_of.go
@@ -15,11 +15,6 @@ type OneOf struct {
 	pathCtx *PathContext
 }
 
-func (oo OneOf) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData {
-	// TODO
-	return nil
-}
-
 func (oo OneOf) SemanticTokens(ctx context.Context) []lang.SemanticToken {
 	// TODO
 	return nil

--- a/decoder/expr_one_of.go
+++ b/decoder/expr_one_of.go
@@ -3,7 +3,6 @@ package decoder
 import (
 	"context"
 
-	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/reference"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
@@ -13,11 +12,6 @@ type OneOf struct {
 	expr    hcl.Expression
 	cons    schema.OneOf
 	pathCtx *PathContext
-}
-
-func (oo OneOf) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {
-	// TODO
-	return nil
 }
 
 func (oo OneOf) ReferenceTargets(ctx context.Context, targetCtx *TargetContext) reference.Targets {

--- a/decoder/expr_one_of.go
+++ b/decoder/expr_one_of.go
@@ -15,11 +15,6 @@ type OneOf struct {
 	pathCtx *PathContext
 }
 
-func (oo OneOf) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate {
-	// TODO
-	return nil
-}
-
 func (oo OneOf) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData {
 	// TODO
 	return nil

--- a/decoder/expr_one_of_completion.go
+++ b/decoder/expr_one_of_completion.go
@@ -1,0 +1,19 @@
+package decoder
+
+import (
+	"context"
+
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl/v2"
+)
+
+func (oo OneOf) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate {
+	candidates := make([]lang.Candidate, 0)
+
+	for _, con := range oo.cons {
+		expr := newExpression(oo.pathCtx, oo.expr, con)
+		candidates = append(candidates, expr.CompletionAtPos(ctx, pos)...)
+	}
+
+	return candidates
+}

--- a/decoder/expr_one_of_completion_test.go
+++ b/decoder/expr_one_of_completion_test.go
@@ -1,0 +1,1 @@
+package decoder

--- a/decoder/expr_one_of_completion_test.go
+++ b/decoder/expr_one_of_completion_test.go
@@ -1,1 +1,216 @@
 package decoder
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+func TestCompletionAtPos_exprOneOf(t *testing.T) {
+	testCases := []struct {
+		testName           string
+		attrSchema         map[string]*schema.AttributeSchema
+		cfg                string
+		pos                hcl.Pos
+		expectedCandidates lang.Candidates
+	}{
+		{
+			"all expressions",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.OneOf{
+						schema.Keyword{
+							Keyword: "akeyword",
+						},
+						schema.Keyword{
+							Keyword: "bkeyword",
+						},
+						schema.Keyword{
+							Keyword: "ckeyword",
+						},
+					},
+				},
+			},
+			`attr = 
+`,
+			hcl.Pos{Line: 1, Column: 8, Byte: 7},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "akeyword",
+					Detail: "keyword",
+					Kind:   lang.KeywordCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "akeyword",
+						Snippet: "akeyword",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+					},
+				},
+				{
+					Label:  "bkeyword",
+					Detail: "keyword",
+					Kind:   lang.KeywordCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "bkeyword",
+						Snippet: "bkeyword",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+					},
+				},
+				{
+					Label:  "ckeyword",
+					Detail: "keyword",
+					Kind:   lang.KeywordCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "ckeyword",
+						Snippet: "ckeyword",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"partial match first",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.OneOf{
+						schema.Keyword{
+							Keyword: "akeyword",
+						},
+						schema.Keyword{
+							Keyword: "bkeyword",
+						},
+						schema.Keyword{
+							Keyword: "ckeyword",
+						},
+					},
+				},
+			},
+			`attr = akey
+`,
+			hcl.Pos{Line: 1, Column: 12, Byte: 11},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "akeyword",
+					Detail: "keyword",
+					Kind:   lang.KeywordCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "akeyword",
+						Snippet: "akeyword",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 12, Byte: 11},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"partial match multiple",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.OneOf{
+						schema.Keyword{
+							Keyword: "akeyword",
+						},
+						schema.Keyword{
+							Keyword: "keyword1",
+						},
+						schema.Keyword{
+							Keyword: "keyword2",
+						},
+					},
+				},
+			},
+			`attr = key
+`,
+			hcl.Pos{Line: 1, Column: 11, Byte: 10},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "keyword1",
+					Detail: "keyword",
+					Kind:   lang.KeywordCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "keyword1",
+						Snippet: "keyword1",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 11, Byte: 10},
+						},
+					},
+				},
+				{
+					Label:  "keyword2",
+					Detail: "keyword",
+					Kind:   lang.KeywordCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "keyword2",
+						Snippet: "keyword2",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 11, Byte: 10},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"no expr defined",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.OneOf{},
+				},
+			},
+			`attr = 
+`,
+			hcl.Pos{Line: 1, Column: 8, Byte: 7},
+			lang.CompleteCandidates([]lang.Candidate{}),
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := &schema.BodySchema{
+				Attributes: tc.attrSchema,
+			}
+
+			f, _ := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.tf": f,
+				},
+			})
+
+			ctx := context.Background()
+			candidates, err := d.CandidatesAtPos(ctx, "test.tf", tc.pos)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedCandidates, candidates); diff != "" {
+				t.Logf("pos: %#v, config: %s\n", tc.pos, tc.cfg)
+				t.Fatalf("unexpected candidates: %s", diff)
+			}
+		})
+	}
+}

--- a/decoder/expr_one_of_hover.go
+++ b/decoder/expr_one_of_hover.go
@@ -1,0 +1,22 @@
+package decoder
+
+import (
+	"context"
+
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl/v2"
+)
+
+func (oo OneOf) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData {
+	for _, con := range oo.cons {
+		// since we cannot know which "constraint was typed"
+		// we just pick the first which returns some data
+		expr := newExpression(oo.pathCtx, oo.expr, con)
+		hoverData := expr.HoverAtPos(ctx, pos)
+		if hoverData != nil {
+			return hoverData
+		}
+	}
+
+	return nil
+}

--- a/decoder/expr_one_of_hover_test.go
+++ b/decoder/expr_one_of_hover_test.go
@@ -1,0 +1,1 @@
+package decoder

--- a/decoder/expr_one_of_hover_test.go
+++ b/decoder/expr_one_of_hover_test.go
@@ -1,1 +1,132 @@
 package decoder
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+func TestHoverAtPos_exprOneOf(t *testing.T) {
+	testCases := []struct {
+		testName          string
+		attrSchema        map[string]*schema.AttributeSchema
+		cfg               string
+		pos               hcl.Pos
+		expectedHoverData *lang.HoverData
+	}{
+		{
+			"matching first expr",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.OneOf{
+						schema.Keyword{
+							Keyword: "keyword1",
+						},
+						schema.Keyword{
+							Keyword: "keyword2",
+						},
+						schema.Keyword{
+							Keyword: "keyword3",
+						},
+					},
+				},
+			},
+			`attr = keyword1`,
+			hcl.Pos{Line: 1, Column: 11, Byte: 10},
+			&lang.HoverData{
+				Content: lang.Markdown("`keyword1` _keyword_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+				},
+			},
+		},
+		{
+			"matching second expr",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.OneOf{
+						schema.Keyword{
+							Keyword: "keyword1",
+						},
+						schema.Keyword{
+							Keyword: "keyword2",
+						},
+					},
+				},
+			},
+			`attr = keyword2`,
+			hcl.Pos{Line: 1, Column: 11, Byte: 10},
+			&lang.HoverData{
+				Content: lang.Markdown("`keyword2` _keyword_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+				},
+			},
+		},
+		{
+			"no matching expr",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.OneOf{
+						schema.Keyword{
+							Keyword: "keyword1",
+						},
+						schema.Keyword{
+							Keyword: "keyword2",
+						},
+					},
+				},
+			},
+			`attr = keyword3`,
+			hcl.Pos{Line: 1, Column: 11, Byte: 10},
+			nil,
+		},
+		{
+			"no expr defined",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.OneOf{},
+				},
+			},
+			`attr = keyword1`,
+			hcl.Pos{Line: 1, Column: 11, Byte: 10},
+			nil,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := &schema.BodySchema{
+				Attributes: tc.attrSchema,
+			}
+
+			f, _ := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.tf": f,
+				},
+			})
+
+			ctx := context.Background()
+			hoverData, err := d.HoverAtPos(ctx, "test.tf", tc.pos)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedHoverData, hoverData); diff != "" {
+				t.Fatalf("unexpected hover data: %s", diff)
+			}
+		})
+	}
+}

--- a/decoder/expr_one_of_ref_origins.go
+++ b/decoder/expr_one_of_ref_origins.go
@@ -1,0 +1,20 @@
+package decoder
+
+import (
+	"context"
+
+	"github.com/hashicorp/hcl-lang/reference"
+)
+
+func (oo OneOf) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {
+	origins := make(reference.Origins, 0)
+
+	for _, con := range oo.cons {
+		expr := newExpression(oo.pathCtx, oo.expr, con)
+		if e, ok := expr.(ReferenceOriginsExpression); ok {
+			origins = append(origins, e.ReferenceOrigins(ctx, allowSelfRefs)...)
+		}
+	}
+
+	return origins
+}

--- a/decoder/expr_one_of_ref_origins.go
+++ b/decoder/expr_one_of_ref_origins.go
@@ -11,6 +11,7 @@ func (oo OneOf) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) refere
 
 	for _, con := range oo.cons {
 		expr := newExpression(oo.pathCtx, oo.expr, con)
+		// TODO should we only consider the first non-empty constraint, rather than collect all?
 		if e, ok := expr.(ReferenceOriginsExpression); ok {
 			origins = append(origins, e.ReferenceOrigins(ctx, allowSelfRefs)...)
 		}

--- a/decoder/expr_one_of_ref_origins.go
+++ b/decoder/expr_one_of_ref_origins.go
@@ -7,15 +7,17 @@ import (
 )
 
 func (oo OneOf) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {
-	origins := make(reference.Origins, 0)
-
 	for _, con := range oo.cons {
 		expr := newExpression(oo.pathCtx, oo.expr, con)
-		// TODO should we only consider the first non-empty constraint, rather than collect all?
-		if e, ok := expr.(ReferenceOriginsExpression); ok {
-			origins = append(origins, e.ReferenceOrigins(ctx, allowSelfRefs)...)
+		e, ok := expr.(ReferenceOriginsExpression)
+		if !ok {
+			continue
+		}
+		origins := e.ReferenceOrigins(ctx, allowSelfRefs)
+		if len(origins) > 0 {
+			return origins
 		}
 	}
 
-	return origins
+	return reference.Origins{}
 }

--- a/decoder/expr_one_of_ref_origins_test.go
+++ b/decoder/expr_one_of_ref_origins_test.go
@@ -1,0 +1,1 @@
+package decoder

--- a/decoder/expr_one_of_ref_targets.go
+++ b/decoder/expr_one_of_ref_targets.go
@@ -11,6 +11,7 @@ func (oo OneOf) ReferenceTargets(ctx context.Context, targetCtx *TargetContext) 
 
 	for _, con := range oo.cons {
 		expr := newExpression(oo.pathCtx, oo.expr, con)
+		// TODO should we only consider the first non-empty constraint, rather than collect all?
 		if e, ok := expr.(ReferenceTargetsExpression); ok {
 			origins = append(origins, e.ReferenceTargets(ctx, targetCtx)...)
 		}

--- a/decoder/expr_one_of_ref_targets.go
+++ b/decoder/expr_one_of_ref_targets.go
@@ -1,0 +1,20 @@
+package decoder
+
+import (
+	"context"
+
+	"github.com/hashicorp/hcl-lang/reference"
+)
+
+func (oo OneOf) ReferenceTargets(ctx context.Context, targetCtx *TargetContext) reference.Targets {
+	origins := make(reference.Targets, 0)
+
+	for _, con := range oo.cons {
+		expr := newExpression(oo.pathCtx, oo.expr, con)
+		if e, ok := expr.(ReferenceTargetsExpression); ok {
+			origins = append(origins, e.ReferenceTargets(ctx, targetCtx)...)
+		}
+	}
+
+	return origins
+}

--- a/decoder/expr_one_of_ref_targets.go
+++ b/decoder/expr_one_of_ref_targets.go
@@ -7,15 +7,17 @@ import (
 )
 
 func (oo OneOf) ReferenceTargets(ctx context.Context, targetCtx *TargetContext) reference.Targets {
-	origins := make(reference.Targets, 0)
-
 	for _, con := range oo.cons {
 		expr := newExpression(oo.pathCtx, oo.expr, con)
-		// TODO should we only consider the first non-empty constraint, rather than collect all?
-		if e, ok := expr.(ReferenceTargetsExpression); ok {
-			origins = append(origins, e.ReferenceTargets(ctx, targetCtx)...)
+		e, ok := expr.(ReferenceTargetsExpression)
+		if !ok {
+			continue
+		}
+		targets := e.ReferenceTargets(ctx, targetCtx)
+		if len(targets) > 0 {
+			return targets
 		}
 	}
 
-	return origins
+	return reference.Targets{}
 }

--- a/decoder/expr_one_of_ref_targets_test.go
+++ b/decoder/expr_one_of_ref_targets_test.go
@@ -2,6 +2,6 @@ package decoder
 
 import "testing"
 
-func TestCollectRefOrigins_exprOneOf(t *testing.T) {
+func TestCollectRefTargets_exprOneOf(t *testing.T) {
 	// TODO! test when reference expr is available
 }

--- a/decoder/expr_one_of_semtok.go
+++ b/decoder/expr_one_of_semtok.go
@@ -1,0 +1,21 @@
+package decoder
+
+import (
+	"context"
+
+	"github.com/hashicorp/hcl-lang/lang"
+)
+
+func (oo OneOf) SemanticTokens(ctx context.Context) []lang.SemanticToken {
+	for _, con := range oo.cons {
+		// since we cannot know which "constraint was typed"
+		// we just pick the first which returns some tokens
+		expr := newExpression(oo.pathCtx, oo.expr, con)
+		tokens := expr.SemanticTokens(ctx)
+		if len(tokens) > 0 {
+			return tokens
+		}
+	}
+
+	return []lang.SemanticToken{}
+}

--- a/decoder/expr_one_of_semtok_test.go
+++ b/decoder/expr_one_of_semtok_test.go
@@ -1,0 +1,1 @@
+package decoder

--- a/decoder/expr_one_of_semtok_test.go
+++ b/decoder/expr_one_of_semtok_test.go
@@ -1,1 +1,177 @@
 package decoder
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+func TestSemanticTokens_exprTypeDeclaration(t *testing.T) {
+	testCases := []struct {
+		testName       string
+		attrSchema     map[string]*schema.AttributeSchema
+		cfg            string
+		expectedTokens []lang.SemanticToken
+	}{
+		{
+			"matching first expr",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.OneOf{
+						schema.Keyword{
+							Keyword: "cpu",
+						},
+						schema.Keyword{
+							Keyword: "memory",
+						},
+						schema.Keyword{
+							Keyword: "storage",
+						},
+					},
+				},
+			},
+			`attr = cpu`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenKeyword,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						End:      hcl.Pos{Line: 1, Column: 11, Byte: 10},
+					},
+				},
+			},
+		},
+		{
+			"matching second expr",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.OneOf{
+						schema.Keyword{
+							Keyword: "cpu",
+						},
+						schema.Keyword{
+							Keyword: "memory",
+						},
+						schema.Keyword{
+							Keyword: "storage",
+						},
+					},
+				},
+			},
+			`attr = memory`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenKeyword,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						End:      hcl.Pos{Line: 1, Column: 14, Byte: 13},
+					},
+				},
+			},
+		},
+		{
+			"no matching expr",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.OneOf{
+						schema.Keyword{
+							Keyword: "cpu",
+						},
+						schema.Keyword{
+							Keyword: "memory",
+						},
+						schema.Keyword{
+							Keyword: "storage",
+						},
+					},
+				},
+			},
+			`attr = unknown`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+			},
+		},
+		{
+			"no expr defined",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.OneOf{},
+				},
+			},
+			`attr = keyword1`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := &schema.BodySchema{
+				Attributes: tc.attrSchema,
+			}
+
+			f, _ := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.tf": f,
+				},
+			})
+
+			ctx := context.Background()
+			hoverData, err := d.SemanticTokensInFile(ctx, "test.tf")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedTokens, hoverData); diff != "" {
+				t.Fatalf("unexpected tokens: %s", diff)
+			}
+		})
+	}
+}

--- a/schema/constraint_one_of.go
+++ b/schema/constraint_one_of.go
@@ -74,6 +74,18 @@ func namesContain(names []string, name string) bool {
 }
 
 func (o OneOf) EmptyCompletionData(nextPlaceholder int, nestingLevel int) CompletionData {
-	// TODO
-	return CompletionData{}
+	if len(o) == 0 {
+		return CompletionData{
+			LastPlaceholder: nextPlaceholder,
+		}
+	}
+
+	cData := o[0].EmptyCompletionData(nextPlaceholder, nestingLevel)
+
+	return CompletionData{
+		NewText:         cData.NewText,
+		Snippet:         cData.Snippet,
+		LastPlaceholder: cData.LastPlaceholder,
+		TriggerSuggest:  cData.TriggerSuggest,
+	}
 }


### PR DESCRIPTION
Part of https://github.com/hashicorp/terraform-ls/issues/496

--- 

## TODO

 - [x] **completion**: tests
 - [x] **hover**: tests
 - [x] **semantic tokens**: tests
 - [x] **reference origins**: tests
 - [x] **reference origins**: should we only consider first non-empty constraint, rather than collect all?
 - [x] **reference targets**: tests
 - [x] **reference targets**: should we only consider first non-empty constraint, rather than collect all?
