### PR TITLE
decoder: Introduce rawObjectKey to extract raw keys

### DIFF
--- a/decoder/expression_test.go
+++ b/decoder/expression_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 	"unicode"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 )
 
 var (
@@ -92,6 +94,111 @@ func TestRecoverLeftBytes(t *testing.T) {
 			recoveredBytes := recoverLeftBytes(tc.b, tc.pos, tc.f)
 			if !bytes.Equal(tc.expectedBytes, recoveredBytes) {
 				t.Fatalf("mismatch!\nexpected:  %q\nrecovered: %q\n", string(tc.expectedBytes), string(recoveredBytes))
+			}
+		})
+	}
+}
+
+func TestRawObjectKey(t *testing.T) {
+	testCases := []struct {
+		cfg           string
+		expectedKey   string
+		expectedRange *hcl.Range
+		expectedOk    bool
+	}{
+		{
+			`attr = { foo = "bar" }`,
+			"foo",
+			&hcl.Range{
+				Filename: "test.hcl",
+				Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+				End:      hcl.Pos{Line: 1, Column: 13, Byte: 12},
+			},
+			true,
+		},
+		{
+			`attr = { 42 = "bar" }`,
+			"",
+			nil,
+			false,
+		},
+		{
+			`attr = { foo.x = "bar" }`,
+			"",
+			nil,
+			false,
+		},
+		{
+			`attr = { (foo) = "bar" }`,
+			"",
+			nil,
+			false,
+		},
+		{
+			`attr = { (var.foo) = "bar" }`,
+			"",
+			nil,
+			false,
+		},
+		{
+			`attr = { "foo" = "bar" }`,
+			"foo",
+			&hcl.Range{
+				Filename: "test.hcl",
+				Start:    hcl.Pos{Line: 1, Column: 11, Byte: 10},
+				End:      hcl.Pos{Line: 1, Column: 14, Byte: 13},
+			},
+			true,
+		},
+		{
+			`attr = { "${foo}" = "bar" }`,
+			"",
+			nil,
+			false,
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			f, diags := hclsyntax.ParseConfig([]byte(tc.cfg), "test.hcl", hcl.InitialPos)
+			if len(diags) > 0 {
+				t.Fatal(diags)
+			}
+
+			attrs, diags := f.Body.JustAttributes()
+			if len(diags) > 0 {
+				t.Fatal(diags)
+			}
+
+			if len(attrs) != 1 {
+				t.Fatalf("expected exactly 1 attribute, %d given", len(attrs))
+			}
+
+			attr, ok := attrs["attr"]
+			if !ok {
+				t.Fatalf("expected to find attribute %q", "attr")
+			}
+
+			objConsExpr, ok := attr.Expr.(*hclsyntax.ObjectConsExpr)
+			if !ok {
+				t.Fatalf("expected expression to be ObjectConsExpr, %T given", attr.Expr)
+			}
+
+			if len(objConsExpr.Items) != 1 {
+				t.Fatalf("expected exactly 1 object item, %d given", len(objConsExpr.Items))
+			}
+
+			rawKey, rng, ok := rawObjectKey(objConsExpr.Items[0].KeyExpr)
+			if !tc.expectedOk && ok {
+				t.Fatal("expected parsing to fail")
+			}
+			if tc.expectedOk && !ok {
+				t.Fatal("expected parsing to succeed")
+			}
+			if tc.expectedKey != rawKey {
+				t.Fatalf("extracted key mismatch\nexpected: %q\ngiven: %q", tc.expectedKey, rawKey)
+			}
+			if diff := cmp.Diff(tc.expectedRange, rng); diff != "" {
+				t.Fatalf("unexpected range: %s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
As per in-line comment:

```go
// rawObjectKey extracts raw key (as string) from KeyExpr of
// any hclsyntax.ObjectConsExpr along with the corresponding range
// and boolean indicating whether the extraction was successful.
```

This is expected to be used in any expression type that involves `ObjectConsExpr`, i.e.

 - https://github.com/hashicorp/hcl-lang/pull/203
 - https://github.com/hashicorp/hcl-lang/pull/199
 - https://github.com/hashicorp/hcl-lang/pull/183

for validating keys before reporting them as semantic tokens, or to isolate the unquoted part which in turn enables validation/lookup of the attribute name in case of an object. Range then allows us to also extract the prefix for any necessary filtering when doing completion for the whole attribute.