### PR TITLE
decoder: Add support for `Set` as `Constraint`

### DIFF
--- a/decoder/expr_set.go
+++ b/decoder/expr_set.go
@@ -15,11 +15,6 @@ type Set struct {
 	pathCtx *PathContext
 }
 
-func (s Set) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate {
-	// TODO
-	return nil
-}
-
 func (s Set) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData {
 	// TODO
 	return nil

--- a/decoder/expr_set.go
+++ b/decoder/expr_set.go
@@ -15,11 +15,6 @@ type Set struct {
 	pathCtx *PathContext
 }
 
-func (s Set) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData {
-	// TODO
-	return nil
-}
-
 func (s Set) SemanticTokens(ctx context.Context) []lang.SemanticToken {
 	// TODO
 	return nil

--- a/decoder/expr_set.go
+++ b/decoder/expr_set.go
@@ -3,7 +3,6 @@ package decoder
 import (
 	"context"
 
-	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/reference"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
@@ -13,11 +12,6 @@ type Set struct {
 	expr    hcl.Expression
 	cons    schema.Set
 	pathCtx *PathContext
-}
-
-func (s Set) SemanticTokens(ctx context.Context) []lang.SemanticToken {
-	// TODO
-	return nil
 }
 
 func (s Set) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {

--- a/decoder/expr_set.go
+++ b/decoder/expr_set.go
@@ -1,9 +1,6 @@
 package decoder
 
 import (
-	"context"
-
-	"github.com/hashicorp/hcl-lang/reference"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
 )
@@ -12,9 +9,4 @@ type Set struct {
 	expr    hcl.Expression
 	cons    schema.Set
 	pathCtx *PathContext
-}
-
-func (s Set) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {
-	// TODO
-	return nil
 }

--- a/decoder/expr_set_completion.go
+++ b/decoder/expr_set_completion.go
@@ -12,12 +12,12 @@ import (
 func (set Set) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate {
 	if isEmptyExpression(set.expr) {
 		label := "[ ]"
-		triggerSuggest := false
 
 		if set.cons.Elem != nil {
 			label = fmt.Sprintf("[ %s ]", set.cons.Elem.FriendlyName())
-			triggerSuggest = true
 		}
+
+		d := set.cons.EmptyCompletionData(1, 0)
 
 		return []lang.Candidate{
 			{
@@ -26,15 +26,15 @@ func (set Set) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidat
 				Kind:        lang.SetCandidateKind,
 				Description: set.cons.Description,
 				TextEdit: lang.TextEdit{
-					NewText: "[ ]",
-					Snippet: "[ ${0} ]",
+					NewText: d.NewText,
+					Snippet: d.Snippet,
 					Range: hcl.Range{
 						Filename: set.expr.Range().Filename,
 						Start:    pos,
 						End:      pos,
 					},
 				},
-				TriggerSuggest: triggerSuggest,
+				TriggerSuggest: d.TriggerSuggest,
 			},
 		}
 	}

--- a/decoder/expr_set_completion.go
+++ b/decoder/expr_set_completion.go
@@ -1,0 +1,95 @@
+package decoder
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+func (set Set) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate {
+	if isEmptyExpression(set.expr) {
+		label := "[ ]"
+		triggerSuggest := false
+
+		if set.cons.Elem != nil {
+			label = fmt.Sprintf("[ %s ]", set.cons.Elem.FriendlyName())
+			triggerSuggest = true
+		}
+
+		return []lang.Candidate{
+			{
+				Label:       label,
+				Detail:      set.cons.FriendlyName(),
+				Kind:        lang.SetCandidateKind,
+				Description: set.cons.Description,
+				TextEdit: lang.TextEdit{
+					NewText: "[ ]",
+					Snippet: "[ ${0} ]",
+					Range: hcl.Range{
+						Filename: set.expr.Range().Filename,
+						Start:    pos,
+						End:      pos,
+					},
+				},
+				TriggerSuggest: triggerSuggest,
+			},
+		}
+	}
+
+	eType, ok := set.expr.(*hclsyntax.TupleConsExpr)
+	if !ok {
+		return []lang.Candidate{}
+	}
+
+	if set.cons.Elem == nil {
+		return []lang.Candidate{}
+	}
+
+	fileBytes := set.pathCtx.Files[set.expr.Range().Filename].Bytes
+
+	betweenBraces := hcl.Range{
+		Filename: eType.Range().Filename,
+		Start:    eType.OpenRange.End,
+		End:      eType.Range().End,
+	}
+
+	if betweenBraces.ContainsPos(pos) {
+		if len(eType.Exprs) == 0 {
+			expr := newEmptyExpressionAtPos(eType.Range().Filename, pos)
+			return newExpression(set.pathCtx, expr, set.cons.Elem).CompletionAtPos(ctx, pos)
+		}
+
+		// TODO: depending on set.cons.Elem (Keyword, LiteralValue, Reference),
+		// filter out declared elements to provide uniqueness as that is the nature of set
+
+		var lastElemEndPos hcl.Pos
+		for _, elemExpr := range eType.Exprs {
+			if elemExpr.Range().ContainsPos(pos) || elemExpr.Range().End.Byte == pos.Byte {
+				return newExpression(set.pathCtx, elemExpr, set.cons.Elem).CompletionAtPos(ctx, pos)
+			}
+			lastElemEndPos = elemExpr.Range().End
+		}
+
+		rng := hcl.Range{
+			Filename: eType.Range().Filename,
+			Start:    lastElemEndPos,
+			End:      pos,
+		}
+
+		// TODO: test with multi-line element expressions
+
+		b := rng.SliceBytes(fileBytes)
+		if strings.TrimSpace(string(b)) != "," {
+			return []lang.Candidate{}
+		}
+
+		expr := newEmptyExpressionAtPos(eType.Range().Filename, pos)
+		return newExpression(set.pathCtx, expr, set.cons.Elem).CompletionAtPos(ctx, pos)
+	}
+
+	return []lang.Candidate{}
+}

--- a/decoder/expr_set_completion.go
+++ b/decoder/expr_set_completion.go
@@ -61,7 +61,8 @@ func (set Set) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidat
 		}
 
 		// TODO: depending on set.cons.Elem (Keyword, LiteralValue, Reference),
-		// filter out declared elements to provide uniqueness as that is the nature of set
+		// filter out declared elements to provide uniqueness as that is the nature of set.
+		// See https://github.com/hashicorp/hcl-lang/issues/225
 
 		for _, elemExpr := range eType.Exprs {
 			// We cannot trust ranges of empty expressions, so we imply

--- a/decoder/expr_set_completion_test.go
+++ b/decoder/expr_set_completion_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
 )
 
 func TestCompletionAtPos_exprSet(t *testing.T) {
@@ -73,7 +74,7 @@ func TestCompletionAtPos_exprSet(t *testing.T) {
 							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
 						},
 						NewText: "[ ]",
-						Snippet: "[ ${0} ]",
+						Snippet: "[ ${1} ]",
 					},
 					Kind: lang.SetCandidateKind,
 				},
@@ -84,8 +85,8 @@ func TestCompletionAtPos_exprSet(t *testing.T) {
 			map[string]*schema.AttributeSchema{
 				"attr": {
 					Constraint: schema.Set{
-						Elem: schema.Keyword{
-							Keyword: "keyword",
+						Elem: schema.LiteralType{
+							Type: cty.String,
 						},
 					},
 				},
@@ -95,19 +96,19 @@ func TestCompletionAtPos_exprSet(t *testing.T) {
 			hcl.Pos{Line: 1, Column: 8, Byte: 7},
 			lang.CompleteCandidates([]lang.Candidate{
 				{
-					Label:  `[ keyword ]`,
-					Detail: "set of keyword",
+					Label:  `[ string ]`,
+					Detail: "set of string",
 					TextEdit: lang.TextEdit{
 						Range: hcl.Range{
 							Filename: "test.tf",
 							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
 							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
 						},
-						NewText: "[ keyword ]",
-						Snippet: "[ ${0:keyword} ]",
+						NewText: "[ \"value\" ]",
+						Snippet: "[ \"${1:value}\" ]",
 					},
 					Kind:           lang.SetCandidateKind,
-					TriggerSuggest: true,
+					TriggerSuggest: false,
 				},
 			}),
 		},

--- a/decoder/expr_set_completion_test.go
+++ b/decoder/expr_set_completion_test.go
@@ -1,0 +1,646 @@
+package decoder
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+func TestCompletionAtPos_exprSet(t *testing.T) {
+	testCases := []struct {
+		testName           string
+		attrSchema         map[string]*schema.AttributeSchema
+		cfg                string
+		pos                hcl.Pos
+		expectedCandidates lang.Candidates
+	}{
+		{
+			"attribute as set expression",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Set{
+						Elem: schema.LiteralType{
+							Type: cty.String,
+						},
+					},
+				},
+			},
+			`
+`,
+			hcl.Pos{Line: 1, Column: 1, Byte: 0},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `attr`,
+					Detail: "set of string",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+							End:      hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						},
+						NewText: "attr",
+						Snippet: "attr = [ \"${1:value}\" ]",
+					},
+					Kind:           lang.AttributeCandidateKind,
+					TriggerSuggest: false,
+				},
+			}),
+		},
+		{
+			"empty expression no element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Set{},
+				},
+			},
+			`attr = 
+`,
+			hcl.Pos{Line: 1, Column: 8, Byte: 7},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `[ ]`,
+					Detail: "set",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+						NewText: "[ ]",
+						Snippet: "[ ${0} ]",
+					},
+					Kind: lang.SetCandidateKind,
+				},
+			}),
+		},
+		{
+			"empty expression with element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Set{
+						Elem: schema.Keyword{
+							Keyword: "keyword",
+						},
+					},
+				},
+			},
+			`attr = 
+`,
+			hcl.Pos{Line: 1, Column: 8, Byte: 7},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `[ keyword ]`,
+					Detail: "set of keyword",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+						NewText: "[ keyword ]",
+						Snippet: "[ ${0:keyword} ]",
+					},
+					Kind:           lang.SetCandidateKind,
+					TriggerSuggest: true,
+				},
+			}),
+		},
+
+		// single line tests
+		{
+			"inside brackets single-line",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Set{
+						Elem: schema.Keyword{
+							Keyword: "keyword",
+						},
+					},
+				},
+			},
+			`attr = [  ]
+`,
+			hcl.Pos{Line: 1, Column: 10, Byte: 9},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `keyword`,
+					Detail: "keyword",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+							End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+						},
+						NewText: `keyword`,
+						Snippet: `keyword`,
+					},
+					Kind: lang.KeywordCandidateKind,
+				},
+			}),
+		},
+		{
+			"inside single-line partial element near end",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Set{
+						Elem: schema.Keyword{
+							Keyword: "keyword",
+						},
+					},
+				},
+			},
+			`attr = [ key ]
+`,
+			hcl.Pos{Line: 1, Column: 13, Byte: 12},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `keyword`,
+					Detail: "keyword",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+							End:      hcl.Pos{Line: 1, Column: 13, Byte: 12},
+						},
+						NewText: `keyword`,
+						Snippet: `keyword`,
+					},
+					Kind: lang.KeywordCandidateKind,
+				},
+			}),
+		},
+		{
+			// TODO: revisit if we allow only unique elements in sets
+			"inside single-line complete element in the middle",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Set{
+						Elem: schema.Keyword{
+							Keyword: "keyword",
+						},
+					},
+				},
+			},
+			`attr = [ keyword, ]
+`,
+			hcl.Pos{Line: 1, Column: 13, Byte: 12},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `keyword`,
+					Detail: "keyword",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+							End:      hcl.Pos{Line: 1, Column: 17, Byte: 16},
+						},
+						NewText: `keyword`,
+						Snippet: `keyword`,
+					},
+					Kind: lang.KeywordCandidateKind,
+				},
+			}),
+		},
+		{
+			// TODO: revisit if we allow only unique elements in sets
+			"inside single-line after previous element with comma",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Set{
+						Elem: schema.Keyword{
+							Keyword: "keyword",
+						},
+					},
+				},
+			},
+			`attr = [ keyword, ]
+`,
+			hcl.Pos{Line: 1, Column: 19, Byte: 18},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `keyword`,
+					Detail: "keyword",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 19, Byte: 18},
+							End:      hcl.Pos{Line: 1, Column: 19, Byte: 18},
+						},
+						NewText: `keyword`,
+						Snippet: `keyword`,
+					},
+					Kind: lang.KeywordCandidateKind,
+				},
+			}),
+		},
+		{
+			// TODO: revisit if we allow only unique elements in sets
+			"inside single-line after previous element without comma",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Set{
+						Elem: schema.Keyword{
+							Keyword: "keyword",
+						},
+					},
+				},
+			},
+			`attr = [ keyword  ]
+`,
+			hcl.Pos{Line: 1, Column: 19, Byte: 18},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `keyword`,
+					Detail: "keyword",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 19, Byte: 18},
+							End:      hcl.Pos{Line: 1, Column: 19, Byte: 18},
+						},
+						NewText: `keyword`,
+						Snippet: `keyword`,
+					},
+					Kind: lang.KeywordCandidateKind,
+				},
+			}),
+		},
+		{
+			// TODO: revisit if we allow only unique elements in sets
+			"inside single-line between elements with commas",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Set{
+						Elem: schema.Keyword{
+							Keyword: "keyword",
+						},
+					},
+				},
+			},
+			`attr = [ keyword,  , keyword ]
+`,
+			hcl.Pos{Line: 1, Column: 19, Byte: 18},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `keyword`,
+					Detail: "keyword",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 19, Byte: 18},
+							End:      hcl.Pos{Line: 1, Column: 19, Byte: 18},
+						},
+						NewText: `keyword`,
+						Snippet: `keyword`,
+					},
+					Kind: lang.KeywordCandidateKind,
+				},
+			}),
+		},
+
+		// multi line tests
+		{
+			"inside brackets multi-line",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Set{
+						Elem: schema.Keyword{
+							Keyword: "keyword",
+						},
+					},
+				},
+			},
+			`attr = [
+  
+]
+`,
+			hcl.Pos{Line: 2, Column: 3, Byte: 11},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `keyword`,
+					Detail: "keyword",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+							End:      hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						},
+						NewText: `keyword`,
+						Snippet: `keyword`,
+					},
+					Kind: lang.KeywordCandidateKind,
+				},
+			}),
+		},
+		{
+			"inside multi-line partial element near end",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Set{
+						Elem: schema.Keyword{
+							Keyword: "keyword",
+						},
+					},
+				},
+			},
+			`attr = [
+  key
+]
+`,
+			hcl.Pos{Line: 2, Column: 6, Byte: 14},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `keyword`,
+					Detail: "keyword",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+							End:      hcl.Pos{Line: 2, Column: 6, Byte: 14},
+						},
+						NewText: `keyword`,
+						Snippet: `keyword`,
+					},
+					Kind: lang.KeywordCandidateKind,
+				},
+			}),
+		},
+		{
+			// TODO: revisit if we allow only unique elements in sets
+			"inside multi-line complete element in the middle",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Set{
+						Elem: schema.Keyword{
+							Keyword: "keyword",
+						},
+					},
+				},
+			},
+			`attr = [
+  keyword,
+]
+`,
+			hcl.Pos{Line: 2, Column: 6, Byte: 14},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `keyword`,
+					Detail: "keyword",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+							End:      hcl.Pos{Line: 2, Column: 10, Byte: 18},
+						},
+						NewText: `keyword`,
+						Snippet: `keyword`,
+					},
+					Kind: lang.KeywordCandidateKind,
+				},
+			}),
+		},
+		{
+			// TODO: revisit if we allow only unique elements in sets
+			"inside multi-line new line before existing element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Set{
+						Elem: schema.Keyword{
+							Keyword: "keyword",
+						},
+					},
+				},
+			},
+			`attr = [
+  
+  keyword,
+]
+`,
+			hcl.Pos{Line: 2, Column: 3, Byte: 11},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `keyword`,
+					Detail: "keyword",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+							End:      hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						},
+						NewText: `keyword`,
+						Snippet: `keyword`,
+					},
+					Kind: lang.KeywordCandidateKind,
+				},
+			}),
+		},
+		{
+			// TODO: revisit if we allow only unique elements in sets
+			"inside multi-line partial element before existing element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Set{
+						Elem: schema.Keyword{
+							Keyword: "keyword",
+						},
+					},
+				},
+			},
+			`attr = [
+  key
+  keyword,
+]
+`,
+			hcl.Pos{Line: 2, Column: 6, Byte: 14},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `keyword`,
+					Detail: "keyword",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+							End:      hcl.Pos{Line: 2, Column: 6, Byte: 14},
+						},
+						NewText: `keyword`,
+						Snippet: `keyword`,
+					},
+					Kind: lang.KeywordCandidateKind,
+				},
+			}),
+		},
+		{
+			// TODO: revisit if we allow only unique elements in sets
+			"inside multi-line after previous element with comma",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Set{
+						Elem: schema.Keyword{
+							Keyword: "keyword",
+						},
+					},
+				},
+			},
+			`attr = [
+  keyword,
+  
+]
+`,
+			hcl.Pos{Line: 3, Column: 3, Byte: 22},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `keyword`,
+					Detail: "keyword",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 3, Column: 3, Byte: 22},
+							End:      hcl.Pos{Line: 3, Column: 3, Byte: 22},
+						},
+						NewText: `keyword`,
+						Snippet: `keyword`,
+					},
+					Kind: lang.KeywordCandidateKind,
+				},
+			}),
+		},
+		{
+			// TODO: revisit if we allow only unique elements in sets
+			"inside multi-line after previous element without comma",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Set{
+						Elem: schema.Keyword{
+							Keyword: "keyword",
+						},
+					},
+				},
+			},
+			`attr = [
+  keyword
+  
+]
+`,
+			hcl.Pos{Line: 3, Column: 3, Byte: 21},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `keyword`,
+					Detail: "keyword",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 3, Column: 3, Byte: 21},
+							End:      hcl.Pos{Line: 3, Column: 3, Byte: 21},
+						},
+						NewText: `keyword`,
+						Snippet: `keyword`,
+					},
+					Kind: lang.KeywordCandidateKind,
+				},
+			}),
+		},
+		{
+			// TODO: revisit if we allow only unique elements in sets
+			"inside multi-line between elements with commas",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Set{
+						Elem: schema.Keyword{
+							Keyword: "keyword",
+						},
+					},
+				},
+			},
+			`attr = [
+  keyword,
+  
+  keyword,
+]
+`,
+			hcl.Pos{Line: 3, Column: 3, Byte: 22},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `keyword`,
+					Detail: "keyword",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 3, Column: 3, Byte: 22},
+							End:      hcl.Pos{Line: 3, Column: 3, Byte: 22},
+						},
+						NewText: `keyword`,
+						Snippet: `keyword`,
+					},
+					Kind: lang.KeywordCandidateKind,
+				},
+			}),
+		},
+		{
+			// TODO: revisit if we allow only unique elements in sets
+			"inside multi-line after previous element with comma same line",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Set{
+						Elem: schema.Keyword{
+							Keyword: "keyword",
+						},
+					},
+				},
+			},
+			`attr = [
+  keyword, 
+]
+`,
+			hcl.Pos{Line: 2, Column: 12, Byte: 20},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `keyword`,
+					Detail: "keyword",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 12, Byte: 20},
+							End:      hcl.Pos{Line: 2, Column: 12, Byte: 20},
+						},
+						NewText: `keyword`,
+						Snippet: `keyword`,
+					},
+					Kind: lang.KeywordCandidateKind,
+				},
+			}),
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%2d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := &schema.BodySchema{
+				Attributes: tc.attrSchema,
+			}
+
+			f, _ := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.tf": f,
+				},
+			})
+
+			ctx := context.Background()
+			candidates, err := d.CandidatesAtPos(ctx, "test.tf", tc.pos)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedCandidates, candidates); diff != "" {
+				t.Logf("position: %#v in config: %s", tc.pos, tc.cfg)
+				t.Fatalf("unexpected candidates: %s", diff)
+			}
+		})
+	}
+}

--- a/decoder/expr_set_hover.go
+++ b/decoder/expr_set_hover.go
@@ -1,0 +1,34 @@
+package decoder
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+func (set Set) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData {
+	eType, ok := set.expr.(*hclsyntax.TupleConsExpr)
+	if !ok {
+		return nil
+	}
+
+	for _, elemExpr := range eType.Exprs {
+		if elemExpr.Range().ContainsPos(pos) {
+			expr := newExpression(set.pathCtx, elemExpr, set.cons.Elem)
+			return expr.HoverAtPos(ctx, pos)
+		}
+	}
+
+	content := fmt.Sprintf("_%s_", set.cons.FriendlyName())
+	if set.cons.Description.Value != "" {
+		content += "\n\n" + set.cons.Description.Value
+	}
+
+	return &lang.HoverData{
+		Content: lang.Markdown(content),
+		Range:   eType.Range(),
+	}
+}

--- a/decoder/expr_set_hover_test.go
+++ b/decoder/expr_set_hover_test.go
@@ -1,0 +1,309 @@
+package decoder
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestHoverAtPos_exprSet(t *testing.T) {
+	testCases := []struct {
+		testName          string
+		attrSchema        map[string]*schema.AttributeSchema
+		cfg               string
+		pos               hcl.Pos
+		expectedHoverData *lang.HoverData
+	}{
+		{
+			"empty single-line set without element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Set{},
+				},
+			},
+			`attr = []`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			&lang.HoverData{
+				Content: lang.Markdown("_set_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+				},
+			},
+		},
+		{
+			"empty multi-line set without element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Set{},
+				},
+			},
+			`attr = [
+  
+]`,
+			hcl.Pos{Line: 2, Column: 2, Byte: 10},
+			&lang.HoverData{
+				Content: lang.Markdown("_set_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 3, Column: 2, Byte: 13},
+				},
+			},
+		},
+		{
+			"empty single-line set with element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Set{
+						Elem: schema.Keyword{
+							Keyword: "keyword",
+						},
+					},
+				},
+			},
+			`attr = []`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			&lang.HoverData{
+				Content: lang.Markdown("_set of keyword_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+				},
+			},
+		},
+		{
+			"empty single-line set with element and description",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Set{
+						Elem: schema.Keyword{
+							Keyword: "keyword",
+						},
+						Description: lang.Markdown("description"),
+					},
+				},
+			},
+			`attr = []`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			&lang.HoverData{
+				Content: lang.Markdown("_set of keyword_\n\ndescription"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+				},
+			},
+		},
+		{
+			"empty multi-line set with element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Set{
+						Elem: schema.Keyword{
+							Keyword: "keyword",
+						},
+					},
+				},
+			},
+			`attr = [
+  
+]`,
+			hcl.Pos{Line: 2, Column: 2, Byte: 10},
+			&lang.HoverData{
+				Content: lang.Markdown("_set of keyword_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 3, Column: 2, Byte: 13},
+				},
+			},
+		},
+		{
+			"single element single-line set on element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Set{
+						Elem: schema.Keyword{
+							Keyword: "keyword",
+						},
+						Description: lang.Markdown("description"),
+					},
+				},
+			},
+			`attr = [keyword]`,
+			hcl.Pos{Line: 1, Column: 12, Byte: 11},
+			&lang.HoverData{
+				Content: lang.Markdown("`keyword` _keyword_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+					End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+				},
+			},
+		},
+		{
+			"single element single-line set on element with custom data",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Set{
+						Elem: schema.Keyword{
+							Keyword:     "keyword",
+							Description: lang.Markdown("key description"),
+						},
+						Description: lang.Markdown("description"),
+					},
+				},
+			},
+			`attr = [keyword]`,
+			hcl.Pos{Line: 1, Column: 12, Byte: 11},
+			&lang.HoverData{
+				Content: lang.Markdown("`keyword` _keyword_\n\nkey description"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+					End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+				},
+			},
+		},
+		{
+			"multi-element single-line set on set",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Set{
+						Elem: schema.LiteralType{
+							Type: cty.String,
+						},
+						Description: lang.Markdown("description"),
+					},
+				},
+			},
+			`attr = [ "one", "two" ]`,
+			hcl.Pos{Line: 1, Column: 8, Byte: 7},
+			&lang.HoverData{
+				Content: lang.Markdown("_set of string_\n\ndescription"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start: hcl.Pos{
+						Line:   1,
+						Column: 8,
+						Byte:   7,
+					},
+					End: hcl.Pos{
+						Line:   1,
+						Column: 24,
+						Byte:   23,
+					},
+				},
+			},
+		},
+		{
+			"single element multi-line set on element with custom data",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Set{
+						Elem: schema.Keyword{
+							Keyword:     "keyword",
+							Description: lang.Markdown("key description"),
+						},
+						Description: lang.Markdown("description"),
+					},
+				},
+			},
+			`attr = [
+  keyword,
+]`,
+			hcl.Pos{Line: 2, Column: 6, Byte: 14},
+			&lang.HoverData{
+				Content: lang.Markdown("`keyword` _keyword_\n\nkey description"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+					End:      hcl.Pos{Line: 2, Column: 10, Byte: 18},
+				},
+			},
+		},
+		{
+			"multi-element multi-line set on invalid element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Set{
+						Elem: schema.Keyword{
+							Keyword:     "keyword",
+							Description: lang.Markdown("key description"),
+						},
+						Description: lang.Markdown("description"),
+					},
+				},
+			},
+			`attr = [
+  "foo",
+  keyword,
+]`,
+			hcl.Pos{Line: 2, Column: 6, Byte: 14},
+			nil,
+		},
+		{
+			"multi-element multi-line set on second element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Set{
+						Elem: schema.Keyword{
+							Keyword:     "keyword",
+							Description: lang.Markdown("key description"),
+						},
+						Description: lang.Markdown("description"),
+					},
+				},
+			},
+			`attr = [
+  keyword,
+  keyword,
+]`,
+			hcl.Pos{Line: 3, Column: 6, Byte: 25},
+			&lang.HoverData{
+				Content: lang.Markdown("`keyword` _keyword_\n\nkey description"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 3, Column: 3, Byte: 22},
+					End:      hcl.Pos{Line: 3, Column: 10, Byte: 29},
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := &schema.BodySchema{
+				Attributes: tc.attrSchema,
+			}
+
+			f, _ := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.tf": f,
+				},
+			})
+
+			ctx := context.Background()
+			hoverData, err := d.HoverAtPos(ctx, "test.tf", tc.pos)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedHoverData, hoverData); diff != "" {
+				t.Fatalf("unexpected hover data: %s", diff)
+			}
+		})
+	}
+}

--- a/decoder/expr_set_ref_origins.go
+++ b/decoder/expr_set_ref_origins.go
@@ -1,0 +1,30 @@
+package decoder
+
+import (
+	"context"
+
+	"github.com/hashicorp/hcl-lang/reference"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+func (set Set) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {
+	eType, ok := set.expr.(*hclsyntax.TupleConsExpr)
+	if !ok {
+		return reference.Origins{}
+	}
+
+	if len(eType.Exprs) == 0 || set.cons.Elem == nil {
+		return reference.Origins{}
+	}
+
+	origins := make(reference.Origins, 0)
+
+	for _, elemExpr := range eType.Exprs {
+		expr := newExpression(set.pathCtx, elemExpr, set.cons.Elem)
+		if e, ok := expr.(ReferenceOriginsExpression); ok {
+			origins = append(origins, e.ReferenceOrigins(ctx, allowSelfRefs)...)
+		}
+	}
+
+	return origins
+}

--- a/decoder/expr_set_ref_targets.go
+++ b/decoder/expr_set_ref_targets.go
@@ -1,0 +1,25 @@
+package decoder
+
+import (
+	"context"
+
+	"github.com/hashicorp/hcl-lang/reference"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+func (set Set) ReferenceTargets(ctx context.Context, targetCtx *TargetContext) reference.Targets {
+	eType, ok := set.expr.(*hclsyntax.TupleConsExpr)
+	if !ok {
+		return reference.Targets{}
+	}
+
+	if len(eType.Exprs) == 0 || set.cons.Elem == nil {
+		return reference.Targets{}
+	}
+
+	targets := make(reference.Targets, 0)
+
+	// TODO: collect parent target for the whole set
+
+	return targets
+}

--- a/decoder/expr_set_ref_targets.go
+++ b/decoder/expr_set_ref_targets.go
@@ -20,6 +20,7 @@ func (set Set) ReferenceTargets(ctx context.Context, targetCtx *TargetContext) r
 	targets := make(reference.Targets, 0)
 
 	// TODO: collect parent target for the whole set
+	// See https://github.com/hashicorp/hcl-lang/issues/228
 
 	return targets
 }

--- a/decoder/expr_set_semtok.go
+++ b/decoder/expr_set_semtok.go
@@ -1,0 +1,28 @@
+package decoder
+
+import (
+	"context"
+
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+func (set Set) SemanticTokens(ctx context.Context) []lang.SemanticToken {
+	eType, ok := set.expr.(*hclsyntax.TupleConsExpr)
+	if !ok {
+		return []lang.SemanticToken{}
+	}
+
+	if len(eType.Exprs) == 0 || set.cons.Elem == nil {
+		return []lang.SemanticToken{}
+	}
+
+	tokens := make([]lang.SemanticToken, 0)
+
+	for _, elemExpr := range eType.Exprs {
+		expr := newExpression(set.pathCtx, elemExpr, set.cons.Elem)
+		tokens = append(tokens, expr.SemanticTokens(ctx)...)
+	}
+
+	return tokens
+}

--- a/decoder/expr_set_semtok_test.go
+++ b/decoder/expr_set_semtok_test.go
@@ -1,0 +1,251 @@
+package decoder
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+func TestSemanticTokens_exprSet(t *testing.T) {
+	testCases := []struct {
+		testName               string
+		attrSchema             map[string]*schema.AttributeSchema
+		cfg                    string
+		expectedSemanticTokens []lang.SemanticToken
+	}{
+		{
+			"empty set without element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Set{},
+				},
+			},
+			`attr = []`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+			},
+		},
+		{
+			"empty set with element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Set{
+						Elem: schema.Keyword{
+							Keyword: "keyword",
+						},
+					},
+				},
+			},
+			`attr = []`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+			},
+		},
+		{
+			"single element set",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Set{
+						Elem: schema.Keyword{
+							Keyword: "keyword",
+						},
+					},
+				},
+			},
+			`attr = [keyword]`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenKeyword,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+					},
+				},
+			},
+		},
+		{
+			"single element multi-line set",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Set{
+						Elem: schema.Keyword{
+							Keyword: "keyword",
+						},
+					},
+				},
+			},
+			`attr = [
+  keyword,
+]`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenKeyword,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						End:      hcl.Pos{Line: 2, Column: 10, Byte: 18},
+					},
+				},
+			},
+		},
+		{
+			"multi-element multi-line set",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Set{
+						Elem: schema.Keyword{
+							Keyword: "keyword",
+						},
+					},
+				},
+			},
+			`attr = [
+  keyword,
+  keyword,
+]`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenKeyword,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						End:      hcl.Pos{Line: 2, Column: 10, Byte: 18},
+					},
+				},
+				{
+					Type:      lang.TokenKeyword,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 3, Column: 3, Byte: 22},
+						End:      hcl.Pos{Line: 3, Column: 10, Byte: 29},
+					},
+				},
+			},
+		},
+		{
+			"multi-element multi-line set with invalid element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Set{
+						Elem: schema.Keyword{
+							Keyword: "keyword",
+						},
+					},
+				},
+			},
+			`attr = [
+  keyword,
+  invalid,
+  keyword,
+]`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenKeyword,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						End:      hcl.Pos{Line: 2, Column: 10, Byte: 18},
+					},
+				},
+				{
+					Type:      lang.TokenKeyword,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 4, Column: 3, Byte: 33},
+						End:      hcl.Pos{Line: 4, Column: 10, Byte: 40},
+					},
+				},
+			},
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := &schema.BodySchema{
+				Attributes: tc.attrSchema,
+			}
+
+			f, _ := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.tf": f,
+				},
+			})
+
+			ctx := context.Background()
+			tokens, err := d.SemanticTokensInFile(ctx, "test.tf")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedSemanticTokens, tokens); diff != "" {
+				t.Fatalf("unexpected tokens: %s", diff)
+			}
+		})
+	}
+}

--- a/schema/constraint_set.go
+++ b/schema/constraint_set.go
@@ -51,7 +51,7 @@ func (s Set) Copy() Constraint {
 func (s Set) EmptyCompletionData(nextPlaceholder int, nestingLevel int) CompletionData {
 	if s.Elem == nil {
 		return CompletionData{
-			NewText:         "[]",
+			NewText:         "[ ]",
 			Snippet:         fmt.Sprintf("[ ${%d} ]", nextPlaceholder),
 			NextPlaceholder: nextPlaceholder + 1,
 		}
@@ -60,7 +60,7 @@ func (s Set) EmptyCompletionData(nextPlaceholder int, nestingLevel int) Completi
 	elemData := s.Elem.EmptyCompletionData(nextPlaceholder, nestingLevel)
 	if elemData.NewText == "" || elemData.Snippet == "" {
 		return CompletionData{
-			NewText:         "[]",
+			NewText:         "[ ]",
 			Snippet:         fmt.Sprintf("[ ${%d} ]", nextPlaceholder),
 			TriggerSuggest:  elemData.TriggerSuggest,
 			NextPlaceholder: nextPlaceholder + 1,

--- a/schema/constraint_test.go
+++ b/schema/constraint_test.go
@@ -628,7 +628,7 @@ STRING
 				},
 			},
 			CompletionData{
-				NewText:         "[]",
+				NewText:         "[ ]",
 				Snippet:         "[ ${1} ]",
 				TriggerSuggest:  true,
 				NextPlaceholder: 2,


### PR DESCRIPTION
Part of https://github.com/hashicorp/terraform-ls/issues/496

--- 

## TODO

 - [x] **completion**: `schema` empty completion data
 - [x] **completion**: handle unique elements (create a new issue to track it)
 - [x] **completion**: handling of multiline elements (+tests)
 - [x]  **completion**: tests
 - [x] **hover**: tests
 - [x] **semantic tokens**: tests
 - [x]  **completion**: review existing tests
 - [x] **hover**: review existing tests
 - [x] **semantic tokens**: review existing tests
---

## Later
 - [ ] **reference targets**: Decide how to collect parent target for the whole set
 - [ ] **reference origins**: tests
 - [ ] **reference targets**: tests