### PR TITLE
schema: Replace `Comparable` w/ `TypeAwareConstraint`

### DIFF
--- a/decoder/expression_candidates.go
+++ b/decoder/expression_candidates.go
@@ -240,8 +240,13 @@ func isMultilineTemplateExpr(expr hclsyntax.Expression) bool {
 func (d *PathDecoder) candidatesFromHooks(ctx context.Context, attr *hclsyntax.Attribute, aSchema *schema.AttributeSchema, outerBodyRng hcl.Range, pos hcl.Pos) []lang.Candidate {
 	candidates := make([]lang.Candidate, 0)
 	if aSchema.Constraint != nil {
-		con, ok := aSchema.Constraint.(schema.Comparable)
-		if !ok || !con.IsCompatible(cty.String) {
+		con, ok := aSchema.Constraint.(schema.TypeAwareConstraint)
+		if !ok {
+			// Return early as we only support string values for now
+			return candidates
+		}
+		typ, ok := con.ConstraintType()
+		if !ok || typ != cty.String {
 			// Return early as we only support string values for now
 			return candidates
 		}

--- a/schema/constraint.go
+++ b/schema/constraint.go
@@ -34,12 +34,15 @@ type Validatable interface {
 	Validate() error
 }
 
-// Comparable represents a constraint which is type-aware,
-// making it possible to compare a given type for conformity.
+// TypeAwareConstraint represents a constraint which may be type-aware.
+// Most constraints which implement this are always type-aware,
+// but for some this is runtime concern depending on the configuration.
 //
-// This can affect completion hooks.
-type Comparable interface {
-	IsCompatible(typ cty.Type) bool
+// This makes it comparable to another type for conformity during completion
+// and it enables collection of type-aware reference target, if the attribute
+// itself is targetable as type-aware.
+type TypeAwareConstraint interface {
+	ConstraintType() (cty.Type, bool)
 }
 
 type CompletionData struct {

--- a/schema/constraint_any_expression.go
+++ b/schema/constraint_any_expression.go
@@ -32,3 +32,8 @@ func (ae AnyExpression) EmptyCompletionData(nextPlaceholder int) CompletionData 
 	// TODO
 	return CompletionData{}
 }
+
+func (ae AnyExpression) ConstraintType() (cty.Type, bool) {
+	// TODO
+	return cty.NilType, false
+}

--- a/schema/constraint_list.go
+++ b/schema/constraint_list.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/zclconf/go-cty/cty"
 )
 
 // List represents a list, equivalent of hclsyntax.TupleConsExpr
@@ -55,4 +56,9 @@ func (l List) EmptyCompletionData(nextPlaceholder int) CompletionData {
 func (l List) EmptyHoverData(nestingLevel int) *HoverData {
 	// TODO
 	return nil
+}
+
+func (l List) ConstraintType() (cty.Type, bool) {
+	// TODO
+	return cty.NilType, false
 }

--- a/schema/constraint_literal_type.go
+++ b/schema/constraint_literal_type.go
@@ -41,3 +41,7 @@ func (lt LiteralType) EmptyHoverData(nestingLevel int) *HoverData {
 	// TODO
 	return nil
 }
+
+func (lt LiteralType) ConstraintType() (cty.Type, bool) {
+	return lt.Type, true
+}

--- a/schema/constraint_literal_value.go
+++ b/schema/constraint_literal_value.go
@@ -42,3 +42,7 @@ func (lv LiteralValue) EmptyHoverData(nestingLevel int) *HoverData {
 	// TODO
 	return nil
 }
+
+func (lv LiteralValue) ConstraintType() (cty.Type, bool) {
+	return lv.Value.Type(), true
+}

--- a/schema/constraint_map.go
+++ b/schema/constraint_map.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/zclconf/go-cty/cty"
 )
 
 // Map represents a map, equivalent of hclsyntax.ObjectConsExpr
@@ -62,4 +63,9 @@ func (m Map) EmptyCompletionData(nextPlaceholder int) CompletionData {
 func (m Map) EmptyHoverData(nestingLevel int) *HoverData {
 	// TODO
 	return nil
+}
+
+func (m Map) ConstraintType() (cty.Type, bool) {
+	// TODO
+	return cty.NilType, false
 }

--- a/schema/constraint_object.go
+++ b/schema/constraint_object.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/zclconf/go-cty/cty"
 )
 
 // Object represents an object, equivalent of hclsyntax.ObjectConsExpr
@@ -46,6 +47,11 @@ func (o Object) EmptyCompletionData(placeholder int) CompletionData {
 func (o Object) EmptyHoverData(nestingLevel int) *HoverData {
 	// TODO
 	return nil
+}
+
+func (o Object) ConstraintType() (cty.Type, bool) {
+	// TODO
+	return cty.NilType, false
 }
 
 func (ObjectAttributes) isConstraintImpl() constraintSigil {

--- a/schema/constraint_set.go
+++ b/schema/constraint_set.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/zclconf/go-cty/cty"
 )
 
 // Set represents a set, equivalent of hclsyntax.TupleConsExpr
@@ -55,4 +56,9 @@ func (s Set) EmptyCompletionData(nextPlaceholder int) CompletionData {
 func (s Set) EmptyHoverData(nestingLevel int) *HoverData {
 	// TODO
 	return nil
+}
+
+func (s Set) ConstraintType() (cty.Type, bool) {
+	// TODO
+	return cty.NilType, false
 }

--- a/schema/constraint_test.go
+++ b/schema/constraint_test.go
@@ -22,4 +22,13 @@ var (
 	_ ConstraintWithHoverData = Object{}
 	_ ConstraintWithHoverData = Set{}
 	_ ConstraintWithHoverData = Tuple{}
+
+	_ TypeAwareConstraint = AnyExpression{}
+	_ TypeAwareConstraint = List{}
+	_ TypeAwareConstraint = LiteralType{}
+	_ TypeAwareConstraint = LiteralValue{}
+	_ TypeAwareConstraint = Map{}
+	_ TypeAwareConstraint = Object{}
+	_ TypeAwareConstraint = Set{}
+	_ TypeAwareConstraint = Tuple{}
 )

--- a/schema/constraint_tuple.go
+++ b/schema/constraint_tuple.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/zclconf/go-cty/cty"
 )
 
 // Tuple represents a tuple, equivalent of hclsyntax.TupleConsExpr
@@ -45,4 +46,9 @@ func (t Tuple) EmptyCompletionData(nextPlaceholder int) CompletionData {
 func (t Tuple) EmptyHoverData(nestingLevel int) *HoverData {
 	// TODO
 	return nil
+}
+
+func (t Tuple) ConstraintType() (cty.Type, bool) {
+	// TODO
+	return cty.NilType, false
 }


### PR DESCRIPTION
As illustrated by the diff and some conversation in the original PR https://github.com/hashicorp/hcl-lang/pull/177#issuecomment-1376190653 the plan was for `Comparable` to allow completion hooks to tell whether the constraint is string-compatible (and potentially other type compatible later).

One more use case / problem emerged where we'll need to collect `Object` or `Map` (or `Set`, `List`, `Tuple`) as type-aware reference targets (assuming we intend to use them also as part of `LiteralType` and `LiteralValue`) and we need to know the corresponding type of the nested element/attribute.

--- 

I originally had the interface like this

```go
type TypeAwareConstraint interface {
	ConstraintType() cty.Type
}
```
until I realised that this just won't work e.g. for `OneOf` which can only determine type awareness depending on the configuration, once it matches it to a specific `Constraint`. We also wouldn't be able to treat all the complex types as type-aware at compile time, as these may be e.g. `Map{Elem: Keyword{}}` and so we don't know whether they're type-aware until we check the nested constraints. Hence the `bool`.

--- 

I don't know whether this will be useful in the context of https://github.com/hashicorp/terraform-ls/issues/583 but we'll cross the bridge when we come to it.