### PR TITLE
schema: Introduce `nestingLevel` to EmptyCompletionData()

### DIFF
--- a/decoder/attribute_candidates.go
+++ b/decoder/attribute_candidates.go
@@ -15,7 +15,7 @@ func attributeSchemaToCandidate(name string, attr *schema.AttributeSchema, rng h
 	var snippet string
 	var triggerSuggest bool
 	if attr.Constraint != nil {
-		cData := attr.Constraint.EmptyCompletionData(1)
+		cData := attr.Constraint.EmptyCompletionData(1, 1)
 		snippet = fmt.Sprintf("%s = %s", name, cData.Snippet)
 		triggerSuggest = cData.TriggerSuggest
 	} else {

--- a/decoder/label_candidates.go
+++ b/decoder/label_candidates.go
@@ -164,7 +164,7 @@ func requiredFieldsSnippet(bodySchema *schema.BodySchema, placeholder int, inden
 
 		var snippet string
 		if attr.Constraint != nil {
-			snippet = attr.Constraint.EmptyCompletionData(placeholder).Snippet
+			snippet = attr.Constraint.EmptyCompletionData(placeholder, indentCount).Snippet
 		} else {
 			snippet = snippetForExprContraint(uint(placeholder), attr.Expr)
 		}

--- a/schema/constraint.go
+++ b/schema/constraint.go
@@ -16,7 +16,7 @@ type Constraint interface {
 	// there is no corresponding configuration, such as when the Constraint
 	// is part of another and it is desirable to complete
 	// the parent constraint as whole.
-	EmptyCompletionData(nextPlaceholder int) CompletionData
+	EmptyCompletionData(nextPlaceholder int, nestingLevel int) CompletionData
 }
 
 type ConstraintWithHoverData interface {

--- a/schema/constraint_any_expression.go
+++ b/schema/constraint_any_expression.go
@@ -28,7 +28,7 @@ func (ae AnyExpression) Copy() Constraint {
 	}
 }
 
-func (ae AnyExpression) EmptyCompletionData(nextPlaceholder int) CompletionData {
+func (ae AnyExpression) EmptyCompletionData(nextPlaceholder int, nestingLevel int) CompletionData {
 	// TODO
 	return CompletionData{}
 }

--- a/schema/constraint_keyword.go
+++ b/schema/constraint_keyword.go
@@ -36,7 +36,7 @@ func (k Keyword) Copy() Constraint {
 	}
 }
 
-func (k Keyword) EmptyCompletionData(nextPlaceholder int) CompletionData {
+func (k Keyword) EmptyCompletionData(nextPlaceholder int, nestingLevel int) CompletionData {
 	return CompletionData{
 		TriggerSuggest:  true,
 		LastPlaceholder: nextPlaceholder,

--- a/schema/constraint_list.go
+++ b/schema/constraint_list.go
@@ -48,7 +48,7 @@ func (l List) Copy() Constraint {
 	}
 }
 
-func (l List) EmptyCompletionData(nextPlaceholder int) CompletionData {
+func (l List) EmptyCompletionData(nextPlaceholder int, nestingLevel int) CompletionData {
 	// TODO
 	return CompletionData{}
 }

--- a/schema/constraint_literal_type.go
+++ b/schema/constraint_literal_type.go
@@ -32,7 +32,7 @@ func (lt LiteralType) Copy() Constraint {
 	}
 }
 
-func (lt LiteralType) EmptyCompletionData(nextPlaceholder int) CompletionData {
+func (lt LiteralType) EmptyCompletionData(nextPlaceholder int, nestingLevel int) CompletionData {
 	// TODO
 	return CompletionData{}
 }

--- a/schema/constraint_literal_value.go
+++ b/schema/constraint_literal_value.go
@@ -33,7 +33,7 @@ func (lv LiteralValue) Copy() Constraint {
 	}
 }
 
-func (lv LiteralValue) EmptyCompletionData(nextPlaceholder int) CompletionData {
+func (lv LiteralValue) EmptyCompletionData(nextPlaceholder int, nestingLevel int) CompletionData {
 	// TODO
 	return CompletionData{}
 }

--- a/schema/constraint_map.go
+++ b/schema/constraint_map.go
@@ -55,7 +55,7 @@ func (m Map) Copy() Constraint {
 	}
 }
 
-func (m Map) EmptyCompletionData(nextPlaceholder int) CompletionData {
+func (m Map) EmptyCompletionData(nextPlaceholder int, nestingLevel int) CompletionData {
 	// TODO
 	return CompletionData{}
 }

--- a/schema/constraint_object.go
+++ b/schema/constraint_object.go
@@ -40,7 +40,7 @@ func (o Object) Copy() Constraint {
 	}
 }
 
-func (o Object) EmptyCompletionData(placeholder int) CompletionData {
+func (o Object) EmptyCompletionData(placeholder int, nestingLevel int) CompletionData {
 	return CompletionData{}
 }
 
@@ -70,7 +70,7 @@ func (oa ObjectAttributes) Copy() Constraint {
 	return m
 }
 
-func (oa ObjectAttributes) EmptyCompletionData(nextPlaceholder int) CompletionData {
+func (oa ObjectAttributes) EmptyCompletionData(nextPlaceholder int, nestingLevel int) CompletionData {
 	// TODO
 	return CompletionData{}
 }

--- a/schema/constraint_one_of.go
+++ b/schema/constraint_one_of.go
@@ -73,7 +73,7 @@ func namesContain(names []string, name string) bool {
 	return false
 }
 
-func (o OneOf) EmptyCompletionData(nextPlaceholder int) CompletionData {
+func (o OneOf) EmptyCompletionData(nextPlaceholder int, nestingLevel int) CompletionData {
 	// TODO
 	return CompletionData{}
 }

--- a/schema/constraint_reference.go
+++ b/schema/constraint_reference.go
@@ -65,7 +65,7 @@ func (ref Reference) Copy() Constraint {
 	}
 }
 
-func (ref Reference) EmptyCompletionData(nextPlaceholder int) CompletionData {
+func (ref Reference) EmptyCompletionData(nextPlaceholder int, nestingLevel int) CompletionData {
 	// TODO
 	return CompletionData{}
 }

--- a/schema/constraint_set.go
+++ b/schema/constraint_set.go
@@ -48,7 +48,7 @@ func (s Set) Copy() Constraint {
 	}
 }
 
-func (s Set) EmptyCompletionData(nextPlaceholder int) CompletionData {
+func (s Set) EmptyCompletionData(nextPlaceholder int, nestingLevel int) CompletionData {
 	// TODO
 	return CompletionData{}
 }

--- a/schema/constraint_tuple.go
+++ b/schema/constraint_tuple.go
@@ -38,7 +38,7 @@ func (t Tuple) Copy() Constraint {
 	return newTuple
 }
 
-func (t Tuple) EmptyCompletionData(nextPlaceholder int) CompletionData {
+func (t Tuple) EmptyCompletionData(nextPlaceholder int, nestingLevel int) CompletionData {
 	// TODO
 	return CompletionData{}
 }

--- a/schema/constraint_type_declaration.go
+++ b/schema/constraint_type_declaration.go
@@ -19,7 +19,7 @@ func (td TypeDeclaration) Copy() Constraint {
 	return TypeDeclaration{}
 }
 
-func (td TypeDeclaration) EmptyCompletionData(nextPlaceholder int) CompletionData {
+func (td TypeDeclaration) EmptyCompletionData(nextPlaceholder int, nestingLevel int) CompletionData {
 	// TODO
 	return CompletionData{}
 }


### PR DESCRIPTION
While trying to implement `EmptyCompletionData()` for `Object` and `Map`, I realised that in both cases the constraint may be nested, i.e. the object may be nested under another object/map. In that scenario we need to render the right indentation depending on the nesting level we're at.

The updated interface accounts for this.