### PR TITLE
Fix `LocalAddr` creation in target collection for JSON files

### DIFF
--- a/decoder/reference_targets.go
+++ b/decoder/reference_targets.go
@@ -740,7 +740,7 @@ func (d *PathDecoder) collectInferredReferenceTargetsForBody(addr lang.Address, 
 
 		blockRef := reference.Target{
 			Addr:        blockAddr,
-			LocalAddr:   make(lang.Address, len(selfRefAddr)),
+			LocalAddr:   make(lang.Address, 0),
 			ScopeId:     bAddrSchema.ScopeId,
 			Type:        cty.Object(bodySchemaAsAttrTypes(bCollection.Schema.Body)),
 			Description: bCollection.Schema.Description,
@@ -748,6 +748,7 @@ func (d *PathDecoder) collectInferredReferenceTargetsForBody(addr lang.Address, 
 			RangePtr:    blk.Range.Ptr(),
 		}
 		if bAddrSchema.DependentBodySelfRef && selfRefBodyRangePtr != nil {
+			blockRef.LocalAddr = make(lang.Address, len(selfRefAddr))
 			copy(blockRef.LocalAddr, selfRefAddr)
 			blockRef.LocalAddr = append(blockRef.LocalAddr, lang.AttrStep{Name: bType})
 			blockRef.TargetableFromRangePtr = selfRefBodyRangePtr.Ptr()
@@ -766,13 +767,14 @@ func (d *PathDecoder) collectInferredReferenceTargetsForBody(addr lang.Address, 
 
 		blockRef := reference.Target{
 			Addr:        blockAddr,
-			LocalAddr:   make(lang.Address, len(selfRefAddr)),
+			LocalAddr:   make(lang.Address, 0),
 			ScopeId:     bAddrSchema.ScopeId,
 			Type:        cty.List(cty.Object(bodySchemaAsAttrTypes(bCollection.Schema.Body))),
 			Description: bCollection.Schema.Description,
 			RangePtr:    body.MissingItemRange().Ptr(),
 		}
 		if bAddrSchema.DependentBodySelfRef && selfRefBodyRangePtr != nil {
+			blockRef.LocalAddr = make(lang.Address, len(selfRefAddr))
 			copy(blockRef.LocalAddr, selfRefAddr)
 			blockRef.LocalAddr = append(blockRef.LocalAddr, lang.AttrStep{Name: bType})
 			blockRef.TargetableFromRangePtr = selfRefBodyRangePtr.Ptr()
@@ -787,7 +789,7 @@ func (d *PathDecoder) collectInferredReferenceTargetsForBody(addr lang.Address, 
 
 			elemRef := reference.Target{
 				Addr:        elemAddr,
-				LocalAddr:   make(lang.Address, len(blockRef.LocalAddr)),
+				LocalAddr:   make(lang.Address, 0),
 				ScopeId:     bAddrSchema.ScopeId,
 				Type:        cty.Object(bodySchemaAsAttrTypes(bCollection.Schema.Body)),
 				Description: bCollection.Schema.Description,
@@ -796,6 +798,7 @@ func (d *PathDecoder) collectInferredReferenceTargetsForBody(addr lang.Address, 
 			}
 
 			if bAddrSchema.DependentBodySelfRef && selfRefBodyRangePtr != nil {
+				elemRef.LocalAddr = make(lang.Address, len(blockRef.LocalAddr))
 				copy(elemRef.LocalAddr, blockRef.LocalAddr)
 				elemRef.LocalAddr = append(elemRef.LocalAddr, lang.IndexStep{
 					Key: cty.NumberIntVal(int64(i)),
@@ -835,13 +838,14 @@ func (d *PathDecoder) collectInferredReferenceTargetsForBody(addr lang.Address, 
 
 		blockRef := reference.Target{
 			Addr:        blockAddr,
-			LocalAddr:   make(lang.Address, len(selfRefAddr)),
+			LocalAddr:   make(lang.Address, 0),
 			ScopeId:     bAddrSchema.ScopeId,
 			Type:        cty.Set(cty.Object(bodySchemaAsAttrTypes(bCollection.Schema.Body))),
 			Description: bCollection.Schema.Description,
 			RangePtr:    body.MissingItemRange().Ptr(),
 		}
 		if bAddrSchema.DependentBodySelfRef && selfRefBodyRangePtr != nil {
+			blockRef.LocalAddr = make(lang.Address, len(selfRefAddr))
 			copy(blockRef.LocalAddr, selfRefAddr)
 			blockRef.LocalAddr = append(blockRef.LocalAddr, lang.AttrStep{Name: bType})
 			blockRef.TargetableFromRangePtr = selfRefBodyRangePtr.Ptr()
@@ -873,13 +877,14 @@ func (d *PathDecoder) collectInferredReferenceTargetsForBody(addr lang.Address, 
 
 		blockRef := reference.Target{
 			Addr:        blockAddr,
-			LocalAddr:   make(lang.Address, len(selfRefAddr)),
+			LocalAddr:   make(lang.Address, 0),
 			ScopeId:     bAddrSchema.ScopeId,
 			Type:        cty.Map(cty.Object(bodySchemaAsAttrTypes(bCollection.Schema.Body))),
 			Description: bCollection.Schema.Description,
 			RangePtr:    body.MissingItemRange().Ptr(),
 		}
 		if bAddrSchema.DependentBodySelfRef && selfRefBodyRangePtr != nil {
+			blockRef.LocalAddr = make(lang.Address, len(selfRefAddr))
 			copy(blockRef.LocalAddr, selfRefAddr)
 			blockRef.LocalAddr = append(blockRef.LocalAddr, lang.AttrStep{Name: bType})
 			blockRef.TargetableFromRangePtr = selfRefBodyRangePtr.Ptr()
@@ -896,7 +901,7 @@ func (d *PathDecoder) collectInferredReferenceTargetsForBody(addr lang.Address, 
 
 			elemRef := reference.Target{
 				Addr:        elemAddr,
-				LocalAddr:   make(lang.Address, len(blockRef.LocalAddr)),
+				LocalAddr:   make(lang.Address, 0),
 				ScopeId:     bAddrSchema.ScopeId,
 				Type:        refType,
 				Description: bCollection.Schema.Description,
@@ -904,6 +909,7 @@ func (d *PathDecoder) collectInferredReferenceTargetsForBody(addr lang.Address, 
 				DefRangePtr: b.DefRange.Ptr(),
 			}
 			if bAddrSchema.DependentBodySelfRef && selfRefBodyRangePtr != nil {
+				elemRef.LocalAddr = make(lang.Address, len(blockRef.LocalAddr))
 				copy(elemRef.LocalAddr, blockRef.LocalAddr)
 				elemRef.LocalAddr = append(elemRef.LocalAddr, lang.IndexStep{
 					Key: cty.StringVal(b.Labels[0]),

--- a/decoder/reference_targets_collect_extensions_json_test.go
+++ b/decoder/reference_targets_collect_extensions_json_test.go
@@ -1,0 +1,271 @@
+package decoder
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/reference"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/json"
+	"github.com/zclconf/go-cty-debug/ctydebug"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestCollectReferenceTargets_extension_json(t *testing.T) {
+	testCases := []struct {
+		name         string
+		schema       *schema.BodySchema
+		cfg          string
+		expectedRefs reference.Targets
+	}{
+		{
+			"self references collection - list block",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource": {
+						Address: &schema.BlockAddrSchema{
+							Steps: schema.Address{
+								schema.LabelStep{Index: 0},
+								schema.LabelStep{Index: 1},
+							},
+							DependentBodyAsData:  true,
+							InferDependentBody:   true,
+							DependentBodySelfRef: true,
+						},
+						Labels: []*schema.LabelSchema{
+							{
+								Name:     "type",
+								IsDepKey: true,
+							},
+							{
+								Name: "name",
+							},
+						},
+						Body: schema.NewBodySchema(),
+						DependentBody: map[schema.SchemaKey]*schema.BodySchema{
+							schema.NewSchemaKey(schema.DependencyKeys{
+								Labels: []schema.LabelDependent{
+									{
+										Index: 0,
+										Value: "aws_instance",
+									},
+								},
+							}): {
+								Blocks: map[string]*schema.BlockSchema{
+									"foo": {
+										Type: schema.BlockTypeList,
+										Body: &schema.BodySchema{
+											Attributes: map[string]*schema.AttributeSchema{
+												"bar": {IsOptional: true, Expr: schema.LiteralTypeOnly(cty.Number)},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			`{
+  "resource": {
+    "aws_instance": {
+      "blah": {
+        "foo": {
+          "bar": 42
+        }
+      }
+    }
+  }
+}
+`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "aws_instance"},
+						lang.AttrStep{Name: "blah"},
+					},
+					LocalAddr: lang.Address{
+						lang.RootStep{Name: "self"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.tf.json",
+						Start: hcl.Pos{
+							Line:   4,
+							Column: 15,
+							Byte:   54,
+						},
+						End: hcl.Pos{
+							Line:   8,
+							Column: 8,
+							Byte:   110,
+						},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.tf.json",
+						Start: hcl.Pos{
+							Line:   4,
+							Column: 15,
+							Byte:   54,
+						},
+						End: hcl.Pos{
+							Line:   4,
+							Column: 16,
+							Byte:   55,
+						},
+					},
+					TargetableFromRangePtr: &hcl.Range{
+						Filename: "test.tf.json",
+						Start: hcl.Pos{
+							Line:   4,
+							Column: 15,
+							Byte:   54,
+						},
+						End: hcl.Pos{
+							Line:   8,
+							Column: 8,
+							Byte:   110,
+						},
+					},
+					Type: cty.Object(map[string]cty.Type{
+						"foo": cty.List(cty.Object(map[string]cty.Type{
+							"bar": cty.Number,
+						})),
+					}),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "aws_instance"},
+								lang.AttrStep{Name: "blah"},
+								lang.AttrStep{Name: "foo"},
+							},
+							LocalAddr: lang.Address{}, // no LocalAddr for JSON files
+							RangePtr: &hcl.Range{
+								Filename: "test.tf.json",
+								Start: hcl.Pos{
+									Line:   5,
+									Column: 16,
+									Byte:   71,
+								},
+								End: hcl.Pos{
+									Line:   7,
+									Column: 10,
+									Byte:   102,
+								},
+							},
+							Type: cty.List(cty.Object(map[string]cty.Type{
+								"bar": cty.Number,
+							})),
+							NestedTargets: reference.Targets{
+								{
+									Addr: lang.Address{
+										lang.RootStep{Name: "aws_instance"},
+										lang.AttrStep{Name: "blah"},
+										lang.AttrStep{Name: "foo"},
+										lang.IndexStep{Key: cty.NumberIntVal(0)},
+									},
+									LocalAddr: lang.Address{}, // no LocalAddr for JSON files
+									RangePtr: &hcl.Range{
+										Filename: "test.tf.json",
+										Start: hcl.Pos{
+											Line:   5,
+											Column: 16,
+											Byte:   71,
+										},
+										End: hcl.Pos{
+											Line:   7,
+											Column: 10,
+											Byte:   102,
+										},
+									},
+									DefRangePtr: &hcl.Range{
+										Filename: "test.tf.json",
+										Start: hcl.Pos{
+											Line:   5,
+											Column: 16,
+											Byte:   71,
+										},
+										End: hcl.Pos{
+											Line:   5,
+											Column: 17,
+											Byte:   72,
+										},
+									},
+									Type: cty.Object(map[string]cty.Type{
+										"bar": cty.Number,
+									}),
+									NestedTargets: reference.Targets{
+										{
+											Addr: lang.Address{
+												lang.RootStep{Name: "aws_instance"},
+												lang.AttrStep{Name: "blah"},
+												lang.AttrStep{Name: "foo"},
+												lang.IndexStep{Key: cty.NumberIntVal(0)},
+												lang.AttrStep{Name: "bar"},
+											},
+											LocalAddr: nil, // no LocalAddr for JSON files
+											RangePtr: &hcl.Range{
+												Filename: "test.tf.json",
+												Start: hcl.Pos{
+													Line:   6,
+													Column: 11,
+													Byte:   83,
+												},
+												End: hcl.Pos{
+													Line:   6,
+													Column: 20,
+													Byte:   92,
+												},
+											},
+											DefRangePtr: &hcl.Range{
+												Filename: "test.tf.json",
+												Start: hcl.Pos{
+													Line:   6,
+													Column: 11,
+													Byte:   83,
+												},
+												End: hcl.Pos{
+													Line:   6,
+													Column: 16,
+													Byte:   88,
+												},
+											},
+											Type: cty.Number,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {
+			f, diags := json.Parse([]byte(tc.cfg), "test.tf.json")
+			if len(diags) > 0 {
+				t.Fatal(diags)
+			}
+
+			d := testPathDecoder(t, &PathContext{
+				Schema: tc.schema,
+				Files: map[string]*hcl.File{
+					"test.tf.json": f,
+				},
+			})
+
+			refs, err := d.CollectReferenceTargets()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedRefs, refs, ctydebug.CmpOptions); diff != "" {
+				t.Fatalf("mismatch of references: %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Sometimes, we create local addresses with `nil` steps, and the LS crashes when iterating over those. This PR aims to fix that.

We don't get a body range for JSON-based configuration files, so we can never set the `TargetableFromRangePtr` for collected targets. 

https://github.com/hashicorp/hcl-lang/blob/4804a1caffd2d165978b0dc75ca4df6bd6ada14e/decoder/reference_targets.go#L687-L689

Without this pointer, we can't build a local address. So instead of trying to be clever and set a specific length, we now create all local addresses with a zero length.

Fixes https://github.com/hashicorp/vscode-terraform/issues/1338
Fixes https://github.com/hashicorp/terraform-ls/issues/1157