### PR TITLE
Deprecate old reference matching logic

### DIFF
--- a/decoder/expression_candidates.go
+++ b/decoder/expression_candidates.go
@@ -459,7 +459,7 @@ func (d *PathDecoder) candidatesForTraversalConstraint(ctx context.Context, tc s
 
 	prefix, _ := d.bytesFromRange(prefixRng)
 
-	d.pathCtx.ReferenceTargets.MatchWalk(ctx, tc, string(prefix), outermostBodyRng, editRng, func(target reference.Target) error {
+	d.pathCtx.ReferenceTargets.LegacyMatchWalk(ctx, tc, string(prefix), outermostBodyRng, editRng, func(target reference.Target) error {
 		address := target.Address(ctx, editRng.Start).String()
 
 		candidates = append(candidates, lang.Candidate{

--- a/decoder/hover.go
+++ b/decoder/hover.go
@@ -251,7 +251,7 @@ func (d *PathDecoder) hoverDataForExpr(ctx context.Context, expr hcl.Expression,
 
 		tes, ok := constraints.TraversalExprs()
 		if ok {
-			content, err := d.hoverContentForTraversalExpr(ctx, e.AsTraversal(), tes, pos)
+			content, err := d.legacyHoverContentForTraversalExpr(ctx, e.AsTraversal(), tes, pos)
 			if err != nil {
 				return nil, err
 			}
@@ -599,7 +599,7 @@ func stringValFromTemplateExpr(tplExpr *hclsyntax.TemplateExpr) (cty.Value, bool
 	return cty.StringVal(value), true
 }
 
-func (d *PathDecoder) hoverContentForTraversalExpr(ctx context.Context, traversal hcl.Traversal, tes []schema.TraversalExpr, pos hcl.Pos) (string, error) {
+func (d *PathDecoder) legacyHoverContentForTraversalExpr(ctx context.Context, traversal hcl.Traversal, tes []schema.TraversalExpr, pos hcl.Pos) (string, error) {
 	origins, ok := d.pathCtx.ReferenceOrigins.AtPos(traversal.SourceRange().Filename, pos)
 	if !ok {
 		return "", &reference.NoOriginFound{}

--- a/decoder/reference_origins.go
+++ b/decoder/reference_origins.go
@@ -279,7 +279,7 @@ func (d *PathDecoder) legacyFindOriginsInExpression(expr hcl.Expression, ec sche
 		// see https://github.com/hashicorp/terraform-ls/issues/496
 		tes, ok := ExprConstraints(ec).TraversalExprs()
 		if ok {
-			origins = append(origins, reference.TraversalsToLocalOrigins(expr.Variables(), tes, allowSelfRefs)...)
+			origins = append(origins, reference.LegacyTraversalsToLocalOrigins(expr.Variables(), tes, allowSelfRefs)...)
 		}
 	case *hclsyntax.LiteralValueExpr:
 		// String constant may also be a traversal in some cases, but currently not recognized
@@ -292,7 +292,7 @@ func (d *PathDecoder) legacyFindOriginsInExpression(expr hcl.Expression, ec sche
 		// This may result in less accurate decoding where even origins
 		// which do not actually conform to the constraints are recognized.
 		// TODO: https://github.com/hashicorp/terraform-ls/issues/675
-		origins = append(origins, reference.TraversalsToLocalOrigins(expr.Variables(), schema.TraversalExprs{}, allowSelfRefs)...)
+		origins = append(origins, reference.LegacyTraversalsToLocalOrigins(expr.Variables(), schema.TraversalExprs{}, allowSelfRefs)...)
 	}
 
 	return origins

--- a/reference/target.go
+++ b/reference/target.go
@@ -137,7 +137,7 @@ func (r Target) TargetRange() (hcl.Range, bool) {
 	return *r.RangePtr, true
 }
 
-func (ref Target) MatchesConstraint(te schema.TraversalExpr) bool {
+func (ref Target) LegacyMatchesConstraint(te schema.TraversalExpr) bool {
 	return ref.MatchesScopeId(te.OfScopeId) && ref.ConformsToType(te.OfType)
 }
 

--- a/reference/targets_test.go
+++ b/reference/targets_test.go
@@ -611,7 +611,7 @@ func TestTargets_OutermostInFile(t *testing.T) {
 	}
 }
 
-func TestTargets_MatchWalk(t *testing.T) {
+func TestTargets_LegacyMatchWalk(t *testing.T) {
 	testCases := []struct {
 		name             string
 		targets          Targets
@@ -862,7 +862,7 @@ func TestTargets_MatchWalk(t *testing.T) {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {
 			targets := make(Targets, 0)
 			ctx := context.Background()
-			tc.targets.MatchWalk(ctx, tc.traversalConst, tc.prefix, tc.outermostBodyRng, tc.originRng, func(t Target) error {
+			tc.targets.LegacyMatchWalk(ctx, tc.traversalConst, tc.prefix, tc.outermostBodyRng, tc.originRng, func(t Target) error {
 				targets = append(targets, t)
 				return nil
 			})
@@ -873,7 +873,7 @@ func TestTargets_MatchWalk(t *testing.T) {
 	}
 }
 
-func TestTargets_MatchWalk_localRefs(t *testing.T) {
+func TestTargets_LegacyMatchWalk_localRefs(t *testing.T) {
 	testCases := []struct {
 		name             string
 		targets          Targets
@@ -1341,7 +1341,7 @@ func TestTargets_MatchWalk_localRefs(t *testing.T) {
 			if tc.activeSelfRefs {
 				ctx = schema.WithActiveSelfRefs(ctx)
 			}
-			tc.targets.MatchWalk(ctx, tc.traversalConst, tc.prefix, tc.outermostBodyRng, tc.originRng, func(t Target) error {
+			tc.targets.LegacyMatchWalk(ctx, tc.traversalConst, tc.prefix, tc.outermostBodyRng, tc.originRng, func(t Target) error {
 				targets = append(targets, t)
 				return nil
 			})

--- a/reference/traversal.go
+++ b/reference/traversal.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 )
 
-func TraversalsToLocalOrigins(traversals []hcl.Traversal, tes schema.TraversalExprs, allowSelfRefs bool) Origins {
+func LegacyTraversalsToLocalOrigins(traversals []hcl.Traversal, tes schema.TraversalExprs, allowSelfRefs bool) Origins {
 	origins := make(Origins, 0)
 	for _, traversal := range traversals {
 		// traversal should not be relative here, since the input to this
@@ -16,7 +16,7 @@ func TraversalsToLocalOrigins(traversals []hcl.Traversal, tes schema.TraversalEx
 			// else just continue
 			continue
 		}
-		origin, err := TraversalToLocalOrigin(traversal, tes)
+		origin, err := LegacyTraversalToLocalOrigin(traversal, tes)
 		if err != nil {
 			continue
 		}
@@ -26,7 +26,7 @@ func TraversalsToLocalOrigins(traversals []hcl.Traversal, tes schema.TraversalEx
 	return origins
 }
 
-func TraversalToLocalOrigin(traversal hcl.Traversal, tes schema.TraversalExprs) (LocalOrigin, error) {
+func LegacyTraversalToLocalOrigin(traversal hcl.Traversal, tes schema.TraversalExprs) (LocalOrigin, error) {
 	addr, err := lang.TraversalToAddress(traversal)
 	if err != nil {
 		return LocalOrigin{}, err
@@ -35,11 +35,11 @@ func TraversalToLocalOrigin(traversal hcl.Traversal, tes schema.TraversalExprs) 
 	return LocalOrigin{
 		Addr:        addr,
 		Range:       traversal.SourceRange(),
-		Constraints: traversalExpressionsToOriginConstraints(tes),
+		Constraints: legacyTraversalExpressionsToOriginConstraints(tes),
 	}, nil
 }
 
-func traversalExpressionsToOriginConstraints(tes []schema.TraversalExpr) OriginConstraints {
+func legacyTraversalExpressionsToOriginConstraints(tes []schema.TraversalExpr) OriginConstraints {
 	if len(tes) == 0 {
 		return nil
 	}

--- a/reference/traversal_test.go
+++ b/reference/traversal_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-func TestTraversalToOrigin(t *testing.T) {
+func TestLegacyTraversalToOrigin(t *testing.T) {
 	testCases := []struct {
 		rawTraversal   string
 		traversalExprs schema.TraversalExprs
@@ -87,7 +87,7 @@ func TestTraversalToOrigin(t *testing.T) {
 				t.Fatal(diags)
 			}
 
-			origin, err := TraversalToLocalOrigin(traversal, tc.traversalExprs)
+			origin, err := LegacyTraversalToLocalOrigin(traversal, tc.traversalExprs)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -99,7 +99,7 @@ func TestTraversalToOrigin(t *testing.T) {
 	}
 }
 
-func TestTraversalsToOrigin(t *testing.T) {
+func TestLegacyTraversalsToOrigin(t *testing.T) {
 	testCases := []struct {
 		testName        string
 		rawTraversals   []string
@@ -169,7 +169,7 @@ func TestTraversalsToOrigin(t *testing.T) {
 				traversals = append(traversals, traversal)
 			}
 
-			origins := TraversalsToLocalOrigins(traversals, tc.traversalExprs, tc.allowSelfRefs)
+			origins := LegacyTraversalsToLocalOrigins(traversals, tc.traversalExprs, tc.allowSelfRefs)
 			if diff := cmp.Diff(tc.expectedOrigins, origins, ctydebug.CmpOptions); diff != "" {
 				t.Fatalf("origin mismatch: %s", diff)
 			}


### PR DESCRIPTION
While working on https://github.com/hashicorp/hcl-lang/pull/185 I noticed that there's a number of functions which still accept the "legacy" `schema.TraversalExpr` and these will need to be rewritten for `schema.Reference`.

In preparation for that, and to keep the existing functions working, I am proposing some name changes in this PR.
