### PR TITLE
decoder: Adjust `Expression.ReferenceTargets()` address arguments

### DIFF
--- a/decoder/expr_any.go
+++ b/decoder/expr_any.go
@@ -35,7 +35,7 @@ func (a Any) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference
 	return nil
 }
 
-func (a Any) ReferenceTargets(ctx context.Context, attrAddr *schema.AttributeAddrSchema) reference.Targets {
+func (a Any) ReferenceTargets(ctx context.Context, addr lang.Address, addrCtx AddressContext) reference.Targets {
 	// TODO
 	return nil
 }

--- a/decoder/expr_list.go
+++ b/decoder/expr_list.go
@@ -35,7 +35,7 @@ func (l List) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) referenc
 	return nil
 }
 
-func (l List) ReferenceTargets(ctx context.Context, attrAddr *schema.AttributeAddrSchema) reference.Targets {
+func (l List) ReferenceTargets(ctx context.Context, addr lang.Address, addrCtx AddressContext) reference.Targets {
 	// TODO
 	return nil
 }

--- a/decoder/expr_literal_type.go
+++ b/decoder/expr_literal_type.go
@@ -34,7 +34,7 @@ func (lt LiteralType) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) 
 	return nil
 }
 
-func (lt LiteralType) ReferenceTargets(ctx context.Context, attrAddr *schema.AttributeAddrSchema) reference.Targets {
+func (lt LiteralType) ReferenceTargets(ctx context.Context, addr lang.Address, addrCtx AddressContext) reference.Targets {
 	// TODO
 	return nil
 }

--- a/decoder/expr_map.go
+++ b/decoder/expr_map.go
@@ -35,7 +35,7 @@ func (m Map) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference
 	return nil
 }
 
-func (m Map) ReferenceTargets(ctx context.Context, attrAddr *schema.AttributeAddrSchema) reference.Targets {
+func (m Map) ReferenceTargets(ctx context.Context, addr lang.Address, addrCtx AddressContext) reference.Targets {
 	// TODO
 	return nil
 }

--- a/decoder/expr_object.go
+++ b/decoder/expr_object.go
@@ -35,7 +35,7 @@ func (obj Object) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) refe
 	return nil
 }
 
-func (obj Object) ReferenceTargets(ctx context.Context, attrAddr *schema.AttributeAddrSchema) reference.Targets {
+func (obj Object) ReferenceTargets(ctx context.Context, addr lang.Address, addrCtx AddressContext) reference.Targets {
 	// TODO
 	return nil
 }
@@ -65,7 +65,7 @@ func (oa ObjectAttributes) ReferenceOrigins(ctx context.Context, allowSelfRefs b
 	return nil
 }
 
-func (oa ObjectAttributes) ReferenceTargets(ctx context.Context, attrAddr *schema.AttributeAddrSchema) reference.Targets {
+func (oa ObjectAttributes) ReferenceTargets(ctx context.Context, addr lang.Address, addrCtx AddressContext) reference.Targets {
 	// TODO
 	return nil
 }

--- a/decoder/expr_one_of.go
+++ b/decoder/expr_one_of.go
@@ -35,7 +35,7 @@ func (oo OneOf) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) refere
 	return nil
 }
 
-func (oo OneOf) ReferenceTargets(ctx context.Context, attrAddr *schema.AttributeAddrSchema) reference.Targets {
+func (oo OneOf) ReferenceTargets(ctx context.Context, addr lang.Address, addrCtx AddressContext) reference.Targets {
 	// TODO
 	return nil
 }

--- a/decoder/expr_reference.go
+++ b/decoder/expr_reference.go
@@ -34,7 +34,7 @@ func (ref Reference) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) r
 	return nil
 }
 
-func (ref Reference) ReferenceTargets(ctx context.Context, attrAddr *schema.AttributeAddrSchema) reference.Targets {
+func (ref Reference) ReferenceTargets(ctx context.Context, addr lang.Address, addrCtx AddressContext) reference.Targets {
 	// TODO
 	return nil
 }

--- a/decoder/expr_set.go
+++ b/decoder/expr_set.go
@@ -34,8 +34,3 @@ func (s Set) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference
 	// TODO
 	return nil
 }
-
-func (s Set) ReferenceTargets(ctx context.Context, attrAddr *schema.AttributeAddrSchema) reference.Targets {
-	// TODO
-	return nil
-}

--- a/decoder/expr_tuple.go
+++ b/decoder/expr_tuple.go
@@ -35,7 +35,7 @@ func (t Tuple) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) referen
 	return nil
 }
 
-func (t Tuple) ReferenceTargets(ctx context.Context, attrAddr *schema.AttributeAddrSchema) reference.Targets {
+func (t Tuple) ReferenceTargets(ctx context.Context, addr lang.Address, addrCtx AddressContext) reference.Targets {
 	// TODO
 	return nil
 }

--- a/decoder/expression.go
+++ b/decoder/expression.go
@@ -24,7 +24,31 @@ type ReferenceOriginsExpression interface {
 }
 
 type ReferenceTargetsExpression interface {
-	ReferenceTargets(ctx context.Context, attrAddr *schema.AttributeAddrSchema) reference.Targets
+	ReferenceTargets(ctx context.Context, addr lang.Address, addrCtx AddressContext) reference.Targets
+}
+
+// AddressContext describes context for collecting reference targets
+type AddressContext struct {
+	// FriendlyName is (optional) human-readable name of the expression
+	// interpreted as reference target.
+	FriendlyName string
+
+	// ScopeId defines scope of a reference to allow for more granular
+	// filtering in completion and accurate matching, which is especially
+	// important for type-less reference targets (i.e. AsReference: true).
+	ScopeId lang.ScopeId
+
+	// AsExprType defines whether the value of the attribute
+	// is addressable as a matching literal type constraint included
+	// in attribute Expr.
+	//
+	// cty.DynamicPseudoType (also known as "any type") will create
+	// reference of the real type if value is present else cty.DynamicPseudoType.
+	AsExprType bool
+
+	// AsReference defines whether the attribute
+	// is addressable as a type-less reference
+	AsReference bool
 }
 
 func (d *PathDecoder) newExpression(expr hcl.Expression, cons schema.Constraint) Expression {

--- a/decoder/expression_test.go
+++ b/decoder/expression_test.go
@@ -13,4 +13,23 @@ var (
 	_ Expression = Reference{}
 	_ Expression = Tuple{}
 	_ Expression = TypeDeclaration{}
+
+	_ ReferenceOriginsExpression = Any{}
+	_ ReferenceOriginsExpression = List{}
+	_ ReferenceOriginsExpression = LiteralType{}
+	_ ReferenceOriginsExpression = Map{}
+	_ ReferenceOriginsExpression = ObjectAttributes{}
+	_ ReferenceOriginsExpression = Object{}
+	_ ReferenceOriginsExpression = Set{}
+	_ ReferenceOriginsExpression = Reference{}
+	_ ReferenceOriginsExpression = Tuple{}
+
+	_ ReferenceTargetsExpression = Any{}
+	_ ReferenceTargetsExpression = List{}
+	_ ReferenceTargetsExpression = LiteralType{}
+	_ ReferenceTargetsExpression = Map{}
+	_ ReferenceTargetsExpression = ObjectAttributes{}
+	_ ReferenceTargetsExpression = Object{}
+	_ ReferenceTargetsExpression = Reference{}
+	_ ReferenceTargetsExpression = Tuple{}
 )

--- a/decoder/reference_targets.go
+++ b/decoder/reference_targets.go
@@ -274,7 +274,19 @@ func (d *PathDecoder) decodeReferenceTargetsForAttribute(attr *hcl.Attribute, at
 	if attrSchema.Constraint != nil {
 		expr := d.newExpression(attr.Expr, attrSchema.Constraint)
 		if eType, ok := expr.(ReferenceTargetsExpression); ok {
-			refs = append(refs, eType.ReferenceTargets(ctx, attrSchema.Address)...)
+			addrCtx := AddressContext{
+				FriendlyName: attrSchema.Address.FriendlyName,
+				ScopeId:      attrSchema.Address.ScopeId,
+				AsExprType:   attrSchema.Address.AsExprType,
+				AsReference:  attrSchema.Address.AsReference,
+			}
+
+			attrAddr, ok := resolveAttributeAddress(attr, attrSchema.Address.Steps)
+			if !ok {
+				attrAddr = make(lang.Address, 0)
+			}
+
+			refs = append(refs, eType.ReferenceTargets(ctx, attrAddr, addrCtx)...)
 		}
 	} else {
 		if attrSchema.Address != nil {

--- a/schema/attribute_schema.go
+++ b/schema/attribute_schema.go
@@ -49,10 +49,20 @@ type AttributeSchema struct {
 }
 
 type AttributeAddrSchema struct {
+	// Steps describes address steps used to describe the attribute as whole.
+	// The last step would typically be AttrNameStep{}.
 	Steps Address
 
+	// FriendlyName is (optional) human-readable name of the *outermost*
+	// expression interpreted as reference target.
+	//
+	// The name is used in completion item and in hover data.
 	FriendlyName string
-	ScopeId      lang.ScopeId
+
+	// ScopeId defines scope of a reference to allow for more granular
+	// filtering in completion and accurate matching, which is especially
+	// important for type-less reference targets (i.e. AsReference: true).
+	ScopeId lang.ScopeId
 
 	// AsExprType defines whether the value of the attribute
 	// is addressable as a matching literal type constraint included

--- a/schema/block_schema.go
+++ b/schema/block_schema.go
@@ -36,10 +36,20 @@ type BlockSchema struct {
 }
 
 type BlockAddrSchema struct {
+	// Steps describes address steps used to describe the attribute as whole.
+	// The last step would typically be LabelStep{}.
 	Steps Address
 
+	// FriendlyName is (optional) human-readable name of the block as whole
+	// interpreted as reference target.
+	//
+	// The name is used in completion item and in hover data.
 	FriendlyName string
-	ScopeId      lang.ScopeId
+
+	// ScopeId defines scope of a reference to allow for more granular
+	// filtering in completion and accurate matching, which is especially
+	// important for type-less reference targets (i.e. AsReference: true).
+	ScopeId lang.ScopeId
 
 	// AsReference defines whether the block itself
 	// is addressable as a type-less reference


### PR DESCRIPTION
As discovered while implementing this method for `List`

 - https://github.com/hashicorp/hcl-lang/pull/195

we will need to pass around an address which may not necessarily refer to the attribute as whole, but different expressions depending on levels of nesting.

This is expected to be useful for most other constraints which can have reference targets inside (e.g. `Object` or `Map`).

This also adds some compilation-time tests to ensure that we don't accidentally change interface somewhere and "turn off" collection of origins or targets.