### PR TITLE
decoder: Adjust `Constraint`.`ReferenceTargets` method args

### DIFF
--- a/decoder/expr_any.go
+++ b/decoder/expr_any.go
@@ -35,7 +35,7 @@ func (a Any) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference
 	return nil
 }
 
-func (a Any) ReferenceTargets(ctx context.Context, addr lang.Address, addrCtx AddressContext) reference.Targets {
+func (a Any) ReferenceTargets(ctx context.Context, targetCtx *TargetContext) reference.Targets {
 	// TODO
 	return nil
 }

--- a/decoder/expr_list.go
+++ b/decoder/expr_list.go
@@ -35,7 +35,7 @@ func (l List) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) referenc
 	return nil
 }
 
-func (l List) ReferenceTargets(ctx context.Context, addr lang.Address, addrCtx AddressContext) reference.Targets {
+func (l List) ReferenceTargets(ctx context.Context, targetCtx *TargetContext) reference.Targets {
 	// TODO
 	return nil
 }

--- a/decoder/expr_literal_type.go
+++ b/decoder/expr_literal_type.go
@@ -34,7 +34,7 @@ func (lt LiteralType) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) 
 	return nil
 }
 
-func (lt LiteralType) ReferenceTargets(ctx context.Context, addr lang.Address, addrCtx AddressContext) reference.Targets {
+func (lt LiteralType) ReferenceTargets(ctx context.Context, targetCtx *TargetContext) reference.Targets {
 	// TODO
 	return nil
 }

--- a/decoder/expr_map.go
+++ b/decoder/expr_map.go
@@ -35,7 +35,7 @@ func (m Map) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference
 	return nil
 }
 
-func (m Map) ReferenceTargets(ctx context.Context, addr lang.Address, addrCtx AddressContext) reference.Targets {
+func (m Map) ReferenceTargets(ctx context.Context, targetCtx *TargetContext) reference.Targets {
 	// TODO
 	return nil
 }

--- a/decoder/expr_object.go
+++ b/decoder/expr_object.go
@@ -35,7 +35,7 @@ func (obj Object) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) refe
 	return nil
 }
 
-func (obj Object) ReferenceTargets(ctx context.Context, addr lang.Address, addrCtx AddressContext) reference.Targets {
+func (obj Object) ReferenceTargets(ctx context.Context, targetCtx *TargetContext) reference.Targets {
 	// TODO
 	return nil
 }
@@ -65,7 +65,7 @@ func (oa ObjectAttributes) ReferenceOrigins(ctx context.Context, allowSelfRefs b
 	return nil
 }
 
-func (oa ObjectAttributes) ReferenceTargets(ctx context.Context, addr lang.Address, addrCtx AddressContext) reference.Targets {
+func (oa ObjectAttributes) ReferenceTargets(ctx context.Context, targetCtx *TargetContext) reference.Targets {
 	// TODO
 	return nil
 }

--- a/decoder/expr_one_of.go
+++ b/decoder/expr_one_of.go
@@ -35,7 +35,7 @@ func (oo OneOf) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) refere
 	return nil
 }
 
-func (oo OneOf) ReferenceTargets(ctx context.Context, addr lang.Address, addrCtx AddressContext) reference.Targets {
+func (oo OneOf) ReferenceTargets(ctx context.Context, targetCtx *TargetContext) reference.Targets {
 	// TODO
 	return nil
 }

--- a/decoder/expr_reference.go
+++ b/decoder/expr_reference.go
@@ -34,7 +34,7 @@ func (ref Reference) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) r
 	return nil
 }
 
-func (ref Reference) ReferenceTargets(ctx context.Context, addr lang.Address, addrCtx AddressContext) reference.Targets {
+func (ref Reference) ReferenceTargets(ctx context.Context, targetCtx *TargetContext) reference.Targets {
 	// TODO
 	return nil
 }

--- a/decoder/expr_tuple.go
+++ b/decoder/expr_tuple.go
@@ -35,7 +35,7 @@ func (t Tuple) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) referen
 	return nil
 }
 
-func (t Tuple) ReferenceTargets(ctx context.Context, addr lang.Address, addrCtx AddressContext) reference.Targets {
+func (t Tuple) ReferenceTargets(ctx context.Context, targetCtx *TargetContext) reference.Targets {
 	// TODO
 	return nil
 }

--- a/decoder/expression.go
+++ b/decoder/expression.go
@@ -50,8 +50,8 @@ type TargetContext struct {
 	// is addressable as a type-less reference
 	AsReference bool
 
-	// AttributeAddress represents resolved address for the attribute
-	// which the expression belongs to.
+	// AttributeAddress represents a resolved address for the attribute
+	// to which the expression belongs.
 	AttributeAddress lang.Address
 }
 

--- a/decoder/expression.go
+++ b/decoder/expression.go
@@ -24,11 +24,11 @@ type ReferenceOriginsExpression interface {
 }
 
 type ReferenceTargetsExpression interface {
-	ReferenceTargets(ctx context.Context, addr lang.Address, addrCtx AddressContext) reference.Targets
+	ReferenceTargets(ctx context.Context, targetCtx *TargetContext) reference.Targets
 }
 
-// AddressContext describes context for collecting reference targets
-type AddressContext struct {
+// TargetContext describes context for collecting reference targets
+type TargetContext struct {
 	// FriendlyName is (optional) human-readable name of the expression
 	// interpreted as reference target.
 	FriendlyName string
@@ -49,6 +49,10 @@ type AddressContext struct {
 	// AsReference defines whether the attribute
 	// is addressable as a type-less reference
 	AsReference bool
+
+	// AttributeAddress represents resolved address for the attribute
+	// which the expression belongs to.
+	AttributeAddress lang.Address
 }
 
 func (d *PathDecoder) newExpression(expr hcl.Expression, cons schema.Constraint) Expression {

--- a/decoder/reference_targets.go
+++ b/decoder/reference_targets.go
@@ -274,19 +274,21 @@ func (d *PathDecoder) decodeReferenceTargetsForAttribute(attr *hcl.Attribute, at
 	if attrSchema.Constraint != nil {
 		expr := d.newExpression(attr.Expr, attrSchema.Constraint)
 		if eType, ok := expr.(ReferenceTargetsExpression); ok {
-			addrCtx := AddressContext{
-				FriendlyName: attrSchema.Address.FriendlyName,
-				ScopeId:      attrSchema.Address.ScopeId,
-				AsExprType:   attrSchema.Address.AsExprType,
-				AsReference:  attrSchema.Address.AsReference,
+			var targetCtx *TargetContext
+			if attrSchema.Address != nil {
+				attrAddr, ok := resolveAttributeAddress(attr, attrSchema.Address.Steps)
+				if ok {
+					targetCtx = &TargetContext{
+						FriendlyName:     attrSchema.Address.FriendlyName,
+						ScopeId:          attrSchema.Address.ScopeId,
+						AsExprType:       attrSchema.Address.AsExprType,
+						AsReference:      attrSchema.Address.AsReference,
+						AttributeAddress: attrAddr,
+					}
+				}
 			}
 
-			attrAddr, ok := resolveAttributeAddress(attr, attrSchema.Address.Steps)
-			if !ok {
-				attrAddr = make(lang.Address, 0)
-			}
-
-			refs = append(refs, eType.ReferenceTargets(ctx, attrAddr, addrCtx)...)
+			refs = append(refs, eType.ReferenceTargets(ctx, targetCtx)...)
 		}
 	} else {
 		if attrSchema.Address != nil {


### PR DESCRIPTION
The new interface better reflects a scenario where expression can be targeted by itself, but not the attribute. In Terraform this may occur in `required_providers` > `configuration_aliases` where entries are targetable provider names, but configuration_aliases attribute is not.

In that ^ scenario the expected schema would be e.g.

```go
"configuration_aliases": &schema.AttributeSchema{
	Constraint: schema.Set{
		Elem: schema.Reference{
				Address: &schema.ReferenceAddrSchema{
					ScopeId: refscope.ProviderScope,
				},
				Name: "provider",
			},
		},
	},
},
```
i.e. there would be no `Address` set on the `AttributeSchema`.

I renamed `AddressContext` to `TargetContext` as per earlier discussion in a different PR about lots of things called "address". Hopefully this is a better name 🤞🏻 

Finally, the change in moving resolved attribute address into the `TargetContext` reflects the existing assumption that there's no point in collecting targets within the expression if the address is unresolvable and reduces the number of arguments down to 2.