### PR TITLE
Add function signature types

### DIFF
--- a/decoder/path_context.go
+++ b/decoder/path_context.go
@@ -16,8 +16,7 @@ type PathContext struct {
 	ReferenceOrigins reference.Origins
 	ReferenceTargets reference.Targets
 	Files            map[string]*hcl.File
-
-	// TODO: Functions
+	Functions        map[string]schema.FunctionSignature
 }
 
 type pathCtxKey struct{}

--- a/schema/signature.go
+++ b/schema/signature.go
@@ -1,0 +1,24 @@
+package schema
+
+import (
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+)
+
+type FunctionSignature struct {
+	// Description is an optional human-readable description
+	// of the function.
+	Description string
+
+	// ReturnType is the ctyjson representation of the function's
+	// return types based on supplying all parameters using
+	// dynamic types. Functions can have dynamic return types.
+	ReturnType cty.Type
+
+	// Params describes the function's fixed positional parameters.
+	Params []function.Parameter
+
+	// VarParam describes the function's variadic
+	// parameter if it is supported.
+	VarParam *function.Parameter
+}


### PR DESCRIPTION
This PR extracts the function signature types from #135 to enable us to implement upstream changes in terraform-schema before completing the function signatures features as a whole.

We can use the new signature types to embed function signatures in terraform-schema.

---

* Part of https://github.com/hashicorp/terraform-ls/issues/37