### PR TITLE
decoder: reflect `Constraint` when collecting `AsTypeOf` reference targets

### DIFF
--- a/decoder/reference_targets.go
+++ b/decoder/reference_targets.go
@@ -499,12 +499,21 @@ func asTypeOfAttrExpr(attrs hcl.Attributes, bSchema *schema.BlockSchema) (cty.Ty
 		return cty.DynamicPseudoType, false
 	}
 
-	ec := ExprConstraints(bSchema.Body.Attributes[attrName].Expr)
-	_, ok = ec.TypeDeclarationExpr()
-	if !ok {
-		return cty.DynamicPseudoType, false
+	aSchema := bSchema.Body.Attributes[attrName]
+	if aSchema.Constraint != nil {
+		_, ok := aSchema.Constraint.(schema.TypeDeclaration)
+		if !ok {
+			return cty.DynamicPseudoType, false
+		}
+	} else {
+		ec := ExprConstraints(aSchema.Expr)
+		_, ok = ec.TypeDeclarationExpr()
+		if !ok {
+			return cty.DynamicPseudoType, false
+		}
 	}
 
+	// TODO: TypeConstraintWithDefaults
 	typeDecl, diags := typeexpr.TypeConstraint(attr.Expr)
 	if diags.HasErrors() {
 		return cty.DynamicPseudoType, false

--- a/schema/constraint_type_declaration.go
+++ b/schema/constraint_type_declaration.go
@@ -3,7 +3,9 @@ package schema
 // TypeDeclaration represents a type declaration as
 // interpreted by HCL's ext/typeexpr package,
 // i.e. declaration of cty.Type in HCL
-type TypeDeclaration struct{}
+type TypeDeclaration struct {
+	// TODO: optional object attribute mode
+}
 
 func (TypeDeclaration) isConstraintImpl() constraintSigil {
 	return constraintSigil{}


### PR DESCRIPTION
This was forgotten in the big diff of https://github.com/hashicorp/hcl-lang/pull/177

It is the reason why `var.*` reference targets collected for `variable` blocks in https://github.com/hashicorp/hcl-lang/pull/183 get collected as `dynamic` (unknown/any type).

I also left a note about optional object attributes as that will be implemented as part of https://github.com/hashicorp/terraform-ls/issues/917