### PR TITLE
decoder: Introduce `ParentLocalAddress` to `TargetContext`

### DIFF
--- a/decoder/expression.go
+++ b/decoder/expression.go
@@ -72,13 +72,23 @@ func (tctx *TargetContext) Copy() *TargetContext {
 	if tctx == nil {
 		return nil
 	}
-	return &TargetContext{
+
+	newCtx := &TargetContext{
 		FriendlyName:  tctx.FriendlyName,
 		ScopeId:       tctx.ScopeId,
 		AsExprType:    tctx.AsExprType,
 		AsReference:   tctx.AsReference,
 		ParentAddress: tctx.ParentAddress.Copy(),
 	}
+
+	if tctx.ParentLocalAddress != nil {
+		newCtx.ParentLocalAddress = tctx.ParentLocalAddress.Copy()
+	}
+	if tctx.TargetableFromRangePtr != nil {
+		newCtx.TargetableFromRangePtr = tctx.TargetableFromRangePtr.Ptr()
+	}
+
+	return newCtx
 }
 
 func (d *PathDecoder) newExpression(expr hcl.Expression, cons schema.Constraint) Expression {

--- a/decoder/expression.go
+++ b/decoder/expression.go
@@ -51,10 +51,21 @@ type TargetContext struct {
 	// is addressable as a type-less reference
 	AsReference bool
 
-	// ParentAddress represents a resolved "parent" address.
+	// ParentAddress represents a resolved "parent" absolute address,
+	// such as data.aws_instance.foo.attr_name.
 	// This may be address of the attribute, or implied element/item address
 	// for complex-type expressions such as object, list, map etc.
 	ParentAddress lang.Address
+
+	// ParentLocalAddress represents a resolved "parent" local address,
+	// such as self.attr_name.
+	// This may be address of the attribute, or implied element/item address
+	// for complex-type expressions such as object, list, map etc.
+	ParentLocalAddress lang.Address
+
+	// TargetableFromRangePtr defines where the target is locally targetable
+	// from via the ParentLocalAddress.
+	TargetableFromRangePtr *hcl.Range
 }
 
 func (tctx *TargetContext) Copy() *TargetContext {


### PR DESCRIPTION
This uncovered another part of the codebase which was yet to be adapted to `Constraint`s, which is collection of inferred targets, i.e. targets which have their address inferred from the parent block, as opposed explicitly within the attribute schema.

In addition to the introduction of the new fields, the reference target collection logic is being updated in a backwards-compatible way.