### PR TITLE
decoder: Introduce helper functions for completion inside `ObjectConsExpr`

### DIFF
--- a/decoder/expression.go
+++ b/decoder/expression.go
@@ -197,3 +197,10 @@ func recoverLeftBytes(b []byte, pos hcl.Pos, f func(byteOffset int, r rune) bool
 
 	return []byte{}
 }
+
+// isObjectItemTerminatingRune returns true if the given rune
+// is considered a left terminating character for an item
+// in hclsyntax.ObjectConsExpr.
+func isObjectItemTerminatingRune(r rune) bool {
+	return r == '\n' || r == ',' || r == '{'
+}

--- a/decoder/expression.go
+++ b/decoder/expression.go
@@ -176,11 +176,11 @@ func newEmptyExpressionAtPos(filename string, pos hcl.Pos) hcl.Expression {
 //
 // Zero bytes is returned if no match was found.
 func recoverLeftBytes(b []byte, pos hcl.Pos, f func(byteOffset int, r rune) bool) []byte {
-	lastRune, size := utf8.DecodeLastRune(b[:pos.Byte])
+	firstRune, size := utf8.DecodeLastRune(b[:pos.Byte])
 	offset := pos.Byte - size
 
 	// check for early match
-	if f(pos.Byte, lastRune) {
+	if f(pos.Byte, firstRune) {
 		return b[offset:pos.Byte]
 	}
 


### PR DESCRIPTION
This PR introduces two small helper functions decoupled from a few discovered use cases / PRs:

 - https://github.com/hashicorp/hcl-lang/pull/183 (for `object({ ... })`)
 - https://github.com/hashicorp/hcl-lang/pull/186 (through `Object` or `Map`)
 - https://github.com/hashicorp/hcl-lang/pull/199
 - https://github.com/hashicorp/hcl-lang/pull/203
 - it's also expected to be useful in `AnyExpression` constraint

The last attached test case illustrates an example of the problem.

--- 

### Implementation Notes

Our use cases don't _actually_ involve multi-byte runes, so in theory we could be just comparing single bytes and avoid the decoding, but that then makes the consumer side a bit more verbose since `'\n'` would need to be written e.g. as `byte('\n')`. We could technically allow runes and treat them like single bytes, but that just feels wrong.

Since we'd usually seek through relatively small slice, the decoding is unlikely to pose performance issue, but we can revisit the solution if it does.