### PR TITLE
schema: Introduce `nestingLevel` to `Constraint`.`EmptyHoverData()`

### DIFF
--- a/schema/constraint.go
+++ b/schema/constraint.go
@@ -27,7 +27,7 @@ type ConstraintWithHoverData interface {
 	//
 	// This enables e.g. rendering attributes under Object rather
 	// than just "object".
-	EmptyHoverData() *HoverData
+	EmptyHoverData(nestingLevel int) *HoverData
 }
 
 type Validatable interface {

--- a/schema/constraint_list.go
+++ b/schema/constraint_list.go
@@ -52,7 +52,7 @@ func (l List) EmptyCompletionData(nextPlaceholder int) CompletionData {
 	return CompletionData{}
 }
 
-func (l List) EmptyHoverData() *HoverData {
+func (l List) EmptyHoverData(nestingLevel int) *HoverData {
 	// TODO
 	return nil
 }

--- a/schema/constraint_literal_type.go
+++ b/schema/constraint_literal_type.go
@@ -37,7 +37,7 @@ func (lt LiteralType) EmptyCompletionData(nextPlaceholder int) CompletionData {
 	return CompletionData{}
 }
 
-func (lt LiteralType) EmptyHoverData() *HoverData {
+func (lt LiteralType) EmptyHoverData(nestingLevel int) *HoverData {
 	// TODO
 	return nil
 }

--- a/schema/constraint_literal_value.go
+++ b/schema/constraint_literal_value.go
@@ -38,7 +38,7 @@ func (lv LiteralValue) EmptyCompletionData(nextPlaceholder int) CompletionData {
 	return CompletionData{}
 }
 
-func (lv LiteralValue) EmptyHoverData() *HoverData {
+func (lv LiteralValue) EmptyHoverData(nestingLevel int) *HoverData {
 	// TODO
 	return nil
 }

--- a/schema/constraint_map.go
+++ b/schema/constraint_map.go
@@ -59,7 +59,7 @@ func (m Map) EmptyCompletionData(nextPlaceholder int) CompletionData {
 	return CompletionData{}
 }
 
-func (m Map) EmptyHoverData() *HoverData {
+func (m Map) EmptyHoverData(nestingLevel int) *HoverData {
 	// TODO
 	return nil
 }

--- a/schema/constraint_object.go
+++ b/schema/constraint_object.go
@@ -43,7 +43,7 @@ func (o Object) EmptyCompletionData(placeholder int) CompletionData {
 	return CompletionData{}
 }
 
-func (o Object) EmptyHoverData() *HoverData {
+func (o Object) EmptyHoverData(nestingLevel int) *HoverData {
 	// TODO
 	return nil
 }
@@ -69,7 +69,7 @@ func (oa ObjectAttributes) EmptyCompletionData(nextPlaceholder int) CompletionDa
 	return CompletionData{}
 }
 
-func (oa ObjectAttributes) EmptyHoverData() *HoverData {
+func (oa ObjectAttributes) EmptyHoverData(nestingLevel int) *HoverData {
 	// TODO
 	return nil
 }

--- a/schema/constraint_set.go
+++ b/schema/constraint_set.go
@@ -52,7 +52,7 @@ func (s Set) EmptyCompletionData(nextPlaceholder int) CompletionData {
 	return CompletionData{}
 }
 
-func (s Set) EmptyHoverData() *HoverData {
+func (s Set) EmptyHoverData(nestingLevel int) *HoverData {
 	// TODO
 	return nil
 }

--- a/schema/constraint_tuple.go
+++ b/schema/constraint_tuple.go
@@ -42,7 +42,7 @@ func (t Tuple) EmptyCompletionData(nextPlaceholder int) CompletionData {
 	return CompletionData{}
 }
 
-func (t Tuple) EmptyHoverData() *HoverData {
+func (t Tuple) EmptyHoverData(nestingLevel int) *HoverData {
 	// TODO
 	return nil
 }


### PR DESCRIPTION
When rendering parts of hover data, esp. for constraints which are likely to span multiple lines and contain more nested constraints under them (e.g. objects), it is useful to produce hover data which are already correctly nested according to the parent expression.

This aligns with how we render hover data currently in https://github.com/hashicorp/hcl-lang/blob/6302afc62e3512cd825e75d3f8c1e7c162c31548/decoder/hover.go#L478-L555