### PR TITLE
schema: Implement `ConstraintType()` for all remaining constraints

### DIFF
--- a/schema/constraint_any_expression.go
+++ b/schema/constraint_any_expression.go
@@ -34,6 +34,5 @@ func (ae AnyExpression) EmptyCompletionData(nextPlaceholder int) CompletionData 
 }
 
 func (ae AnyExpression) ConstraintType() (cty.Type, bool) {
-	// TODO
-	return cty.NilType, false
+	return ae.OfType, true
 }

--- a/schema/constraint_list.go
+++ b/schema/constraint_list.go
@@ -59,6 +59,19 @@ func (l List) EmptyHoverData(nestingLevel int) *HoverData {
 }
 
 func (l List) ConstraintType() (cty.Type, bool) {
-	// TODO
-	return cty.NilType, false
+	if l.Elem == nil {
+		return cty.NilType, false
+	}
+
+	elemCons, ok := l.Elem.(TypeAwareConstraint)
+	if !ok {
+		return cty.NilType, false
+	}
+
+	elemType, ok := elemCons.ConstraintType()
+	if !ok {
+		return cty.NilType, false
+	}
+
+	return cty.List(elemType), true
 }

--- a/schema/constraint_map.go
+++ b/schema/constraint_map.go
@@ -66,6 +66,19 @@ func (m Map) EmptyHoverData(nestingLevel int) *HoverData {
 }
 
 func (m Map) ConstraintType() (cty.Type, bool) {
-	// TODO
-	return cty.NilType, false
+	if m.Elem == nil {
+		return cty.NilType, false
+	}
+
+	elemCons, ok := m.Elem.(TypeAwareConstraint)
+	if !ok {
+		return cty.NilType, false
+	}
+
+	elemType, ok := elemCons.ConstraintType()
+	if !ok {
+		return cty.NilType, false
+	}
+
+	return cty.Map(elemType), true
 }

--- a/schema/constraint_object.go
+++ b/schema/constraint_object.go
@@ -50,8 +50,22 @@ func (o Object) EmptyHoverData(nestingLevel int) *HoverData {
 }
 
 func (o Object) ConstraintType() (cty.Type, bool) {
-	// TODO
-	return cty.NilType, false
+	objAttributes := make(map[string]cty.Type)
+
+	for name, attr := range o.Attributes {
+		cons, ok := attr.Constraint.(TypeAwareConstraint)
+		if !ok {
+			return cty.NilType, false
+		}
+		attrType, ok := cons.ConstraintType()
+		if !ok {
+			return cty.NilType, false
+		}
+
+		objAttributes[name] = attrType
+	}
+
+	return cty.Object(objAttributes), true
 }
 
 func (ObjectAttributes) isConstraintImpl() constraintSigil {

--- a/schema/constraint_one_of.go
+++ b/schema/constraint_one_of.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
+	"github.com/zclconf/go-cty/cty"
 )
 
 // OneOf represents multiple constraints where any one of them is acceptable.
@@ -76,4 +77,20 @@ func namesContain(names []string, name string) bool {
 func (o OneOf) EmptyCompletionData(nextPlaceholder int) CompletionData {
 	// TODO
 	return CompletionData{}
+}
+
+func (o OneOf) ConstraintType() (cty.Type, bool) {
+	for _, cons := range o {
+		c, ok := cons.(TypeAwareConstraint)
+		if !ok {
+			continue
+		}
+		typ, ok := c.ConstraintType()
+		if !ok {
+			continue
+		}
+		return typ, true
+	}
+
+	return cty.NilType, false
 }

--- a/schema/constraint_one_of.go
+++ b/schema/constraint_one_of.go
@@ -89,6 +89,12 @@ func (o OneOf) ConstraintType() (cty.Type, bool) {
 		if !ok {
 			continue
 		}
+
+		// Picking first type-aware constraint may not always be
+		// appropriate since we cannot match it against configuration,
+		// but it is mostly a pragmatic choice to mimic existing behaviours
+		// based on common schema, such as OneOf{Reference{}, LiteralType{}}.
+		// TODO: Revisit when AnyExpression{} is implemented & rolled out
 		return typ, true
 	}
 

--- a/schema/constraint_set.go
+++ b/schema/constraint_set.go
@@ -59,6 +59,19 @@ func (s Set) EmptyHoverData(nestingLevel int) *HoverData {
 }
 
 func (s Set) ConstraintType() (cty.Type, bool) {
-	// TODO
-	return cty.NilType, false
+	if s.Elem == nil {
+		return cty.NilType, false
+	}
+
+	elemCons, ok := s.Elem.(TypeAwareConstraint)
+	if !ok {
+		return cty.NilType, false
+	}
+
+	elemType, ok := elemCons.ConstraintType()
+	if !ok {
+		return cty.NilType, false
+	}
+
+	return cty.Set(elemType), true
 }

--- a/schema/constraint_test.go
+++ b/schema/constraint_test.go
@@ -29,6 +29,7 @@ var (
 	_ TypeAwareConstraint = LiteralValue{}
 	_ TypeAwareConstraint = Map{}
 	_ TypeAwareConstraint = Object{}
+	_ TypeAwareConstraint = OneOf{}
 	_ TypeAwareConstraint = Set{}
 	_ TypeAwareConstraint = Tuple{}
 )

--- a/schema/constraint_tuple.go
+++ b/schema/constraint_tuple.go
@@ -49,6 +49,20 @@ func (t Tuple) EmptyHoverData(nestingLevel int) *HoverData {
 }
 
 func (t Tuple) ConstraintType() (cty.Type, bool) {
-	// TODO
-	return cty.NilType, false
+	elemCons := make([]cty.Type, 0)
+
+	for _, elem := range t.Elems {
+		cons, ok := elem.(TypeAwareConstraint)
+		if !ok {
+			return cty.NilType, false
+		}
+
+		elemType, ok := cons.ConstraintType()
+		if !ok {
+			return cty.NilType, false
+		}
+		elemCons = append(elemCons, elemType)
+	}
+
+	return cty.Tuple(elemCons), true
 }


### PR DESCRIPTION
We could add tests, but in all cases it's either simple pass of an existing type (1LOC) or just putting the same data into a different shape, so I'm not sure it's worth testing in isolation.

We can still test it indirectly as part of reference target collection.