### PR TITLE
decoder: Add support for `Tuple` as `Constraint`

### DIFF
--- a/decoder/expr_tuple.go
+++ b/decoder/expr_tuple.go
@@ -15,11 +15,6 @@ type Tuple struct {
 	pathCtx *PathContext
 }
 
-func (t Tuple) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData {
-	// TODO
-	return nil
-}
-
 func (t Tuple) SemanticTokens(ctx context.Context) []lang.SemanticToken {
 	// TODO
 	return nil

--- a/decoder/expr_tuple.go
+++ b/decoder/expr_tuple.go
@@ -15,11 +15,6 @@ type Tuple struct {
 	pathCtx *PathContext
 }
 
-func (t Tuple) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate {
-	// TODO
-	return nil
-}
-
 func (t Tuple) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData {
 	// TODO
 	return nil

--- a/decoder/expr_tuple.go
+++ b/decoder/expr_tuple.go
@@ -1,9 +1,6 @@
 package decoder
 
 import (
-	"context"
-
-	"github.com/hashicorp/hcl-lang/reference"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
 )
@@ -12,9 +9,4 @@ type Tuple struct {
 	expr    hcl.Expression
 	cons    schema.Tuple
 	pathCtx *PathContext
-}
-
-func (t Tuple) ReferenceTargets(ctx context.Context, targetCtx *TargetContext) reference.Targets {
-	// TODO
-	return nil
 }

--- a/decoder/expr_tuple.go
+++ b/decoder/expr_tuple.go
@@ -15,11 +15,6 @@ type Tuple struct {
 	pathCtx *PathContext
 }
 
-func (t Tuple) SemanticTokens(ctx context.Context) []lang.SemanticToken {
-	// TODO
-	return nil
-}
-
 func (t Tuple) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {
 	// TODO
 	return nil

--- a/decoder/expr_tuple.go
+++ b/decoder/expr_tuple.go
@@ -3,7 +3,6 @@ package decoder
 import (
 	"context"
 
-	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/reference"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
@@ -13,11 +12,6 @@ type Tuple struct {
 	expr    hcl.Expression
 	cons    schema.Tuple
 	pathCtx *PathContext
-}
-
-func (t Tuple) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {
-	// TODO
-	return nil
 }
 
 func (t Tuple) ReferenceTargets(ctx context.Context, targetCtx *TargetContext) reference.Targets {

--- a/decoder/expr_tuple_completion.go
+++ b/decoder/expr_tuple_completion.go
@@ -1,0 +1,113 @@
+package decoder
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+func (tuple Tuple) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate {
+	if isEmptyExpression(tuple.expr) {
+		label := "[ ]"
+		triggerSuggest := false
+
+		if len(tuple.cons.Elems) > 0 {
+			elemLabel := ""
+			for _, elemCons := range tuple.cons.Elems {
+				elemLabel += fmt.Sprintf("%s, ", elemCons.FriendlyName())
+			}
+			if len(elemLabel) > 20 {
+				elemLabel = fmt.Sprintf("%s…", elemLabel[0:19])
+			}
+			label = fmt.Sprintf("[ %s ]", elemLabel)
+			triggerSuggest = true
+		}
+
+		return []lang.Candidate{
+			{
+				Label:       label,
+				Detail:      tuple.cons.FriendlyName(),
+				Kind:        lang.TupleCandidateKind,
+				Description: tuple.cons.Description,
+				TextEdit: lang.TextEdit{
+					NewText: "[ ]",
+					Snippet: "[ ${0} ]",
+					Range: hcl.Range{
+						Filename: tuple.expr.Range().Filename,
+						Start:    pos,
+						End:      pos,
+					},
+				},
+				TriggerSuggest: triggerSuggest,
+			},
+		}
+	}
+
+	eType, ok := tuple.expr.(*hclsyntax.TupleConsExpr)
+	if !ok {
+		return []lang.Candidate{}
+	}
+
+	if len(tuple.cons.Elems) == 0 {
+		return []lang.Candidate{}
+	}
+
+	fileBytes := tuple.pathCtx.Files[tuple.expr.Range().Filename].Bytes
+
+	betweenBraces := hcl.Range{
+		Filename: eType.Range().Filename,
+		Start:    eType.OpenRange.End,
+		End: hcl.Pos{
+			// account for the trailing brace }
+			Line:   eType.Range().End.Line,
+			Column: eType.Range().End.Column - 1,
+			Byte:   eType.Range().End.Byte - 1,
+		},
+	}
+
+	if betweenBraces.ContainsPos(pos) {
+		if len(eType.Exprs) == 0 {
+			expr := newEmptyExpressionAtPos(eType.Range().Filename, pos)
+			return newExpression(tuple.pathCtx, expr, tuple.cons.Elems[0]).CompletionAtPos(ctx, pos)
+		}
+
+		if len(eType.Exprs) <= len(tuple.cons.Elems) {
+			var lastElemEndPos hcl.Pos
+			// check for completion inside individual elements
+			for i, elemExpr := range eType.Exprs {
+				if elemExpr.Range().ContainsPos(pos) {
+					return newExpression(tuple.pathCtx, elemExpr, tuple.cons.Elems[i]).CompletionAtPos(ctx, pos)
+				}
+				lastElemEndPos = elemExpr.Range().End
+			}
+
+			if pos.Byte > lastElemEndPos.Byte {
+				if len(eType.Exprs) == len(tuple.cons.Elems) {
+					// no more elements to complete, all declared
+					return []lang.Candidate{}
+				}
+
+				rng := hcl.Range{
+					Filename: eType.Range().Filename,
+					Start:    lastElemEndPos,
+					End:      pos,
+				}
+				// TODO: test with multi-line element expressions
+				b := rng.SliceBytes(fileBytes)
+				if strings.TrimSpace(string(b)) != "," {
+					return []lang.Candidate{}
+				}
+
+				nextIdx := len(eType.Exprs)
+				expr := newEmptyExpressionAtPos(eType.Range().Filename, pos)
+				return newExpression(tuple.pathCtx, expr, tuple.cons.Elems[nextIdx]).CompletionAtPos(ctx, pos)
+			}
+		}
+	}
+
+	return []lang.Candidate{}
+}

--- a/decoder/expr_tuple_completion.go
+++ b/decoder/expr_tuple_completion.go
@@ -65,68 +65,72 @@ func (tuple Tuple) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Cand
 		End:      eType.Range().End,
 	}
 
-	if betweenBraces.ContainsPos(pos) {
-		if len(eType.Exprs) == 0 {
-			expr := newEmptyExpressionAtPos(eType.Range().Filename, pos)
-			return newExpression(tuple.pathCtx, expr, tuple.cons.Elems[0]).CompletionAtPos(ctx, pos)
-		}
-
-		if len(eType.Exprs) <= len(tuple.cons.Elems) {
-			lastElemEndPos := eType.OpenRange.Start
-			lastElemIdx := 0
-			// check for completion inside individual elements
-			for i, elemExpr := range eType.Exprs {
-				// We cannot trust ranges of empty expressions, so we imply
-				// that invalid configuration follows and we stop here
-				// e.g. for completion between commas [keyword, ,keyword]
-				if isEmptyExpression(elemExpr) {
-					break
-				}
-				// We overshot the position and stop
-				if elemExpr.Range().Start.Byte > pos.Byte {
-					break
-				}
-				if elemExpr.Range().ContainsPos(pos) || elemExpr.Range().End.Byte == pos.Byte {
-					return newExpression(tuple.pathCtx, elemExpr, tuple.cons.Elems[i]).CompletionAtPos(ctx, pos)
-				}
-				lastElemEndPos = elemExpr.Range().End
-				lastElemIdx = i
-			}
-
-			if pos.Byte > lastElemEndPos.Byte {
-				if len(eType.Exprs) == len(tuple.cons.Elems) {
-					// no more elements to complete, all declared
-					return []lang.Candidate{}
-				}
-
-				fileBytes := tuple.pathCtx.Files[eType.Range().Filename].Bytes
-				recoveredBytes := recoverLeftBytes(fileBytes, pos, func(byteOffset int, r rune) bool {
-					return (r == '[' || r == ',') && byteOffset > lastElemEndPos.Byte
-				})
-				trimmedBytes := bytes.TrimRight(recoveredBytes, " \t\n")
-
-				if len(trimmedBytes) == 0 {
-					return []lang.Candidate{}
-				}
-
-				nextIdx := len(eType.Exprs)
-				if string(trimmedBytes) == "[" {
-					// We're at the beginning of a tuple and want the
-					// to complete the first element
-					nextIdx = 0
-				}
-				if string(trimmedBytes) == "," {
-					// We're likely within an empty expression and
-					// want to provide completion for the current element
-					// instead of the next one
-					nextIdx = lastElemIdx + 1
-				}
-
-				expr := newEmptyExpressionAtPos(eType.Range().Filename, pos)
-				return newExpression(tuple.pathCtx, expr, tuple.cons.Elems[nextIdx]).CompletionAtPos(ctx, pos)
-			}
-		}
+	if !betweenBraces.ContainsPos(pos) {
+		return []lang.Candidate{}
 	}
 
-	return []lang.Candidate{}
+	if len(eType.Exprs) == 0 {
+		expr := newEmptyExpressionAtPos(eType.Range().Filename, pos)
+		return newExpression(tuple.pathCtx, expr, tuple.cons.Elems[0]).CompletionAtPos(ctx, pos)
+	}
+
+	if len(eType.Exprs) > len(tuple.cons.Elems) {
+		return []lang.Candidate{}
+	}
+
+	lastElemEndPos := eType.OpenRange.Start
+	lastElemIdx := 0
+	// check for completion inside individual elements
+	for i, elemExpr := range eType.Exprs {
+		// We cannot trust ranges of empty expressions, so we imply
+		// that invalid configuration follows and we stop here
+		// e.g. for completion between commas [keyword, ,keyword]
+		if isEmptyExpression(elemExpr) {
+			break
+		}
+		// We overshot the position and stop
+		if elemExpr.Range().Start.Byte > pos.Byte {
+			break
+		}
+		if elemExpr.Range().ContainsPos(pos) || elemExpr.Range().End.Byte == pos.Byte {
+			return newExpression(tuple.pathCtx, elemExpr, tuple.cons.Elems[i]).CompletionAtPos(ctx, pos)
+		}
+		lastElemEndPos = elemExpr.Range().End
+		lastElemIdx = i
+	}
+
+	if pos.Byte <= lastElemEndPos.Byte {
+		return []lang.Candidate{}
+	}
+
+	if len(eType.Exprs) == len(tuple.cons.Elems) {
+		// no more elements to complete, all declared
+		return []lang.Candidate{}
+	}
+
+	fileBytes := tuple.pathCtx.Files[eType.Range().Filename].Bytes
+	recoveredBytes := recoverLeftBytes(fileBytes, pos, func(byteOffset int, r rune) bool {
+		return (r == '[' || r == ',') && byteOffset > lastElemEndPos.Byte
+	})
+	trimmedBytes := bytes.TrimRight(recoveredBytes, " \t\n")
+
+	if len(trimmedBytes) == 0 {
+		return []lang.Candidate{}
+	}
+
+	nextIdx := len(eType.Exprs)
+	if string(trimmedBytes) == "[" {
+		// We're at the beginning of a tuple and want the
+		// to complete the first element
+		nextIdx = 0
+	}
+	if string(trimmedBytes) == "," {
+		// We're likely within an empty expression and
+		// want to provide completion for the current element
+		// instead of the next one
+		nextIdx = lastElemIdx + 1
+	}
+
+	expr := newEmptyExpressionAtPos(eType.Range().Filename, pos)
+	return newExpression(tuple.pathCtx, expr, tuple.cons.Elems[nextIdx]).CompletionAtPos(ctx, pos)
 }

--- a/decoder/expr_tuple_completion.go
+++ b/decoder/expr_tuple_completion.go
@@ -14,19 +14,21 @@ import (
 func (tuple Tuple) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate {
 	if isEmptyExpression(tuple.expr) {
 		label := "[ ]"
-		triggerSuggest := false
 
 		if len(tuple.cons.Elems) > 0 {
-			elemLabel := ""
+			names := make([]string, 0, len(tuple.cons.Elems))
 			for _, elemCons := range tuple.cons.Elems {
-				elemLabel += fmt.Sprintf("%s, ", elemCons.FriendlyName())
+				names = append(names, elemCons.FriendlyName())
 			}
+
+			elemLabel := strings.Join(names, ", ")
 			if len(elemLabel) > 20 {
 				elemLabel = fmt.Sprintf("%s…", elemLabel[0:19])
 			}
 			label = fmt.Sprintf("[ %s ]", elemLabel)
-			triggerSuggest = true
 		}
+
+		d := tuple.cons.EmptyCompletionData(1, 0)
 
 		return []lang.Candidate{
 			{
@@ -35,15 +37,15 @@ func (tuple Tuple) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Cand
 				Kind:        lang.TupleCandidateKind,
 				Description: tuple.cons.Description,
 				TextEdit: lang.TextEdit{
-					NewText: "[ ]",
-					Snippet: "[ ${0} ]",
+					NewText: d.NewText,
+					Snippet: d.Snippet,
 					Range: hcl.Range{
 						Filename: tuple.expr.Range().Filename,
 						Start:    pos,
 						End:      pos,
 					},
 				},
-				TriggerSuggest: triggerSuggest,
+				TriggerSuggest: d.TriggerSuggest,
 			},
 		}
 	}

--- a/decoder/expr_tuple_completion_test.go
+++ b/decoder/expr_tuple_completion_test.go
@@ -1,0 +1,713 @@
+package decoder
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+func TestCompletionAtPos_exprTuple(t *testing.T) {
+	testCases := []struct {
+		testName           string
+		attrSchema         map[string]*schema.AttributeSchema
+		cfg                string
+		pos                hcl.Pos
+		expectedCandidates lang.Candidates
+	}{
+		{
+			"attribute as tuple expression",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Tuple{
+						Elems: []schema.Constraint{
+							schema.LiteralType{
+								Type: cty.String,
+							},
+							schema.LiteralType{
+								Type: cty.Bool,
+							},
+						},
+					},
+				},
+			},
+			`
+`,
+			hcl.Pos{Line: 1, Column: 1, Byte: 0},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `attr`,
+					Detail: "tuple",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+							End:      hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						},
+						NewText: "attr",
+						Snippet: "attr = [ \"${1:value}\", ${2:false} ]",
+					},
+					Kind:           lang.AttributeCandidateKind,
+					TriggerSuggest: false,
+				},
+			}),
+		},
+		{
+			"empty expression no element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Tuple{},
+				},
+			},
+			`attr = 
+`,
+			hcl.Pos{Line: 1, Column: 8, Byte: 7},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `[ ]`,
+					Detail: "tuple",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+						NewText: "[ ]",
+						Snippet: "[ ${0} ]",
+					},
+					Kind: lang.TupleCandidateKind,
+				},
+			}),
+		},
+		{
+			"empty expression with element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Tuple{
+						Elems: []schema.Constraint{
+							schema.Keyword{
+								Keyword: "keyword",
+							},
+						},
+					},
+				},
+			},
+			`attr = 
+`,
+			hcl.Pos{Line: 1, Column: 8, Byte: 7},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `[ keyword ]`,
+					Detail: "tuple",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+						NewText: "[ keyword ]",
+						Snippet: "[ ${0:keyword} ]",
+					},
+					Kind:           lang.TupleCandidateKind,
+					TriggerSuggest: true,
+				},
+			}),
+		},
+
+		// single line tests
+		{
+			"inside brackets single-line",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Tuple{
+						Elems: []schema.Constraint{
+							schema.Keyword{
+								Keyword: "keyword",
+							},
+						},
+					},
+				},
+			},
+			`attr = [  ]
+`,
+			hcl.Pos{Line: 1, Column: 10, Byte: 9},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `keyword`,
+					Detail: "keyword",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+							End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+						},
+						NewText: `keyword`,
+						Snippet: `keyword`,
+					},
+					Kind: lang.KeywordCandidateKind,
+				},
+			}),
+		},
+		{
+			"inside single-line partial element near end",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Tuple{
+						Elems: []schema.Constraint{
+							schema.Keyword{
+								Keyword: "keyword",
+							},
+						},
+					},
+				},
+			},
+			`attr = [ key ]
+`,
+			hcl.Pos{Line: 1, Column: 13, Byte: 12},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `keyword`,
+					Detail: "keyword",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+							End:      hcl.Pos{Line: 1, Column: 13, Byte: 12},
+						},
+						NewText: `keyword`,
+						Snippet: `keyword`,
+					},
+					Kind: lang.KeywordCandidateKind,
+				},
+			}),
+		},
+		{
+			"inside single-line complete element in the middle",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Tuple{
+						Elems: []schema.Constraint{
+							schema.Keyword{
+								Keyword: "keyword",
+							},
+						},
+					},
+				},
+			},
+			`attr = [ keyword, ]
+`,
+			hcl.Pos{Line: 1, Column: 13, Byte: 12},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `keyword`,
+					Detail: "keyword",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+							End:      hcl.Pos{Line: 1, Column: 17, Byte: 16},
+						},
+						NewText: `keyword`,
+						Snippet: `keyword`,
+					},
+					Kind: lang.KeywordCandidateKind,
+				},
+			}),
+		},
+		{
+			"inside single-line before existing element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Tuple{
+						Elems: []schema.Constraint{
+							schema.Keyword{
+								Keyword: "keyword",
+							},
+						},
+					},
+				},
+			},
+			`attr = [  keyword, ]
+`,
+			hcl.Pos{Line: 1, Column: 10, Byte: 9},
+			lang.CompleteCandidates([]lang.Candidate{}),
+		},
+		{
+			"inside single-line after previous element with comma",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Tuple{
+						Elems: []schema.Constraint{
+							schema.Keyword{
+								Keyword: "keyword",
+							},
+							schema.Keyword{
+								Keyword: "drowyek",
+							},
+						},
+					},
+				},
+			},
+			`attr = [ keyword, ]
+`,
+			hcl.Pos{Line: 1, Column: 19, Byte: 18},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `drowyek`,
+					Detail: "keyword",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 19, Byte: 18},
+							End:      hcl.Pos{Line: 1, Column: 19, Byte: 18},
+						},
+						NewText: `drowyek`,
+						Snippet: `drowyek`,
+					},
+					Kind: lang.KeywordCandidateKind,
+				},
+			}),
+		},
+		{
+			"inside single-line after previous element without comma",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Tuple{
+						Elems: []schema.Constraint{
+							schema.Keyword{
+								Keyword: "keyword",
+							},
+							schema.Keyword{
+								Keyword: "drowyek",
+							},
+						},
+					},
+				},
+			},
+			`attr = [ keyword  ]
+`,
+			hcl.Pos{Line: 1, Column: 19, Byte: 18},
+			lang.CompleteCandidates([]lang.Candidate{}),
+		},
+		{
+			"inside single-line between elements with commas",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Tuple{
+						Elems: []schema.Constraint{
+							schema.Keyword{
+								Keyword: "keyword",
+							},
+							schema.Keyword{
+								Keyword: "drowyek",
+							},
+							schema.Keyword{
+								Keyword: "valid",
+							},
+						},
+					},
+				},
+			},
+			`attr = [ keyword,  , valid ]
+`,
+			hcl.Pos{Line: 1, Column: 19, Byte: 18},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `drowyek`,
+					Detail: "keyword",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 19, Byte: 18},
+							End:      hcl.Pos{Line: 1, Column: 19, Byte: 18},
+						},
+						NewText: `drowyek`,
+						Snippet: `drowyek`,
+					},
+					Kind: lang.KeywordCandidateKind,
+				},
+			}),
+		},
+
+		// multi line tests
+		{
+			"inside brackets multi-line",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Tuple{
+						Elems: []schema.Constraint{
+							schema.Keyword{
+								Keyword: "keyword",
+							},
+						},
+					},
+				},
+			},
+			`attr = [
+  
+]
+`,
+			hcl.Pos{Line: 2, Column: 3, Byte: 11},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `keyword`,
+					Detail: "keyword",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+							End:      hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						},
+						NewText: `keyword`,
+						Snippet: `keyword`,
+					},
+					Kind: lang.KeywordCandidateKind,
+				},
+			}),
+		},
+		{
+			"inside multi-line partial element near end",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Tuple{
+						Elems: []schema.Constraint{
+							schema.Keyword{
+								Keyword: "keyword",
+							},
+						},
+					},
+				},
+			},
+			`attr = [
+  key
+]
+`,
+			hcl.Pos{Line: 2, Column: 6, Byte: 14},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `keyword`,
+					Detail: "keyword",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+							End:      hcl.Pos{Line: 2, Column: 6, Byte: 14},
+						},
+						NewText: `keyword`,
+						Snippet: `keyword`,
+					},
+					Kind: lang.KeywordCandidateKind,
+				},
+			}),
+		},
+		{
+			"inside multi-line complete element in the middle",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Tuple{
+						Elems: []schema.Constraint{
+							schema.Keyword{
+								Keyword: "keyword",
+							},
+						},
+					},
+				},
+			},
+			`attr = [
+  keyword,
+]
+`,
+			hcl.Pos{Line: 2, Column: 6, Byte: 14},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `keyword`,
+					Detail: "keyword",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+							End:      hcl.Pos{Line: 2, Column: 10, Byte: 18},
+						},
+						NewText: `keyword`,
+						Snippet: `keyword`,
+					},
+					Kind: lang.KeywordCandidateKind,
+				},
+			}),
+		},
+		{
+			"inside multi-line same line before existing element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Tuple{
+						Elems: []schema.Constraint{
+							schema.Keyword{
+								Keyword: "keyword",
+							},
+						},
+					},
+				},
+			},
+			`attr = [
+  keyword,
+]
+`,
+			hcl.Pos{Line: 2, Column: 2, Byte: 10},
+			lang.CompleteCandidates([]lang.Candidate{}),
+		},
+		{
+			"inside multi-line new line before existing element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Tuple{
+						Elems: []schema.Constraint{
+							schema.Keyword{
+								Keyword: "drowyek",
+							},
+							schema.Keyword{
+								Keyword: "keyword",
+							},
+						},
+					},
+				},
+			},
+			`attr = [
+  
+  keyword,
+]
+`,
+			hcl.Pos{Line: 2, Column: 3, Byte: 11},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `drowyek`,
+					Detail: "keyword",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+							End:      hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						},
+						NewText: `drowyek`,
+						Snippet: `drowyek`,
+					},
+					Kind: lang.KeywordCandidateKind,
+				},
+			}),
+		},
+		{
+			"inside multi-line partial element before existing element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Tuple{
+						Elems: []schema.Constraint{
+							schema.Keyword{
+								Keyword: "drowyek",
+							},
+							schema.Keyword{
+								Keyword: "keyword",
+							},
+						},
+					},
+				},
+			},
+			`attr = [
+  dro
+  keyword,
+]
+`,
+			hcl.Pos{Line: 2, Column: 6, Byte: 14},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `drowyek`,
+					Detail: "keyword",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+							End:      hcl.Pos{Line: 2, Column: 6, Byte: 14},
+						},
+						NewText: `drowyek`,
+						Snippet: `drowyek`,
+					},
+					Kind: lang.KeywordCandidateKind,
+				},
+			}),
+		},
+		{
+			"inside multi-line after previous element with comma",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Tuple{
+						Elems: []schema.Constraint{
+							schema.Keyword{
+								Keyword: "keyword",
+							},
+							schema.Keyword{
+								Keyword: "drowyek",
+							},
+						},
+					},
+				},
+			},
+			`attr = [
+  keyword,
+  
+]
+`,
+			hcl.Pos{Line: 3, Column: 3, Byte: 22},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `drowyek`,
+					Detail: "keyword",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 3, Column: 3, Byte: 22},
+							End:      hcl.Pos{Line: 3, Column: 3, Byte: 22},
+						},
+						NewText: `drowyek`,
+						Snippet: `drowyek`,
+					},
+					Kind: lang.KeywordCandidateKind,
+				},
+			}),
+		},
+		{
+			"inside multi-line after previous element without comma",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Tuple{
+						Elems: []schema.Constraint{
+							schema.Keyword{
+								Keyword: "keyword",
+							},
+							schema.Keyword{
+								Keyword: "drowyek",
+							},
+						},
+					},
+				},
+			},
+			`attr = [
+  keyword
+  
+]
+`,
+			hcl.Pos{Line: 3, Column: 3, Byte: 21},
+			lang.CompleteCandidates([]lang.Candidate{}),
+		},
+		{
+			"inside multi-line between elements with commas",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Tuple{
+						Elems: []schema.Constraint{
+							schema.Keyword{
+								Keyword: "keyword",
+							},
+							schema.Keyword{
+								Keyword: "drowyek",
+							},
+							schema.Keyword{
+								Keyword: "valid",
+							},
+						},
+					},
+				},
+			},
+			`attr = [
+  keyword,
+  
+  valid,
+]
+`,
+			hcl.Pos{Line: 3, Column: 3, Byte: 22},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `drowyek`,
+					Detail: "keyword",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 3, Column: 3, Byte: 22},
+							End:      hcl.Pos{Line: 3, Column: 3, Byte: 22},
+						},
+						NewText: `drowyek`,
+						Snippet: `drowyek`,
+					},
+					Kind: lang.KeywordCandidateKind,
+				},
+			}),
+		},
+		{
+			"inside multi-line after previous element with comma same line",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Tuple{
+						Elems: []schema.Constraint{
+							schema.Keyword{
+								Keyword: "keyword",
+							},
+							schema.Keyword{
+								Keyword: "drowyek",
+							},
+						},
+					},
+				},
+			},
+			`attr = [
+  keyword, 
+]
+`,
+			hcl.Pos{Line: 2, Column: 12, Byte: 20},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `drowyek`,
+					Detail: "keyword",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 12, Byte: 20},
+							End:      hcl.Pos{Line: 2, Column: 12, Byte: 20},
+						},
+						NewText: `drowyek`,
+						Snippet: `drowyek`,
+					},
+					Kind: lang.KeywordCandidateKind,
+				},
+			}),
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%2d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := &schema.BodySchema{
+				Attributes: tc.attrSchema,
+			}
+
+			f, _ := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.tf": f,
+				},
+			})
+
+			ctx := context.Background()
+			candidates, err := d.CandidatesAtPos(ctx, "test.tf", tc.pos)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedCandidates, candidates); diff != "" {
+				t.Logf("position: %#v in config: %s", tc.pos, tc.cfg)
+				t.Fatalf("unexpected candidates: %s", diff)
+			}
+		})
+	}
+}

--- a/decoder/expr_tuple_hover.go
+++ b/decoder/expr_tuple_hover.go
@@ -1,0 +1,38 @@
+package decoder
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+func (tuple Tuple) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData {
+	eType, ok := tuple.expr.(*hclsyntax.TupleConsExpr)
+	if !ok {
+		return nil
+	}
+
+	for i, elemExpr := range eType.Exprs {
+		if i+1 > len(tuple.cons.Elems) {
+			return nil
+		}
+
+		if elemExpr.Range().ContainsPos(pos) {
+			expr := newExpression(tuple.pathCtx, elemExpr, tuple.cons.Elems[i])
+			return expr.HoverAtPos(ctx, pos)
+		}
+	}
+
+	content := fmt.Sprintf("_%s_", tuple.cons.FriendlyName())
+	if tuple.cons.Description.Value != "" {
+		content += "\n\n" + tuple.cons.Description.Value
+	}
+
+	return &lang.HoverData{
+		Content: lang.Markdown(content),
+		Range:   eType.Range(),
+	}
+}

--- a/decoder/expr_tuple_hover_test.go
+++ b/decoder/expr_tuple_hover_test.go
@@ -1,0 +1,355 @@
+package decoder
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestHoverAtPos_exprTuple(t *testing.T) {
+	testCases := []struct {
+		testName          string
+		attrSchema        map[string]*schema.AttributeSchema
+		cfg               string
+		pos               hcl.Pos
+		expectedHoverData *lang.HoverData
+	}{
+		{
+			"empty single-line tuple without element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Tuple{},
+				},
+			},
+			`attr = []`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			&lang.HoverData{
+				Content: lang.Markdown("_tuple_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+				},
+			},
+		},
+		{
+			"empty multi-line tuple without element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Tuple{},
+				},
+			},
+			`attr = [
+  
+]`,
+			hcl.Pos{Line: 2, Column: 2, Byte: 10},
+			&lang.HoverData{
+				Content: lang.Markdown("_tuple_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 3, Column: 2, Byte: 13},
+				},
+			},
+		},
+		{
+			"empty single-line tuple with one element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Tuple{
+						Elems: []schema.Constraint{
+							schema.Keyword{
+								Keyword: "keyword",
+							},
+							schema.Keyword{
+								Keyword: "drowyek",
+							},
+						},
+					},
+				},
+			},
+			`attr = []`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			&lang.HoverData{
+				Content: lang.Markdown("_tuple_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+				},
+			},
+		},
+		{
+			"empty single-line tuple with elements and description",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Tuple{
+						Elems: []schema.Constraint{
+							schema.Keyword{
+								Keyword: "keyword",
+							},
+							schema.Keyword{
+								Keyword: "drowyek",
+							},
+						},
+						Description: lang.Markdown("description"),
+					},
+				},
+			},
+			`attr = []`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			&lang.HoverData{
+				Content: lang.Markdown("_tuple_\n\ndescription"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+				},
+			},
+		},
+		{
+			"empty multi-line tuple with one element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Tuple{
+						Elems: []schema.Constraint{
+							schema.Keyword{
+								Keyword: "keyword",
+							},
+						},
+					},
+				},
+			},
+			`attr = [
+  
+]`,
+			hcl.Pos{Line: 2, Column: 2, Byte: 10},
+			&lang.HoverData{
+				Content: lang.Markdown("_tuple_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 3, Column: 2, Byte: 13},
+				},
+			},
+		},
+		{
+			"single element single-line tuple on element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Tuple{
+						Elems: []schema.Constraint{
+							schema.Keyword{
+								Keyword: "keyword",
+							},
+							schema.Keyword{
+								Keyword: "drowyek",
+							},
+						},
+						Description: lang.Markdown("description"),
+					},
+				},
+			},
+			`attr = [keyword]`,
+			hcl.Pos{Line: 1, Column: 12, Byte: 11},
+			&lang.HoverData{
+				Content: lang.Markdown("`keyword` _keyword_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+					End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+				},
+			},
+		},
+		{
+			"single element single-line tuple on element with custom data",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Tuple{
+						Elems: []schema.Constraint{
+							schema.Keyword{
+								Keyword:     "keyword",
+								Description: lang.Markdown("key description"),
+							},
+							schema.Keyword{
+								Keyword:     "drowyek",
+								Description: lang.Markdown("dro description"),
+							},
+						},
+						Description: lang.Markdown("description"),
+					},
+				},
+			},
+			`attr = [keyword]`,
+			hcl.Pos{Line: 1, Column: 12, Byte: 11},
+			&lang.HoverData{
+				Content: lang.Markdown("`keyword` _keyword_\n\nkey description"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+					End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+				},
+			},
+		},
+		{
+			"multi-element single-line tuple on tuple",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Tuple{
+						Elems: []schema.Constraint{
+							schema.LiteralType{
+								Type: cty.String,
+							},
+							schema.LiteralType{
+								Type: cty.String,
+							},
+						},
+						Description: lang.Markdown("description"),
+					},
+				},
+			},
+			`attr = [ "one", "two" ]`,
+			hcl.Pos{Line: 1, Column: 8, Byte: 7},
+			&lang.HoverData{
+				Content: lang.Markdown("_tuple_\n\ndescription"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start: hcl.Pos{
+						Line:   1,
+						Column: 8,
+						Byte:   7,
+					},
+					End: hcl.Pos{
+						Line:   1,
+						Column: 24,
+						Byte:   23,
+					},
+				},
+			},
+		},
+		{
+			"single element multi-line tuple on element with custom data",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Tuple{
+						Elems: []schema.Constraint{
+							schema.Keyword{
+								Keyword:     "keyword",
+								Description: lang.Markdown("key description"),
+							},
+							schema.Keyword{
+								Keyword:     "drowyek",
+								Description: lang.Markdown("dro description"),
+							},
+						},
+						Description: lang.Markdown("description"),
+					},
+				},
+			},
+			`attr = [
+  keyword,
+]`,
+			hcl.Pos{Line: 2, Column: 6, Byte: 14},
+			&lang.HoverData{
+				Content: lang.Markdown("`keyword` _keyword_\n\nkey description"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+					End:      hcl.Pos{Line: 2, Column: 10, Byte: 18},
+				},
+			},
+		},
+		{
+			"multi-element multi-line tuple on invalid element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Tuple{
+						Elems: []schema.Constraint{
+							schema.Keyword{
+								Keyword:     "keyword",
+								Description: lang.Markdown("key description"),
+							},
+							schema.Keyword{
+								Keyword:     "drowyek",
+								Description: lang.Markdown("dro description"),
+							},
+						},
+						Description: lang.Markdown("description"),
+					},
+				},
+			},
+			`attr = [
+  "foo",
+  keyword,
+]`,
+			hcl.Pos{Line: 2, Column: 6, Byte: 14},
+			nil,
+		},
+		{
+			"multi-element multi-line tuple on second element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Tuple{
+						Elems: []schema.Constraint{
+							schema.Keyword{
+								Keyword:     "keyword",
+								Description: lang.Markdown("key description"),
+							},
+							schema.Keyword{
+								Keyword:     "drowyek",
+								Description: lang.Markdown("dro description"),
+							},
+						},
+						Description: lang.Markdown("description"),
+					},
+				},
+			},
+			`attr = [
+  keyword,
+  drowyek,
+]`,
+			hcl.Pos{Line: 3, Column: 6, Byte: 25},
+			&lang.HoverData{
+				Content: lang.Markdown("`drowyek` _keyword_\n\ndro description"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 3, Column: 3, Byte: 22},
+					End:      hcl.Pos{Line: 3, Column: 10, Byte: 29},
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := &schema.BodySchema{
+				Attributes: tc.attrSchema,
+			}
+
+			f, _ := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.tf": f,
+				},
+			})
+
+			ctx := context.Background()
+			hoverData, err := d.HoverAtPos(ctx, "test.tf", tc.pos)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedHoverData, hoverData); diff != "" {
+				t.Fatalf("unexpected hover data: %s", diff)
+			}
+		})
+	}
+}

--- a/decoder/expr_tuple_ref_origins.go
+++ b/decoder/expr_tuple_ref_origins.go
@@ -1,0 +1,34 @@
+package decoder
+
+import (
+	"context"
+
+	"github.com/hashicorp/hcl-lang/reference"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+func (tuple Tuple) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {
+	eType, ok := tuple.expr.(*hclsyntax.TupleConsExpr)
+	if !ok {
+		return reference.Origins{}
+	}
+
+	if len(eType.Exprs) == 0 || len(tuple.cons.Elems) == 0 {
+		return reference.Origins{}
+	}
+
+	origins := make(reference.Origins, 0)
+
+	for i, elemExpr := range eType.Exprs {
+		if i+1 > len(tuple.cons.Elems) {
+			break
+		}
+
+		expr := newExpression(tuple.pathCtx, elemExpr, tuple.cons.Elems[i])
+		if e, ok := expr.(ReferenceOriginsExpression); ok {
+			origins = append(origins, e.ReferenceOrigins(ctx, allowSelfRefs)...)
+		}
+	}
+
+	return origins
+}

--- a/decoder/expr_tuple_ref_targets.go
+++ b/decoder/expr_tuple_ref_targets.go
@@ -22,6 +22,7 @@ func (tuple Tuple) ReferenceTargets(ctx context.Context, targetCtx *TargetContex
 	targets := make(reference.Targets, 0)
 
 	// TODO: collect parent target for the whole tuple
+	// See https://github.com/hashicorp/hcl-lang/issues/228
 
 	for i, elemExpr := range eType.Exprs {
 		if i+1 > len(tuple.cons.Elems) {

--- a/decoder/expr_tuple_ref_targets.go
+++ b/decoder/expr_tuple_ref_targets.go
@@ -1,0 +1,47 @@
+package decoder
+
+import (
+	"context"
+
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/reference"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func (tuple Tuple) ReferenceTargets(ctx context.Context, targetCtx *TargetContext) reference.Targets {
+	eType, ok := tuple.expr.(*hclsyntax.TupleConsExpr)
+	if !ok {
+		return reference.Targets{}
+	}
+
+	if len(eType.Exprs) == 0 || len(tuple.cons.Elems) == 0 {
+		return reference.Targets{}
+	}
+
+	targets := make(reference.Targets, 0)
+
+	// TODO: collect parent target for the whole tuple
+
+	for i, elemExpr := range eType.Exprs {
+		if i+1 > len(tuple.cons.Elems) {
+			break
+		}
+
+		expr := newExpression(tuple.pathCtx, elemExpr, tuple.cons.Elems[i])
+		if e, ok := expr.(ReferenceTargetsExpression); ok {
+			elemCtx := targetCtx.Copy()
+			elemCtx.ParentAddress = append(elemCtx.ParentAddress, lang.IndexStep{
+				Key: cty.NumberIntVal(int64(i)),
+			})
+			if elemCtx.ParentLocalAddress != nil {
+				elemCtx.ParentLocalAddress = append(elemCtx.ParentLocalAddress, lang.IndexStep{
+					Key: cty.NumberIntVal(int64(i)),
+				})
+			}
+			targets = append(targets, e.ReferenceTargets(ctx, elemCtx)...)
+		}
+	}
+
+	return targets
+}

--- a/decoder/expr_tuple_semtok.go
+++ b/decoder/expr_tuple_semtok.go
@@ -1,0 +1,32 @@
+package decoder
+
+import (
+	"context"
+
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+func (tuple Tuple) SemanticTokens(ctx context.Context) []lang.SemanticToken {
+	eType, ok := tuple.expr.(*hclsyntax.TupleConsExpr)
+	if !ok {
+		return []lang.SemanticToken{}
+	}
+
+	if len(eType.Exprs) == 0 || len(tuple.cons.Elems) == 0 {
+		return []lang.SemanticToken{}
+	}
+
+	tokens := make([]lang.SemanticToken, 0)
+
+	for i, elemExpr := range eType.Exprs {
+		if i+1 > len(tuple.cons.Elems) {
+			break
+		}
+
+		expr := newExpression(tuple.pathCtx, elemExpr, tuple.cons.Elems[i])
+		tokens = append(tokens, expr.SemanticTokens(ctx)...)
+	}
+
+	return tokens
+}

--- a/decoder/expr_tuple_semtok_test.go
+++ b/decoder/expr_tuple_semtok_test.go
@@ -1,0 +1,267 @@
+package decoder
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+func TestSemanticTokens_exprTuple(t *testing.T) {
+	testCases := []struct {
+		testName               string
+		attrSchema             map[string]*schema.AttributeSchema
+		cfg                    string
+		expectedSemanticTokens []lang.SemanticToken
+	}{
+		{
+			"empty tuple without element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Tuple{},
+				},
+			},
+			`attr = []`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+			},
+		},
+		{
+			"empty tuple with element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Tuple{
+						Elems: []schema.Constraint{
+							schema.Keyword{
+								Keyword: "keyword",
+							},
+						},
+					},
+				},
+			},
+			`attr = []`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+			},
+		},
+		{
+			"single element tuple",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Tuple{
+						Elems: []schema.Constraint{
+							schema.Keyword{
+								Keyword: "keyword",
+							},
+						},
+					},
+				},
+			},
+			`attr = [keyword]`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenKeyword,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+					},
+				},
+			},
+		},
+		{
+			"single element multi-line tuple",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Tuple{
+						Elems: []schema.Constraint{
+							schema.Keyword{
+								Keyword: "keyword",
+							},
+						},
+					},
+				},
+			},
+			`attr = [
+  keyword,
+]`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenKeyword,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						End:      hcl.Pos{Line: 2, Column: 10, Byte: 18},
+					},
+				},
+			},
+		},
+		{
+			"multi-element multi-line tuple",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Tuple{
+						Elems: []schema.Constraint{
+							schema.Keyword{
+								Keyword: "keyword",
+							},
+							schema.Keyword{
+								Keyword: "drowyek",
+							},
+						},
+					},
+				},
+			},
+			`attr = [
+  keyword,
+  drowyek,
+]`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenKeyword,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						End:      hcl.Pos{Line: 2, Column: 10, Byte: 18},
+					},
+				},
+				{
+					Type:      lang.TokenKeyword,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 3, Column: 3, Byte: 22},
+						End:      hcl.Pos{Line: 3, Column: 10, Byte: 29},
+					},
+				},
+			},
+		},
+		{
+			"multi-element multi-line tuple with invalid element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Tuple{
+						Elems: []schema.Constraint{
+							schema.Keyword{
+								Keyword: "keyword",
+							},
+							schema.Keyword{
+								Keyword: "drowyek",
+							},
+						},
+					},
+				},
+			},
+			`attr = [
+  keyword,
+  drowyek,
+  invalid,
+]`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenKeyword,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						End:      hcl.Pos{Line: 2, Column: 10, Byte: 18},
+					},
+				},
+				{
+					Type:      lang.TokenKeyword,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 3, Column: 3, Byte: 22},
+						End:      hcl.Pos{Line: 3, Column: 10, Byte: 29},
+					},
+				},
+			},
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := &schema.BodySchema{
+				Attributes: tc.attrSchema,
+			}
+
+			f, _ := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.tf": f,
+				},
+			})
+
+			ctx := context.Background()
+			tokens, err := d.SemanticTokensInFile(ctx, "test.tf")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedSemanticTokens, tokens); diff != "" {
+				t.Fatalf("unexpected tokens: %s", diff)
+			}
+		})
+	}
+}

--- a/decoder/expr_tuple_semtok_test.go
+++ b/decoder/expr_tuple_semtok_test.go
@@ -197,6 +197,9 @@ func TestSemanticTokens_exprTuple(t *testing.T) {
 								Keyword: "keyword",
 							},
 							schema.Keyword{
+								Keyword: "valid",
+							},
+							schema.Keyword{
 								Keyword: "drowyek",
 							},
 						},
@@ -205,8 +208,8 @@ func TestSemanticTokens_exprTuple(t *testing.T) {
 			},
 			`attr = [
   keyword,
-  drowyek,
   invalid,
+  drowyek,
 ]`,
 			[]lang.SemanticToken{
 				{
@@ -232,8 +235,8 @@ func TestSemanticTokens_exprTuple(t *testing.T) {
 					Modifiers: lang.SemanticTokenModifiers{},
 					Range: hcl.Range{
 						Filename: "test.tf",
-						Start:    hcl.Pos{Line: 3, Column: 3, Byte: 22},
-						End:      hcl.Pos{Line: 3, Column: 10, Byte: 29},
+						Start:    hcl.Pos{Line: 4, Column: 3, Byte: 33},
+						End:      hcl.Pos{Line: 4, Column: 10, Byte: 40},
 					},
 				},
 			},

--- a/schema/constraint_test.go
+++ b/schema/constraint_test.go
@@ -643,7 +643,7 @@ STRING
 				},
 			},
 			CompletionData{
-				NewText:         "[]",
+				NewText:         "[ ]",
 				Snippet:         "[ ${1} ]",
 				TriggerSuggest:  true,
 				NextPlaceholder: 2,

--- a/schema/constraint_tuple.go
+++ b/schema/constraint_tuple.go
@@ -44,7 +44,7 @@ func (t Tuple) Copy() Constraint {
 func (t Tuple) EmptyCompletionData(nextPlaceholder int, nestingLevel int) CompletionData {
 	if len(t.Elems) == 0 {
 		return CompletionData{
-			NewText:         "[]",
+			NewText:         "[ ]",
 			Snippet:         fmt.Sprintf("[ ${%d} ]", nextPlaceholder),
 			NextPlaceholder: nextPlaceholder + 1,
 		}
@@ -58,7 +58,7 @@ func (t Tuple) EmptyCompletionData(nextPlaceholder int, nestingLevel int) Comple
 		cData := elem.EmptyCompletionData(lastPlaceholder, nestingLevel)
 		if cData.NewText == "" || cData.Snippet == "" {
 			return CompletionData{
-				NewText:         "[]",
+				NewText:         "[ ]",
 				Snippet:         fmt.Sprintf("[ ${%d} ]", nextPlaceholder),
 				TriggerSuggest:  cData.TriggerSuggest,
 				NextPlaceholder: nextPlaceholder + 1,


### PR DESCRIPTION
Part of https://github.com/hashicorp/terraform-ls/issues/496

--- 

## TODO

 - [x] **completion**: `schema`: empty completion data
 - [x] **completion**: handling of multiline elements (+tests)
 - [x] **completion**: tests
 - [x] **hover**: tests
 - [x] **semantic tokens**: tests
 - [x]  **completion**: review existing tests
 - [x] **hover**: review existing tests
 - [x] **semantic tokens**: review existing tests
---

## Later
 - [ ] **reference targets**: Decide how to collect parent target for the whole tuple
 - [ ] **reference origins**: tests
 - [ ] **reference targets**: tests