### PR TITLE
schema: Implement `EmptyHoverData()` for all constraints

### DIFF
--- a/schema/constraint_list.go
+++ b/schema/constraint_list.go
@@ -54,8 +54,19 @@ func (l List) EmptyCompletionData(nextPlaceholder int, nestingLevel int) Complet
 }
 
 func (l List) EmptyHoverData(nestingLevel int) *HoverData {
-	// TODO
-	return nil
+	elemCons, ok := l.Elem.(ConstraintWithHoverData)
+	if !ok {
+		return nil
+	}
+
+	hoverData := elemCons.EmptyHoverData(nestingLevel)
+	if hoverData == nil {
+		return nil
+	}
+
+	return &HoverData{
+		Content: lang.Markdown(fmt.Sprintf(`list(%s)`, hoverData.Content.Value)),
+	}
 }
 
 func (l List) ConstraintType() (cty.Type, bool) {

--- a/schema/constraint_literal_value.go
+++ b/schema/constraint_literal_value.go
@@ -1,6 +1,11 @@
 package schema
 
 import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
 	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -39,8 +44,169 @@ func (lv LiteralValue) EmptyCompletionData(nextPlaceholder int, nestingLevel int
 }
 
 func (lv LiteralValue) EmptyHoverData(nestingLevel int) *HoverData {
-	// TODO
+	if lv.Value.Type().IsPrimitiveType() {
+		var value string
+		switch lv.Value.Type() {
+		case cty.Bool:
+			value = fmt.Sprintf("%t", lv.Value.True())
+		case cty.String:
+			if strings.ContainsAny(lv.Value.AsString(), "\n") && nestingLevel == 0 {
+				// avoid double newline
+				strValue := strings.TrimSuffix(lv.Value.AsString(), "\n")
+				value = fmt.Sprintf("```\n%s\n```\n", strValue)
+			} else {
+				value = fmt.Sprintf("%q", lv.Value.AsString())
+			}
+		case cty.Number:
+			value = formatNumberVal(lv.Value)
+		}
+
+		return &HoverData{
+			Content: lang.Markdown(value),
+		}
+	}
+	if lv.Value.Type().IsListType() {
+		vals := lv.Value.AsValueSlice()
+		elemData := make([]string, len(vals))
+		for i, val := range vals {
+			c := LiteralValue{
+				Value: val,
+			}
+			hoverData := c.EmptyHoverData(nestingLevel)
+			if hoverData == nil {
+				return nil
+			}
+			elemData[i] = hoverData.Content.Value
+		}
+
+		return &HoverData{
+			Content: lang.Markdown(fmt.Sprintf(`tolist([%s])`, strings.Join(elemData, ", "))),
+		}
+	}
+	if lv.Value.Type().IsSetType() {
+		vals := lv.Value.AsValueSlice()
+		elemData := make([]string, len(vals))
+		for i, val := range vals {
+			c := LiteralValue{
+				Value: val,
+			}
+			hoverData := c.EmptyHoverData(nestingLevel)
+			if hoverData == nil {
+				return nil
+			}
+			elemData[i] = hoverData.Content.Value
+		}
+
+		return &HoverData{
+			Content: lang.Markdown(fmt.Sprintf(`toset([%s])`, strings.Join(elemData, ", "))),
+		}
+	}
+	if lv.Value.Type().IsTupleType() {
+		vals := lv.Value.AsValueSlice()
+		elemData := make([]string, len(vals))
+		for i, val := range vals {
+			c := LiteralValue{
+				Value: val,
+			}
+			hoverData := c.EmptyHoverData(nestingLevel)
+			if hoverData == nil {
+				return nil
+			}
+			elemData[i] = hoverData.Content.Value
+		}
+
+		return &HoverData{
+			Content: lang.Markdown(fmt.Sprintf(`[%s]`, strings.Join(elemData, ", "))),
+		}
+	}
+	if lv.Value.Type().IsMapType() {
+		valueMap := lv.Value.AsValueMap()
+
+		attrNames := sortedValueMap(valueMap)
+
+		data := ""
+		if nestingLevel == 0 {
+			data += "```\n"
+		}
+
+		data += "tomap({\n"
+		for _, name := range attrNames {
+			val := valueMap[name]
+
+			cons := LiteralValue{
+				Value: val,
+			}
+
+			hoverData := cons.EmptyHoverData(nestingLevel + 1)
+			if hoverData == nil {
+				return nil
+			}
+
+			data += fmt.Sprintf("%s%q = %s\n",
+				strings.Repeat("  ", nestingLevel+1),
+				name, hoverData.Content.Value)
+		}
+		data += fmt.Sprintf("%s})", strings.Repeat("  ", nestingLevel))
+		if nestingLevel == 0 {
+			data += "\n```\n"
+		}
+
+		return &HoverData{
+			Content: lang.Markdown(data),
+		}
+	}
+	if lv.Value.Type().IsObjectType() {
+		valueMap := lv.Value.AsValueMap()
+		attrs := make(ObjectAttributes, 0)
+		for name, attrValue := range valueMap {
+			aSchema := &AttributeSchema{
+				Constraint: LiteralValue{
+					Value: attrValue,
+				},
+			}
+			if lv.Value.Type().AttributeOptional(name) {
+				aSchema.IsOptional = true
+			} else {
+				aSchema.IsRequired = true
+			}
+			attrs[name] = aSchema
+		}
+		cons := Object{
+			Attributes: attrs,
+		}
+		return cons.EmptyHoverData(nestingLevel)
+	}
+
 	return nil
+}
+
+func sortedValueMap(valueMap map[string]cty.Value) []string {
+	if len(valueMap) == 0 {
+		return []string{}
+	}
+
+	constraints := valueMap
+	names := make([]string, len(constraints))
+	i := 0
+	for name := range constraints {
+		names[i] = name
+		i++
+	}
+
+	sort.Strings(names)
+	return names
+}
+
+func formatNumberVal(val cty.Value) string {
+	bf := val.AsBigFloat()
+
+	if bf.IsInt() {
+		intNum, _ := bf.Int64()
+		return fmt.Sprintf("%d", intNum)
+	}
+
+	fNum, _ := bf.Float64()
+	return strconv.FormatFloat(fNum, 'f', -1, 64)
 }
 
 func (lv LiteralValue) ConstraintType() (cty.Type, bool) {

--- a/schema/constraint_map.go
+++ b/schema/constraint_map.go
@@ -61,8 +61,19 @@ func (m Map) EmptyCompletionData(nextPlaceholder int, nestingLevel int) Completi
 }
 
 func (m Map) EmptyHoverData(nestingLevel int) *HoverData {
-	// TODO
-	return nil
+	elemCons, ok := m.Elem.(ConstraintWithHoverData)
+	if !ok {
+		return nil
+	}
+
+	hoverData := elemCons.EmptyHoverData(nestingLevel)
+	if hoverData == nil {
+		return nil
+	}
+
+	return &HoverData{
+		Content: lang.Markdown(fmt.Sprintf(`map(%s)`, hoverData.Content.Value)),
+	}
 }
 
 func (m Map) ConstraintType() (cty.Type, bool) {

--- a/schema/constraint_object.go
+++ b/schema/constraint_object.go
@@ -1,6 +1,10 @@
 package schema
 
 import (
+	"fmt"
+	"sort"
+	"strings"
+
 	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -45,8 +49,72 @@ func (o Object) EmptyCompletionData(placeholder int, nestingLevel int) Completio
 }
 
 func (o Object) EmptyHoverData(nestingLevel int) *HoverData {
-	// TODO
-	return nil
+	if len(o.Attributes) == 0 {
+		return nil
+	}
+
+	attrNames := sortedObjectExprAttrNames(o.Attributes)
+
+	data := ""
+	if nestingLevel == 0 {
+		data += "```\n"
+	}
+
+	data += "{\n"
+	for _, name := range attrNames {
+		attr := o.Attributes[name]
+
+		cons, ok := attr.Constraint.(ConstraintWithHoverData)
+		if !ok {
+			return nil
+		}
+
+		hoverData := cons.EmptyHoverData(nestingLevel + 1)
+		if hoverData == nil {
+			return nil
+		}
+
+		attrFlags := []string{}
+		if attr.IsOptional {
+			attrFlags = append(attrFlags, "optional")
+		}
+		if attr.IsSensitive {
+			attrFlags = append(attrFlags, "sensitive")
+		}
+		attrComment := ""
+		if len(attrFlags) > 0 {
+			attrComment = fmt.Sprintf(" # %s", strings.Join(attrFlags, ", "))
+		}
+
+		data += fmt.Sprintf("%s%s = %s%s\n",
+			strings.Repeat("  ", nestingLevel+1),
+			name, hoverData.Content.Value, attrComment)
+	}
+	data += fmt.Sprintf("%s}", strings.Repeat("  ", nestingLevel))
+	if nestingLevel == 0 {
+		data += "\n```\n"
+	}
+
+	return &HoverData{
+		Content: lang.Markdown(data),
+	}
+}
+
+func sortedObjectExprAttrNames(attributes ObjectAttributes) []string {
+	if len(attributes) == 0 {
+		return []string{}
+	}
+
+	constraints := attributes
+	names := make([]string, len(constraints))
+	i := 0
+	for name := range constraints {
+		names[i] = name
+		i++
+	}
+
+	sort.Strings(names)
+	return names
 }
 
 func (o Object) ConstraintType() (cty.Type, bool) {

--- a/schema/constraint_set.go
+++ b/schema/constraint_set.go
@@ -54,8 +54,19 @@ func (s Set) EmptyCompletionData(nextPlaceholder int, nestingLevel int) Completi
 }
 
 func (s Set) EmptyHoverData(nestingLevel int) *HoverData {
-	// TODO
-	return nil
+	elemCons, ok := s.Elem.(ConstraintWithHoverData)
+	if !ok {
+		return nil
+	}
+
+	hoverData := elemCons.EmptyHoverData(nestingLevel)
+	if hoverData == nil {
+		return nil
+	}
+
+	return &HoverData{
+		Content: lang.Markdown(fmt.Sprintf(`set(%s)`, hoverData.Content.Value)),
+	}
 }
 
 func (s Set) ConstraintType() (cty.Type, bool) {

--- a/schema/constraint_test.go
+++ b/schema/constraint_test.go
@@ -134,6 +134,138 @@ func TestConstraint_EmptyHoverData(t *testing.T) {
 ` + "```\n"),
 			},
 		},
+		// literal value
+		{
+			LiteralValue{
+				Value: cty.StringVal("foobar"),
+			},
+			&HoverData{
+				Content: lang.Markdown(`"foobar"`),
+			},
+		},
+		{
+			LiteralValue{
+				Value: cty.StringVal("foo\nbar"),
+			},
+			&HoverData{
+				Content: lang.Markdown("```\nfoo\nbar\n```\n"),
+			},
+		},
+		{
+			LiteralValue{
+				Value: cty.NumberIntVal(42),
+			},
+			&HoverData{
+				Content: lang.Markdown(`42`),
+			},
+		},
+		{
+			LiteralValue{
+				Value: cty.ObjectVal(map[string]cty.Value{
+					"foo": cty.StringVal("too"),
+					"bar": cty.NumberIntVal(42),
+					"baz": cty.ListVal([]cty.Value{cty.StringVal("toot")}),
+				}),
+			},
+			&HoverData{
+				Content: lang.Markdown("```" + `
+{
+  bar = 42
+  baz = tolist(["toot"])
+  foo = "too"
+}
+` + "```\n"),
+			},
+		},
+		{
+			LiteralValue{
+				Value: cty.MapVal(map[string]cty.Value{
+					"foo": cty.StringVal("too"),
+					"bar": cty.StringVal("boo"),
+				}),
+			},
+			&HoverData{
+				Content: lang.Markdown("```" + `
+tomap({
+  "bar" = "boo"
+  "foo" = "too"
+})
+` + "```\n"),
+			},
+		},
+		{
+			LiteralValue{
+				Value: cty.MapVal(map[string]cty.Value{
+					"foo": cty.MapVal(map[string]cty.Value{
+						"noot": cty.StringVal("noot"),
+					}),
+					"bar": cty.MapVal(map[string]cty.Value{
+						"baz": cty.StringVal("toot"),
+					}),
+				}),
+			},
+			&HoverData{
+				Content: lang.Markdown("```" + `
+tomap({
+  "bar" = tomap({
+    "baz" = "toot"
+  })
+  "foo" = tomap({
+    "noot" = "noot"
+  })
+})
+` + "```\n"),
+			},
+		},
+		{
+			LiteralValue{
+				Value: cty.ObjectVal(map[string]cty.Value{
+					"foo": cty.StringVal("too"),
+					"bar": cty.NumberIntVal(43),
+					"baz": cty.ObjectVal(map[string]cty.Value{
+						"foo": cty.StringVal("boo"),
+						"bar": cty.NumberIntVal(32),
+					}),
+				}),
+			},
+			&HoverData{
+				Content: lang.Markdown("```" + `
+{
+  bar = 43
+  baz = {
+    bar = 32
+    foo = "boo"
+  }
+  foo = "too"
+}
+` + "```\n"),
+			},
+		},
+		{
+			LiteralValue{
+				Value: cty.ObjectVal(map[string]cty.Value{
+					"foo": cty.StringVal("too"),
+					"bar": cty.NumberIntVal(43),
+					"baz": cty.MapVal(map[string]cty.Value{
+						"foo": cty.NumberIntVal(42),
+						"bar": cty.NumberIntVal(32),
+					}),
+				}),
+			},
+			&HoverData{
+				Content: lang.Markdown("```" + `
+{
+  bar = 43
+  baz = tomap({
+    "bar" = 32
+    "foo" = 42
+  })
+  foo = "too"
+}
+` + "```\n"),
+			},
+		},
+
 		// negative tests
 		{
 			List{

--- a/schema/constraint_test.go
+++ b/schema/constraint_test.go
@@ -1,5 +1,14 @@
 package schema
 
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/zclconf/go-cty/cty"
+)
+
 var (
 	_ Constraint = AnyExpression{}
 	_ Constraint = Keyword{}
@@ -33,3 +42,152 @@ var (
 	_ TypeAwareConstraint = Set{}
 	_ TypeAwareConstraint = Tuple{}
 )
+
+func TestConstraint_EmptyHoverData(t *testing.T) {
+	testCases := []struct {
+		cons              ConstraintWithHoverData
+		expectedHoverData *HoverData
+	}{
+		{
+			LiteralType{
+				Type: cty.String,
+			},
+			&HoverData{
+				Content: lang.Markdown(`string`),
+			},
+		},
+		{
+			List{
+				Elem: LiteralType{
+					Type: cty.String,
+				},
+			},
+			&HoverData{
+				Content: lang.Markdown("list(string)"),
+			},
+		},
+		{
+			LiteralType{
+				Type: cty.List(cty.String),
+			},
+			&HoverData{
+				Content: lang.Markdown("list(string)"),
+			},
+		},
+		{
+			Set{
+				Elem: LiteralType{
+					Type: cty.String,
+				},
+			},
+			&HoverData{
+				Content: lang.Markdown("set(string)"),
+			},
+		},
+		{
+			LiteralType{
+				Type: cty.Set(cty.String),
+			},
+			&HoverData{
+				Content: lang.Markdown("set(string)"),
+			},
+		},
+		{
+			LiteralType{
+				Type: cty.Object(map[string]cty.Type{
+					"foo": cty.String,
+					"bar": cty.Number,
+					"baz": cty.List(cty.String),
+				}),
+			},
+			&HoverData{
+				Content: lang.Markdown("```" + `
+{
+  bar = number
+  baz = list(string)
+  foo = string
+}
+` + "```\n"),
+			},
+		},
+		{
+			LiteralType{
+				Type: cty.Object(map[string]cty.Type{
+					"foo": cty.String,
+					"bar": cty.Number,
+					"baz": cty.Object(map[string]cty.Type{
+						"foo": cty.String,
+						"bar": cty.Number,
+					}),
+				}),
+			},
+			&HoverData{
+				Content: lang.Markdown("```" + `
+{
+  bar = number
+  baz = {
+    bar = number
+    foo = string
+  }
+  foo = string
+}
+` + "```\n"),
+			},
+		},
+		// negative tests
+		{
+			List{
+				Elem: Keyword{
+					Keyword: "kw",
+				},
+			},
+			nil,
+		},
+		{
+			Set{
+				Elem: Keyword{
+					Keyword: "kw",
+				},
+			},
+			nil,
+		},
+		{
+			Tuple{
+				Elems: []Constraint{
+					Keyword{
+						Keyword: "kw",
+					},
+				},
+			},
+			nil,
+		},
+		{
+			Map{
+				Elem: Keyword{
+					Keyword: "kw",
+				},
+			},
+			nil,
+		},
+		{
+			Object{
+				Attributes: map[string]*AttributeSchema{
+					"foo": {
+						Constraint: Keyword{
+							Keyword: "kw",
+						},
+					},
+				},
+			},
+			nil,
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			hoverData := tc.cons.EmptyHoverData(0)
+			if diff := cmp.Diff(tc.expectedHoverData, hoverData); diff != "" {
+				t.Fatalf("unexpected hover data: %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The implementation for `LiteralValue` specifically turns out to be a little more involved than I originally hoped, but I decided to include it in the PR as well.

It reminds me that implementing https://github.com/hashicorp/hcl-lang/pull/187 may be more involved in general, but we can cross the bridge when we come to it.

The primary motivation to get this PR out was to enable more comprehensive testing of hover in https://github.com/hashicorp/hcl-lang/pull/203