### PR TITLE
schema: Introduce `EmptyHoverData()` to `Constraint`

### DIFF
--- a/schema/constraint.go
+++ b/schema/constraint.go
@@ -1,6 +1,9 @@
 package schema
 
-import "github.com/zclconf/go-cty/cty"
+import (
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/zclconf/go-cty/cty"
+)
 
 type constraintSigil struct{}
 
@@ -8,12 +11,23 @@ type Constraint interface {
 	isConstraintImpl() constraintSigil
 	FriendlyName() string
 	Copy() Constraint
-	// EmptyCompletionData provides completion data (to be used in text edits),
-	// with snippet placeholder identifiers such as ${4} (if any) starting
-	// from given nextPlaceholder.
-	// 1 is the most appropriate placeholder, if none were yet assigned prior
-	// to rendering completion data for this constraint (e.g. map key).
+
+	// EmptyCompletionData provides completion data in context where
+	// there is no corresponding configuration, such as when the Constraint
+	// is part of another and it is desirable to complete
+	// the parent constraint as whole.
 	EmptyCompletionData(nextPlaceholder int) CompletionData
+}
+
+type ConstraintWithHoverData interface {
+	// EmptyHoverData provides hover data in context where there is
+	// no corresponding configuration, such as when the Constraint
+	// is part of another and more detailed hover data is requested
+	// for the parent.
+	//
+	// This enables e.g. rendering attributes under Object rather
+	// than just "object".
+	EmptyHoverData() *HoverData
 }
 
 type Validatable interface {
@@ -29,8 +43,17 @@ type Comparable interface {
 }
 
 type CompletionData struct {
-	NewText         string
-	Snippet         string
+	NewText string
+
+	// Snippet represents text to be inserted via text edits,
+	// with snippet placeholder identifiers such as ${1} (if any) starting
+	// from given nextPlaceholder (provided as arg to EmptyCompletionData).
+	Snippet string
+
 	TriggerSuggest  bool
 	LastPlaceholder int
+}
+
+type HoverData struct {
+	Content lang.MarkupContent
 }

--- a/schema/constraint_list.go
+++ b/schema/constraint_list.go
@@ -51,3 +51,8 @@ func (l List) EmptyCompletionData(nextPlaceholder int) CompletionData {
 	// TODO
 	return CompletionData{}
 }
+
+func (l List) EmptyHoverData() *HoverData {
+	// TODO
+	return nil
+}

--- a/schema/constraint_literal_type.go
+++ b/schema/constraint_literal_type.go
@@ -36,3 +36,8 @@ func (lt LiteralType) EmptyCompletionData(nextPlaceholder int) CompletionData {
 	// TODO
 	return CompletionData{}
 }
+
+func (lt LiteralType) EmptyHoverData() *HoverData {
+	// TODO
+	return nil
+}

--- a/schema/constraint_literal_value.go
+++ b/schema/constraint_literal_value.go
@@ -37,3 +37,8 @@ func (lv LiteralValue) EmptyCompletionData(nextPlaceholder int) CompletionData {
 	// TODO
 	return CompletionData{}
 }
+
+func (lv LiteralValue) EmptyHoverData() *HoverData {
+	// TODO
+	return nil
+}

--- a/schema/constraint_map.go
+++ b/schema/constraint_map.go
@@ -58,3 +58,8 @@ func (m Map) EmptyCompletionData(nextPlaceholder int) CompletionData {
 	// TODO
 	return CompletionData{}
 }
+
+func (m Map) EmptyHoverData() *HoverData {
+	// TODO
+	return nil
+}

--- a/schema/constraint_object.go
+++ b/schema/constraint_object.go
@@ -43,6 +43,11 @@ func (o Object) EmptyCompletionData(placeholder int) CompletionData {
 	return CompletionData{}
 }
 
+func (o Object) EmptyHoverData() *HoverData {
+	// TODO
+	return nil
+}
+
 func (ObjectAttributes) isConstraintImpl() constraintSigil {
 	return constraintSigil{}
 }
@@ -62,4 +67,9 @@ func (oa ObjectAttributes) Copy() Constraint {
 func (oa ObjectAttributes) EmptyCompletionData(nextPlaceholder int) CompletionData {
 	// TODO
 	return CompletionData{}
+}
+
+func (oa ObjectAttributes) EmptyHoverData() *HoverData {
+	// TODO
+	return nil
 }

--- a/schema/constraint_set.go
+++ b/schema/constraint_set.go
@@ -51,3 +51,8 @@ func (s Set) EmptyCompletionData(nextPlaceholder int) CompletionData {
 	// TODO
 	return CompletionData{}
 }
+
+func (s Set) EmptyHoverData() *HoverData {
+	// TODO
+	return nil
+}

--- a/schema/constraint_test.go
+++ b/schema/constraint_test.go
@@ -13,4 +13,13 @@ var (
 	_ Constraint = Reference{}
 	_ Constraint = Tuple{}
 	_ Constraint = TypeDeclaration{}
+
+	_ ConstraintWithHoverData = List{}
+	_ ConstraintWithHoverData = LiteralType{}
+	_ ConstraintWithHoverData = LiteralValue{}
+	_ ConstraintWithHoverData = Map{}
+	_ ConstraintWithHoverData = ObjectAttributes{}
+	_ ConstraintWithHoverData = Object{}
+	_ ConstraintWithHoverData = Set{}
+	_ ConstraintWithHoverData = Tuple{}
 )

--- a/schema/constraint_tuple.go
+++ b/schema/constraint_tuple.go
@@ -41,3 +41,8 @@ func (t Tuple) EmptyCompletionData(nextPlaceholder int) CompletionData {
 	// TODO
 	return CompletionData{}
 }
+
+func (t Tuple) EmptyHoverData() *HoverData {
+	// TODO
+	return nil
+}


### PR DESCRIPTION
Similar to the existing `EmptyCompletionData()`, in some contexts it feels more appropriate to display something more helpful than just short "friendly name" for the type.

The friendly name is still relevant to display e.g. next to the completion item, where there is no space for more details.

We could potentially use this also when displaying hover for attributes, where we currently use just `FriendlyName()`, but I'd leave that for another discussion later.

The aim is to be able to mimic the existing hover data for complex `LiteralType` constraints.

I also used the pointer (`*HoverData`) just so that we could also still decide at runtime in each constraint whether or not to return hover data. This is because e.g.`List` or `Set` may behave differently depending on the Constraints of its elements.

Similar logic could in theory apply to `EmptyCompletionData()` - i.e. one could argue we should also be returning a pointer there, but the added complexity there is that we also use that when pre-filling required fields and in that context we don't really have any reasonable fallback, such as `FriendlyName()`. We could fall back to just empty string, but I'm not sure that's always appropriate as we would end up generating grossly incomplete configuration with lots of trailing `=` which may be harder to navigate and produce a lot of diagnostics. Maybe the ideal solution here is to have another method for pre-filling required fields. 🤷🏻 