### PR TITLE
schema: Implement `EmptyCompletionData()` for all constraints

### DIFF
--- a/schema/constraint.go
+++ b/schema/constraint.go
@@ -54,7 +54,7 @@ type CompletionData struct {
 	Snippet string
 
 	TriggerSuggest  bool
-	LastPlaceholder int
+	NextPlaceholder int
 }
 
 type HoverData struct {

--- a/schema/constraint_keyword.go
+++ b/schema/constraint_keyword.go
@@ -39,6 +39,6 @@ func (k Keyword) Copy() Constraint {
 func (k Keyword) EmptyCompletionData(nextPlaceholder int, nestingLevel int) CompletionData {
 	return CompletionData{
 		TriggerSuggest:  true,
-		LastPlaceholder: nextPlaceholder,
+		NextPlaceholder: nextPlaceholder,
 	}
 }

--- a/schema/constraint_list.go
+++ b/schema/constraint_list.go
@@ -53,7 +53,7 @@ func (l List) EmptyCompletionData(nextPlaceholder int, nestingLevel int) Complet
 		return CompletionData{
 			NewText:         "[]",
 			Snippet:         fmt.Sprintf("[ ${%d} ]", nextPlaceholder),
-			LastPlaceholder: nextPlaceholder + 1,
+			NextPlaceholder: nextPlaceholder + 1,
 		}
 	}
 
@@ -63,14 +63,14 @@ func (l List) EmptyCompletionData(nextPlaceholder int, nestingLevel int) Complet
 			NewText:         "[]",
 			Snippet:         fmt.Sprintf("[ ${%d} ]", nextPlaceholder),
 			TriggerSuggest:  elemData.TriggerSuggest,
-			LastPlaceholder: nextPlaceholder + 1,
+			NextPlaceholder: nextPlaceholder + 1,
 		}
 	}
 
 	return CompletionData{
 		NewText:         fmt.Sprintf("[ %s ]", elemData.NewText),
 		Snippet:         fmt.Sprintf("[ %s ]", elemData.Snippet),
-		LastPlaceholder: elemData.LastPlaceholder,
+		NextPlaceholder: elemData.NextPlaceholder,
 	}
 }
 

--- a/schema/constraint_list.go
+++ b/schema/constraint_list.go
@@ -49,8 +49,29 @@ func (l List) Copy() Constraint {
 }
 
 func (l List) EmptyCompletionData(nextPlaceholder int, nestingLevel int) CompletionData {
-	// TODO
-	return CompletionData{}
+	if l.Elem == nil {
+		return CompletionData{
+			NewText:         "[]",
+			Snippet:         fmt.Sprintf("[ ${%d} ]", nextPlaceholder),
+			LastPlaceholder: nextPlaceholder + 1,
+		}
+	}
+
+	elemData := l.Elem.EmptyCompletionData(nextPlaceholder, nestingLevel)
+	if elemData.NewText == "" || elemData.Snippet == "" {
+		return CompletionData{
+			NewText:         "[]",
+			Snippet:         fmt.Sprintf("[ ${%d} ]", nextPlaceholder),
+			TriggerSuggest:  elemData.TriggerSuggest,
+			LastPlaceholder: nextPlaceholder + 1,
+		}
+	}
+
+	return CompletionData{
+		NewText:         fmt.Sprintf("[ %s ]", elemData.NewText),
+		Snippet:         fmt.Sprintf("[ %s ]", elemData.Snippet),
+		LastPlaceholder: elemData.LastPlaceholder,
+	}
 }
 
 func (l List) EmptyHoverData(nestingLevel int) *HoverData {

--- a/schema/constraint_literal_type.go
+++ b/schema/constraint_literal_type.go
@@ -59,7 +59,7 @@ func (lt LiteralType) EmptyCompletionData(nextPlaceholder int, nestingLevel int)
 		return CompletionData{
 			NewText:         newText,
 			Snippet:         snippet,
-			LastPlaceholder: nextPlaceholder,
+			NextPlaceholder: nextPlaceholder,
 		}
 	}
 
@@ -121,7 +121,7 @@ func (lt LiteralType) EmptyCompletionData(nextPlaceholder int, nestingLevel int)
 	}
 
 	return CompletionData{
-		LastPlaceholder: nextPlaceholder,
+		NextPlaceholder: nextPlaceholder,
 	}
 }
 

--- a/schema/constraint_literal_type.go
+++ b/schema/constraint_literal_type.go
@@ -1,6 +1,8 @@
 package schema
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -35,8 +37,92 @@ func (lt LiteralType) Copy() Constraint {
 }
 
 func (lt LiteralType) EmptyCompletionData(nextPlaceholder int, nestingLevel int) CompletionData {
-	// TODO
-	return CompletionData{}
+	if lt.Type.IsPrimitiveType() {
+		var newText, snippet string
+
+		switch lt.Type {
+		case cty.Bool:
+			newText = fmt.Sprintf("%t", false)
+			// TODO: consider using snippet "choice"
+			// https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#snippet_syntax
+			snippet = fmt.Sprintf("${%d:false}", nextPlaceholder)
+		case cty.String:
+			newText = fmt.Sprintf("%q", "value")
+			snippet = fmt.Sprintf("\"${%d:%s}\"", nextPlaceholder, "value")
+		case cty.Number:
+			newText = "0"
+			snippet = fmt.Sprintf("${%d:0}", nextPlaceholder)
+		}
+
+		nextPlaceholder++
+
+		return CompletionData{
+			NewText:         newText,
+			Snippet:         snippet,
+			LastPlaceholder: nextPlaceholder,
+		}
+	}
+
+	if lt.Type.IsListType() {
+		listCons := List{
+			Elem: LiteralType{
+				Type: lt.Type.ElementType(),
+			},
+		}
+		return listCons.EmptyCompletionData(nextPlaceholder, nestingLevel)
+	}
+	if lt.Type.IsSetType() {
+		setCons := Set{
+			Elem: LiteralType{
+				Type: lt.Type.ElementType(),
+			},
+		}
+		return setCons.EmptyCompletionData(nextPlaceholder, nestingLevel)
+	}
+	if lt.Type.IsMapType() {
+		mapCons := Map{
+			Elem: LiteralType{
+				Type: lt.Type.ElementType(),
+			},
+		}
+		return mapCons.EmptyCompletionData(nextPlaceholder, nestingLevel)
+	}
+	if lt.Type.IsTupleType() {
+		types := lt.Type.TupleElementTypes()
+		tupleCons := Tuple{}
+		for i, typ := range types {
+			tupleCons.Elems[i] = LiteralType{
+				Type: typ,
+			}
+		}
+		return tupleCons.EmptyCompletionData(nextPlaceholder, nestingLevel)
+	}
+	if lt.Type.IsObjectType() {
+		attrTypes := lt.Type.AttributeTypes()
+		attrs := make(ObjectAttributes, 0)
+		for name, attrType := range attrTypes {
+			aSchema := &AttributeSchema{
+				Constraint: LiteralType{
+					Type: attrType,
+				},
+			}
+			if lt.Type.AttributeOptional(name) {
+				aSchema.IsOptional = true
+			} else {
+				aSchema.IsRequired = true
+			}
+
+			attrs[name] = aSchema
+		}
+		cons := Object{
+			Attributes: attrs,
+		}
+		return cons.EmptyCompletionData(nextPlaceholder, nestingLevel)
+	}
+
+	return CompletionData{
+		LastPlaceholder: nextPlaceholder,
+	}
 }
 
 func (lt LiteralType) EmptyHoverData(nestingLevel int) *HoverData {

--- a/schema/constraint_literal_value.go
+++ b/schema/constraint_literal_value.go
@@ -39,8 +39,179 @@ func (lv LiteralValue) Copy() Constraint {
 }
 
 func (lv LiteralValue) EmptyCompletionData(nextPlaceholder int, nestingLevel int) CompletionData {
-	// TODO
-	return CompletionData{}
+	if lv.Value.Type().IsPrimitiveType() {
+		var value string
+		switch lv.Value.Type() {
+		case cty.Bool:
+			value = fmt.Sprintf("%t", lv.Value.True())
+		case cty.String:
+			if strings.ContainsAny(lv.Value.AsString(), "\n") && nestingLevel == 0 {
+				// avoid double newline
+				strValue := strings.TrimSuffix(lv.Value.AsString(), "\n")
+				value = fmt.Sprintf("<<<STRING\n%s\nSTRING", strValue)
+				if nestingLevel == 0 {
+					value += "\n"
+				}
+			} else {
+				value = fmt.Sprintf("%q", lv.Value.AsString())
+			}
+		case cty.Number:
+			value = formatNumberVal(lv.Value)
+		}
+
+		return CompletionData{
+			NewText:         value,
+			Snippet:         value,
+			LastPlaceholder: nextPlaceholder,
+		}
+	}
+	if lv.Value.Type().IsListType() {
+		vals := lv.Value.AsValueSlice()
+		elemNewText := make([]string, len(vals))
+		elemSnippets := make([]string, len(vals))
+		lastPlaceholder := nextPlaceholder
+
+		for i, val := range vals {
+			c := LiteralValue{
+				Value: val,
+			}
+			cData := c.EmptyCompletionData(lastPlaceholder, nestingLevel)
+			if cData.NewText == "" || cData.Snippet == "" {
+				return CompletionData{
+					LastPlaceholder: lastPlaceholder,
+				}
+			}
+			elemNewText[i] = cData.NewText
+			elemSnippets[i] = cData.Snippet
+			lastPlaceholder = cData.LastPlaceholder
+		}
+
+		return CompletionData{
+			// TODO: consider wrapping this in tolist()
+			NewText:         fmt.Sprintf("[%s]", strings.Join(elemNewText, ", ")),
+			Snippet:         fmt.Sprintf("[%s]", strings.Join(elemSnippets, ", ")),
+			LastPlaceholder: lastPlaceholder,
+		}
+	}
+	if lv.Value.Type().IsSetType() {
+		vals := lv.Value.AsValueSlice()
+		elemNewText := make([]string, len(vals))
+		elemSnippets := make([]string, len(vals))
+		lastPlaceholder := nextPlaceholder
+
+		for i, val := range vals {
+			c := LiteralValue{
+				Value: val,
+			}
+			cData := c.EmptyCompletionData(lastPlaceholder, nestingLevel)
+			if cData.NewText == "" || cData.Snippet == "" {
+				return CompletionData{
+					LastPlaceholder: lastPlaceholder,
+				}
+			}
+			elemNewText[i] = cData.NewText
+			elemSnippets[i] = cData.Snippet
+			lastPlaceholder = cData.LastPlaceholder
+		}
+
+		return CompletionData{
+			// TODO: consider wrapping this in toset()
+			NewText:         fmt.Sprintf("[%s]", strings.Join(elemNewText, ", ")),
+			Snippet:         fmt.Sprintf("[%s]", strings.Join(elemSnippets, ", ")),
+			LastPlaceholder: lastPlaceholder,
+		}
+	}
+	if lv.Value.Type().IsTupleType() {
+		vals := lv.Value.AsValueSlice()
+		elemNewText := make([]string, len(vals))
+		elemSnippets := make([]string, len(vals))
+		lastPlaceholder := nextPlaceholder
+
+		for i, val := range vals {
+			c := LiteralValue{
+				Value: val,
+			}
+			cData := c.EmptyCompletionData(lastPlaceholder, nestingLevel)
+			if cData.NewText == "" || cData.Snippet == "" {
+				return CompletionData{
+					LastPlaceholder: lastPlaceholder,
+				}
+			}
+			elemNewText[i] = cData.NewText
+			elemSnippets[i] = cData.Snippet
+			lastPlaceholder = cData.LastPlaceholder
+		}
+
+		return CompletionData{
+			NewText:         fmt.Sprintf("[%s]", strings.Join(elemNewText, ", ")),
+			Snippet:         fmt.Sprintf("[%s]", strings.Join(elemSnippets, ", ")),
+			LastPlaceholder: lastPlaceholder,
+		}
+	}
+	if lv.Value.Type().IsMapType() {
+		valueMap := lv.Value.AsValueMap()
+
+		attrNames := sortedValueMap(valueMap)
+
+		// TODO: consider wrapping in tomap()
+		newText, snippet := "{\n", "{\n"
+		lastPlaceholder := nextPlaceholder
+		for _, name := range attrNames {
+			val := valueMap[name]
+
+			cons := LiteralValue{
+				Value: val,
+			}
+
+			cData := cons.EmptyCompletionData(lastPlaceholder, nestingLevel+1)
+			if cData.NewText == "" || cData.Snippet == "" {
+				return CompletionData{
+					LastPlaceholder: lastPlaceholder,
+				}
+			}
+
+			newText += fmt.Sprintf("%s%q = %s\n",
+				strings.Repeat("  ", nestingLevel+1),
+				name, cData.NewText)
+			snippet += fmt.Sprintf("%s%q = %s\n",
+				strings.Repeat("  ", nestingLevel+1),
+				name, cData.Snippet)
+			lastPlaceholder = cData.LastPlaceholder
+		}
+		newText += fmt.Sprintf("%s}", strings.Repeat("  ", nestingLevel))
+		snippet += fmt.Sprintf("%s}", strings.Repeat("  ", nestingLevel))
+
+		return CompletionData{
+			NewText:         newText,
+			Snippet:         snippet,
+			LastPlaceholder: lastPlaceholder,
+		}
+	}
+	if lv.Value.Type().IsObjectType() {
+		valueMap := lv.Value.AsValueMap()
+		attrs := make(ObjectAttributes, 0)
+		for name, attrValue := range valueMap {
+			aSchema := &AttributeSchema{
+				Constraint: LiteralValue{
+					Value: attrValue,
+				},
+			}
+			if lv.Value.Type().AttributeOptional(name) {
+				aSchema.IsOptional = true
+			} else {
+				aSchema.IsRequired = true
+			}
+			attrs[name] = aSchema
+		}
+		cons := Object{
+			Attributes: attrs,
+		}
+		return cons.EmptyCompletionData(nextPlaceholder, nestingLevel)
+	}
+
+	return CompletionData{
+		LastPlaceholder: nextPlaceholder,
+	}
 }
 
 func (lv LiteralValue) EmptyHoverData(nestingLevel int) *HoverData {

--- a/schema/constraint_literal_value.go
+++ b/schema/constraint_literal_value.go
@@ -62,7 +62,7 @@ func (lv LiteralValue) EmptyCompletionData(nextPlaceholder int, nestingLevel int
 		return CompletionData{
 			NewText:         value,
 			Snippet:         value,
-			LastPlaceholder: nextPlaceholder,
+			NextPlaceholder: nextPlaceholder,
 		}
 	}
 	if lv.Value.Type().IsListType() {
@@ -78,19 +78,19 @@ func (lv LiteralValue) EmptyCompletionData(nextPlaceholder int, nestingLevel int
 			cData := c.EmptyCompletionData(lastPlaceholder, nestingLevel)
 			if cData.NewText == "" || cData.Snippet == "" {
 				return CompletionData{
-					LastPlaceholder: lastPlaceholder,
+					NextPlaceholder: lastPlaceholder,
 				}
 			}
 			elemNewText[i] = cData.NewText
 			elemSnippets[i] = cData.Snippet
-			lastPlaceholder = cData.LastPlaceholder
+			lastPlaceholder = cData.NextPlaceholder
 		}
 
 		return CompletionData{
 			// TODO: consider wrapping this in tolist()
 			NewText:         fmt.Sprintf("[%s]", strings.Join(elemNewText, ", ")),
 			Snippet:         fmt.Sprintf("[%s]", strings.Join(elemSnippets, ", ")),
-			LastPlaceholder: lastPlaceholder,
+			NextPlaceholder: lastPlaceholder,
 		}
 	}
 	if lv.Value.Type().IsSetType() {
@@ -106,19 +106,19 @@ func (lv LiteralValue) EmptyCompletionData(nextPlaceholder int, nestingLevel int
 			cData := c.EmptyCompletionData(lastPlaceholder, nestingLevel)
 			if cData.NewText == "" || cData.Snippet == "" {
 				return CompletionData{
-					LastPlaceholder: lastPlaceholder,
+					NextPlaceholder: lastPlaceholder,
 				}
 			}
 			elemNewText[i] = cData.NewText
 			elemSnippets[i] = cData.Snippet
-			lastPlaceholder = cData.LastPlaceholder
+			lastPlaceholder = cData.NextPlaceholder
 		}
 
 		return CompletionData{
 			// TODO: consider wrapping this in toset()
 			NewText:         fmt.Sprintf("[%s]", strings.Join(elemNewText, ", ")),
 			Snippet:         fmt.Sprintf("[%s]", strings.Join(elemSnippets, ", ")),
-			LastPlaceholder: lastPlaceholder,
+			NextPlaceholder: lastPlaceholder,
 		}
 	}
 	if lv.Value.Type().IsTupleType() {
@@ -134,18 +134,18 @@ func (lv LiteralValue) EmptyCompletionData(nextPlaceholder int, nestingLevel int
 			cData := c.EmptyCompletionData(lastPlaceholder, nestingLevel)
 			if cData.NewText == "" || cData.Snippet == "" {
 				return CompletionData{
-					LastPlaceholder: lastPlaceholder,
+					NextPlaceholder: lastPlaceholder,
 				}
 			}
 			elemNewText[i] = cData.NewText
 			elemSnippets[i] = cData.Snippet
-			lastPlaceholder = cData.LastPlaceholder
+			lastPlaceholder = cData.NextPlaceholder
 		}
 
 		return CompletionData{
 			NewText:         fmt.Sprintf("[%s]", strings.Join(elemNewText, ", ")),
 			Snippet:         fmt.Sprintf("[%s]", strings.Join(elemSnippets, ", ")),
-			LastPlaceholder: lastPlaceholder,
+			NextPlaceholder: lastPlaceholder,
 		}
 	}
 	if lv.Value.Type().IsMapType() {
@@ -166,7 +166,7 @@ func (lv LiteralValue) EmptyCompletionData(nextPlaceholder int, nestingLevel int
 			cData := cons.EmptyCompletionData(lastPlaceholder, nestingLevel+1)
 			if cData.NewText == "" || cData.Snippet == "" {
 				return CompletionData{
-					LastPlaceholder: lastPlaceholder,
+					NextPlaceholder: lastPlaceholder,
 				}
 			}
 
@@ -176,7 +176,7 @@ func (lv LiteralValue) EmptyCompletionData(nextPlaceholder int, nestingLevel int
 			snippet += fmt.Sprintf("%s%q = %s\n",
 				strings.Repeat("  ", nestingLevel+1),
 				name, cData.Snippet)
-			lastPlaceholder = cData.LastPlaceholder
+			lastPlaceholder = cData.NextPlaceholder
 		}
 		newText += fmt.Sprintf("%s}", strings.Repeat("  ", nestingLevel))
 		snippet += fmt.Sprintf("%s}", strings.Repeat("  ", nestingLevel))
@@ -184,7 +184,7 @@ func (lv LiteralValue) EmptyCompletionData(nextPlaceholder int, nestingLevel int
 		return CompletionData{
 			NewText:         newText,
 			Snippet:         snippet,
-			LastPlaceholder: lastPlaceholder,
+			NextPlaceholder: lastPlaceholder,
 		}
 	}
 	if lv.Value.Type().IsObjectType() {
@@ -210,7 +210,7 @@ func (lv LiteralValue) EmptyCompletionData(nextPlaceholder int, nestingLevel int
 	}
 
 	return CompletionData{
-		LastPlaceholder: nextPlaceholder,
+		NextPlaceholder: nextPlaceholder,
 	}
 }
 

--- a/schema/constraint_map.go
+++ b/schema/constraint_map.go
@@ -61,7 +61,7 @@ func (m Map) EmptyCompletionData(nextPlaceholder int, nestingLevel int) Completi
 		return CompletionData{
 			NewText:         "{}",
 			Snippet:         fmt.Sprintf("{ ${%d} }", nextPlaceholder),
-			LastPlaceholder: nextPlaceholder + 1,
+			NextPlaceholder: nextPlaceholder + 1,
 		}
 	}
 
@@ -70,7 +70,7 @@ func (m Map) EmptyCompletionData(nextPlaceholder int, nestingLevel int) Completi
 		return CompletionData{
 			NewText:         "{}",
 			Snippet:         fmt.Sprintf("{ ${%d} }", nextPlaceholder),
-			LastPlaceholder: nextPlaceholder + 1,
+			NextPlaceholder: nextPlaceholder + 1,
 			TriggerSuggest:  elemData.TriggerSuggest,
 		}
 	}
@@ -80,7 +80,7 @@ func (m Map) EmptyCompletionData(nextPlaceholder int, nestingLevel int) Completi
 	return CompletionData{
 		NewText:         fmt.Sprintf("{\n%s\"name\" = %s\n}", nesting, elemData.NewText),
 		Snippet:         fmt.Sprintf("{\n%s\"${%d:name}\" = %s\n}", nesting, nextPlaceholder, elemData.Snippet),
-		LastPlaceholder: elemData.LastPlaceholder,
+		NextPlaceholder: elemData.NextPlaceholder,
 		TriggerSuggest:  elemData.TriggerSuggest,
 	}
 }

--- a/schema/constraint_object.go
+++ b/schema/constraint_object.go
@@ -45,7 +45,52 @@ func (o Object) Copy() Constraint {
 }
 
 func (o Object) EmptyCompletionData(placeholder int, nestingLevel int) CompletionData {
-	return CompletionData{}
+	if len(o.Attributes) == 0 {
+		return CompletionData{
+			NewText:         "{}",
+			Snippet:         fmt.Sprintf("{ ${%d} }", placeholder),
+			LastPlaceholder: placeholder + 1,
+		}
+	}
+
+	newText := "{\n"
+	snippet := "{\n"
+
+	nesting := strings.Repeat("  ", nestingLevel+1)
+	lastPlaceholder := placeholder
+
+	attrNames := sortedObjectExprAttrNames(o.Attributes)
+
+	for _, name := range attrNames {
+		attr := o.Attributes[name]
+		cData := attr.Constraint.EmptyCompletionData(lastPlaceholder, nestingLevel+1)
+		if cData.NewText == "" || cData.Snippet == "" {
+			return CompletionData{
+				NewText:         "{}",
+				Snippet:         fmt.Sprintf("{ ${%d} }", placeholder),
+				TriggerSuggest:  cData.TriggerSuggest,
+				LastPlaceholder: placeholder + 1,
+			}
+		}
+
+		newText += fmt.Sprintf("%s%s = %s\n", nesting, name, cData.NewText)
+		snippet += fmt.Sprintf("%s%s = %s\n", nesting, name, cData.Snippet)
+		lastPlaceholder = cData.LastPlaceholder
+	}
+
+	if nestingLevel > 0 {
+		newText += fmt.Sprintf("%s}", strings.Repeat("  ", nestingLevel))
+		snippet += fmt.Sprintf("%s}", strings.Repeat("  ", nestingLevel))
+	} else {
+		newText += "}"
+		snippet += "}"
+	}
+
+	return CompletionData{
+		NewText:         newText,
+		Snippet:         snippet,
+		LastPlaceholder: lastPlaceholder,
+	}
 }
 
 func (o Object) EmptyHoverData(nestingLevel int) *HoverData {

--- a/schema/constraint_object.go
+++ b/schema/constraint_object.go
@@ -49,7 +49,7 @@ func (o Object) EmptyCompletionData(placeholder int, nestingLevel int) Completio
 		return CompletionData{
 			NewText:         "{}",
 			Snippet:         fmt.Sprintf("{ ${%d} }", placeholder),
-			LastPlaceholder: placeholder + 1,
+			NextPlaceholder: placeholder + 1,
 		}
 	}
 
@@ -69,13 +69,13 @@ func (o Object) EmptyCompletionData(placeholder int, nestingLevel int) Completio
 				NewText:         "{}",
 				Snippet:         fmt.Sprintf("{ ${%d} }", placeholder),
 				TriggerSuggest:  cData.TriggerSuggest,
-				LastPlaceholder: placeholder + 1,
+				NextPlaceholder: placeholder + 1,
 			}
 		}
 
 		newText += fmt.Sprintf("%s%s = %s\n", nesting, name, cData.NewText)
 		snippet += fmt.Sprintf("%s%s = %s\n", nesting, name, cData.Snippet)
-		lastPlaceholder = cData.LastPlaceholder
+		lastPlaceholder = cData.NextPlaceholder
 	}
 
 	if nestingLevel > 0 {
@@ -89,7 +89,7 @@ func (o Object) EmptyCompletionData(placeholder int, nestingLevel int) Completio
 	return CompletionData{
 		NewText:         newText,
 		Snippet:         snippet,
-		LastPlaceholder: lastPlaceholder,
+		NextPlaceholder: lastPlaceholder,
 	}
 }
 

--- a/schema/constraint_one_of.go
+++ b/schema/constraint_one_of.go
@@ -77,7 +77,7 @@ func namesContain(names []string, name string) bool {
 func (o OneOf) EmptyCompletionData(nextPlaceholder int, nestingLevel int) CompletionData {
 	if len(o) == 0 {
 		return CompletionData{
-			LastPlaceholder: nextPlaceholder,
+			NextPlaceholder: nextPlaceholder,
 		}
 	}
 
@@ -86,7 +86,7 @@ func (o OneOf) EmptyCompletionData(nextPlaceholder int, nestingLevel int) Comple
 	return CompletionData{
 		NewText:         cData.NewText,
 		Snippet:         cData.Snippet,
-		LastPlaceholder: cData.LastPlaceholder,
+		NextPlaceholder: cData.NextPlaceholder,
 		TriggerSuggest:  cData.TriggerSuggest,
 	}
 }

--- a/schema/constraint_set.go
+++ b/schema/constraint_set.go
@@ -53,7 +53,7 @@ func (s Set) EmptyCompletionData(nextPlaceholder int, nestingLevel int) Completi
 		return CompletionData{
 			NewText:         "[]",
 			Snippet:         fmt.Sprintf("[ ${%d} ]", nextPlaceholder),
-			LastPlaceholder: nextPlaceholder + 1,
+			NextPlaceholder: nextPlaceholder + 1,
 		}
 	}
 
@@ -63,14 +63,14 @@ func (s Set) EmptyCompletionData(nextPlaceholder int, nestingLevel int) Completi
 			NewText:         "[]",
 			Snippet:         fmt.Sprintf("[ ${%d} ]", nextPlaceholder),
 			TriggerSuggest:  elemData.TriggerSuggest,
-			LastPlaceholder: nextPlaceholder + 1,
+			NextPlaceholder: nextPlaceholder + 1,
 		}
 	}
 
 	return CompletionData{
 		NewText:         fmt.Sprintf("[ %s ]", elemData.NewText),
 		Snippet:         fmt.Sprintf("[ %s ]", elemData.Snippet),
-		LastPlaceholder: elemData.LastPlaceholder,
+		NextPlaceholder: elemData.NextPlaceholder,
 	}
 }
 

--- a/schema/constraint_set.go
+++ b/schema/constraint_set.go
@@ -49,8 +49,29 @@ func (s Set) Copy() Constraint {
 }
 
 func (s Set) EmptyCompletionData(nextPlaceholder int, nestingLevel int) CompletionData {
-	// TODO
-	return CompletionData{}
+	if s.Elem == nil {
+		return CompletionData{
+			NewText:         "[]",
+			Snippet:         fmt.Sprintf("[ ${%d} ]", nextPlaceholder),
+			LastPlaceholder: nextPlaceholder + 1,
+		}
+	}
+
+	elemData := s.Elem.EmptyCompletionData(nextPlaceholder, nestingLevel)
+	if elemData.NewText == "" || elemData.Snippet == "" {
+		return CompletionData{
+			NewText:         "[]",
+			Snippet:         fmt.Sprintf("[ ${%d} ]", nextPlaceholder),
+			TriggerSuggest:  elemData.TriggerSuggest,
+			LastPlaceholder: nextPlaceholder + 1,
+		}
+	}
+
+	return CompletionData{
+		NewText:         fmt.Sprintf("[ %s ]", elemData.NewText),
+		Snippet:         fmt.Sprintf("[ %s ]", elemData.Snippet),
+		LastPlaceholder: elemData.LastPlaceholder,
+	}
 }
 
 func (s Set) EmptyHoverData(nestingLevel int) *HoverData {

--- a/schema/constraint_test.go
+++ b/schema/constraint_test.go
@@ -336,7 +336,7 @@ func TestConstraint_EmptyCompletionData(t *testing.T) {
 			CompletionData{
 				NewText:         `"value"`,
 				Snippet:         `"${1:value}"`,
-				LastPlaceholder: 2,
+				NextPlaceholder: 2,
 			},
 		},
 		{
@@ -348,7 +348,7 @@ func TestConstraint_EmptyCompletionData(t *testing.T) {
 			CompletionData{
 				NewText:         `[ "value" ]`,
 				Snippet:         `[ "${1:value}" ]`,
-				LastPlaceholder: 2,
+				NextPlaceholder: 2,
 			},
 		},
 		{
@@ -358,7 +358,7 @@ func TestConstraint_EmptyCompletionData(t *testing.T) {
 			CompletionData{
 				NewText:         `[ "value" ]`,
 				Snippet:         `[ "${1:value}" ]`,
-				LastPlaceholder: 2,
+				NextPlaceholder: 2,
 			},
 		},
 		{
@@ -370,7 +370,7 @@ func TestConstraint_EmptyCompletionData(t *testing.T) {
 			CompletionData{
 				NewText:         `[ "value" ]`,
 				Snippet:         `[ "${1:value}" ]`,
-				LastPlaceholder: 2,
+				NextPlaceholder: 2,
 			},
 		},
 		{
@@ -380,7 +380,7 @@ func TestConstraint_EmptyCompletionData(t *testing.T) {
 			CompletionData{
 				NewText:         `[ "value" ]`,
 				Snippet:         `[ "${1:value}" ]`,
-				LastPlaceholder: 2,
+				NextPlaceholder: 2,
 			},
 		},
 		{
@@ -402,7 +402,7 @@ func TestConstraint_EmptyCompletionData(t *testing.T) {
   baz = [ "${2:value}" ]
   foo = "${3:value}"
 }`,
-				LastPlaceholder: 4,
+				NextPlaceholder: 4,
 			},
 		},
 		{
@@ -433,7 +433,7 @@ func TestConstraint_EmptyCompletionData(t *testing.T) {
   }
   foo = "${4:value}"
 }`,
-				LastPlaceholder: 5,
+				NextPlaceholder: 5,
 			},
 		},
 		{
@@ -443,7 +443,7 @@ func TestConstraint_EmptyCompletionData(t *testing.T) {
 			CompletionData{
 				NewText:         `"foobar"`,
 				Snippet:         `"foobar"`,
-				LastPlaceholder: 1,
+				NextPlaceholder: 1,
 			},
 		},
 		{
@@ -461,7 +461,7 @@ foo
 bar
 STRING
 `,
-				LastPlaceholder: 1,
+				NextPlaceholder: 1,
 			},
 		},
 		{
@@ -471,7 +471,7 @@ STRING
 			CompletionData{
 				NewText:         "42",
 				Snippet:         "42",
-				LastPlaceholder: 1,
+				NextPlaceholder: 1,
 			},
 		},
 		{
@@ -493,7 +493,7 @@ STRING
   baz = ["toot"]
   foo = "too"
 }`,
-				LastPlaceholder: 1,
+				NextPlaceholder: 1,
 			},
 		},
 		{
@@ -512,7 +512,7 @@ STRING
   "bar" = "boo"
   "foo" = "too"
 }`,
-				LastPlaceholder: 1,
+				NextPlaceholder: 1,
 			},
 		},
 		{
@@ -543,7 +543,7 @@ STRING
     "noot" = "noot"
   }
 }`,
-				LastPlaceholder: 1,
+				NextPlaceholder: 1,
 			},
 		},
 		{
@@ -574,7 +574,7 @@ STRING
   }
   foo = "too"
 }`,
-				LastPlaceholder: 1,
+				NextPlaceholder: 1,
 			},
 		},
 		{
@@ -605,7 +605,7 @@ STRING
   }
   foo = "too"
 }`,
-				LastPlaceholder: 1,
+				NextPlaceholder: 1,
 			},
 		},
 		{
@@ -618,7 +618,7 @@ STRING
 				NewText:         "[]",
 				Snippet:         "[ ${1} ]",
 				TriggerSuggest:  true,
-				LastPlaceholder: 2,
+				NextPlaceholder: 2,
 			},
 		},
 		{
@@ -631,7 +631,7 @@ STRING
 				NewText:         "[]",
 				Snippet:         "[ ${1} ]",
 				TriggerSuggest:  true,
-				LastPlaceholder: 2,
+				NextPlaceholder: 2,
 			},
 		},
 		{
@@ -646,7 +646,7 @@ STRING
 				NewText:         "[]",
 				Snippet:         "[ ${1} ]",
 				TriggerSuggest:  true,
-				LastPlaceholder: 2,
+				NextPlaceholder: 2,
 			},
 		},
 		{
@@ -659,7 +659,7 @@ STRING
 				NewText:         `{}`,
 				Snippet:         `{ ${1} }`,
 				TriggerSuggest:  true,
-				LastPlaceholder: 2,
+				NextPlaceholder: 2,
 			},
 		},
 		{
@@ -676,7 +676,7 @@ STRING
 				NewText:         `{}`,
 				Snippet:         `{ ${1} }`,
 				TriggerSuggest:  true,
-				LastPlaceholder: 2,
+				NextPlaceholder: 2,
 			},
 		},
 	}

--- a/schema/constraint_test.go
+++ b/schema/constraint_test.go
@@ -323,3 +323,369 @@ tomap({
 		})
 	}
 }
+
+func TestConstraint_EmptyCompletionData(t *testing.T) {
+	testCases := []struct {
+		cons             Constraint
+		expectedCompData CompletionData
+	}{
+		{
+			LiteralType{
+				Type: cty.String,
+			},
+			CompletionData{
+				NewText:         `"value"`,
+				Snippet:         `"${1:value}"`,
+				LastPlaceholder: 2,
+			},
+		},
+		{
+			List{
+				Elem: LiteralType{
+					Type: cty.String,
+				},
+			},
+			CompletionData{
+				NewText:         `[ "value" ]`,
+				Snippet:         `[ "${1:value}" ]`,
+				LastPlaceholder: 2,
+			},
+		},
+		{
+			LiteralType{
+				Type: cty.List(cty.String),
+			},
+			CompletionData{
+				NewText:         `[ "value" ]`,
+				Snippet:         `[ "${1:value}" ]`,
+				LastPlaceholder: 2,
+			},
+		},
+		{
+			Set{
+				Elem: LiteralType{
+					Type: cty.String,
+				},
+			},
+			CompletionData{
+				NewText:         `[ "value" ]`,
+				Snippet:         `[ "${1:value}" ]`,
+				LastPlaceholder: 2,
+			},
+		},
+		{
+			LiteralType{
+				Type: cty.Set(cty.String),
+			},
+			CompletionData{
+				NewText:         `[ "value" ]`,
+				Snippet:         `[ "${1:value}" ]`,
+				LastPlaceholder: 2,
+			},
+		},
+		{
+			LiteralType{
+				Type: cty.Object(map[string]cty.Type{
+					"foo": cty.String,
+					"bar": cty.Number,
+					"baz": cty.List(cty.String),
+				}),
+			},
+			CompletionData{
+				NewText: `{
+  bar = 0
+  baz = [ "value" ]
+  foo = "value"
+}`,
+				Snippet: `{
+  bar = ${1:0}
+  baz = [ "${2:value}" ]
+  foo = "${3:value}"
+}`,
+				LastPlaceholder: 4,
+			},
+		},
+		{
+			LiteralType{
+				Type: cty.Object(map[string]cty.Type{
+					"foo": cty.String,
+					"bar": cty.Number,
+					"baz": cty.Object(map[string]cty.Type{
+						"foo": cty.String,
+						"bar": cty.Number,
+					}),
+				}),
+			},
+			CompletionData{
+				NewText: `{
+  bar = 0
+  baz = {
+    bar = 0
+    foo = "value"
+  }
+  foo = "value"
+}`,
+				Snippet: `{
+  bar = ${1:0}
+  baz = {
+    bar = ${2:0}
+    foo = "${3:value}"
+  }
+  foo = "${4:value}"
+}`,
+				LastPlaceholder: 5,
+			},
+		},
+		{
+			LiteralValue{
+				Value: cty.StringVal("foobar"),
+			},
+			CompletionData{
+				NewText:         `"foobar"`,
+				Snippet:         `"foobar"`,
+				LastPlaceholder: 1,
+			},
+		},
+		{
+			LiteralValue{
+				Value: cty.StringVal("foo\nbar"),
+			},
+			CompletionData{
+				NewText: `<<<STRING
+foo
+bar
+STRING
+`,
+				Snippet: `<<<STRING
+foo
+bar
+STRING
+`,
+				LastPlaceholder: 1,
+			},
+		},
+		{
+			LiteralValue{
+				Value: cty.NumberIntVal(42),
+			},
+			CompletionData{
+				NewText:         "42",
+				Snippet:         "42",
+				LastPlaceholder: 1,
+			},
+		},
+		{
+			LiteralValue{
+				Value: cty.ObjectVal(map[string]cty.Value{
+					"foo": cty.StringVal("too"),
+					"bar": cty.NumberIntVal(42),
+					"baz": cty.ListVal([]cty.Value{cty.StringVal("toot")}),
+				}),
+			},
+			CompletionData{
+				NewText: `{
+  bar = 42
+  baz = ["toot"]
+  foo = "too"
+}`,
+				Snippet: `{
+  bar = 42
+  baz = ["toot"]
+  foo = "too"
+}`,
+				LastPlaceholder: 1,
+			},
+		},
+		{
+			LiteralValue{
+				Value: cty.MapVal(map[string]cty.Value{
+					"foo": cty.StringVal("too"),
+					"bar": cty.StringVal("boo"),
+				}),
+			},
+			CompletionData{
+				NewText: `{
+  "bar" = "boo"
+  "foo" = "too"
+}`,
+				Snippet: `{
+  "bar" = "boo"
+  "foo" = "too"
+}`,
+				LastPlaceholder: 1,
+			},
+		},
+		{
+			LiteralValue{
+				Value: cty.MapVal(map[string]cty.Value{
+					"foo": cty.MapVal(map[string]cty.Value{
+						"noot": cty.StringVal("noot"),
+					}),
+					"bar": cty.MapVal(map[string]cty.Value{
+						"baz": cty.StringVal("toot"),
+					}),
+				}),
+			},
+			CompletionData{
+				NewText: `{
+  "bar" = {
+    "baz" = "toot"
+  }
+  "foo" = {
+    "noot" = "noot"
+  }
+}`,
+				Snippet: `{
+  "bar" = {
+    "baz" = "toot"
+  }
+  "foo" = {
+    "noot" = "noot"
+  }
+}`,
+				LastPlaceholder: 1,
+			},
+		},
+		{
+			LiteralValue{
+				Value: cty.ObjectVal(map[string]cty.Value{
+					"foo": cty.StringVal("too"),
+					"bar": cty.NumberIntVal(43),
+					"baz": cty.ObjectVal(map[string]cty.Value{
+						"foo": cty.StringVal("boo"),
+						"bar": cty.NumberIntVal(32),
+					}),
+				}),
+			},
+			CompletionData{
+				NewText: `{
+  bar = 43
+  baz = {
+    bar = 32
+    foo = "boo"
+  }
+  foo = "too"
+}`,
+				Snippet: `{
+  bar = 43
+  baz = {
+    bar = 32
+    foo = "boo"
+  }
+  foo = "too"
+}`,
+				LastPlaceholder: 1,
+			},
+		},
+		{
+			LiteralValue{
+				Value: cty.ObjectVal(map[string]cty.Value{
+					"foo": cty.StringVal("too"),
+					"bar": cty.NumberIntVal(43),
+					"baz": cty.MapVal(map[string]cty.Value{
+						"foo": cty.NumberIntVal(42),
+						"bar": cty.NumberIntVal(32),
+					}),
+				}),
+			},
+			CompletionData{
+				NewText: `{
+  bar = 43
+  baz = {
+    "bar" = 32
+    "foo" = 42
+  }
+  foo = "too"
+}`,
+				Snippet: `{
+  bar = 43
+  baz = {
+    "bar" = 32
+    "foo" = 42
+  }
+  foo = "too"
+}`,
+				LastPlaceholder: 1,
+			},
+		},
+		{
+			List{
+				Elem: Keyword{
+					Keyword: "kw",
+				},
+			},
+			CompletionData{
+				NewText:         "[]",
+				Snippet:         "[ ${1} ]",
+				TriggerSuggest:  true,
+				LastPlaceholder: 2,
+			},
+		},
+		{
+			Set{
+				Elem: Keyword{
+					Keyword: "kw",
+				},
+			},
+			CompletionData{
+				NewText:         "[]",
+				Snippet:         "[ ${1} ]",
+				TriggerSuggest:  true,
+				LastPlaceholder: 2,
+			},
+		},
+		{
+			Tuple{
+				Elems: []Constraint{
+					Keyword{
+						Keyword: "kw",
+					},
+				},
+			},
+			CompletionData{
+				NewText:         "[]",
+				Snippet:         "[ ${1} ]",
+				TriggerSuggest:  true,
+				LastPlaceholder: 2,
+			},
+		},
+		{
+			Map{
+				Elem: Keyword{
+					Keyword: "kw",
+				},
+			},
+			CompletionData{
+				NewText:         `{}`,
+				Snippet:         `{ ${1} }`,
+				TriggerSuggest:  true,
+				LastPlaceholder: 2,
+			},
+		},
+		{
+			Object{
+				Attributes: map[string]*AttributeSchema{
+					"foo": {
+						Constraint: Keyword{
+							Keyword: "kw",
+						},
+					},
+				},
+			},
+			CompletionData{
+				NewText:         `{}`,
+				Snippet:         `{ ${1} }`,
+				TriggerSuggest:  true,
+				LastPlaceholder: 2,
+			},
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			data := tc.cons.EmptyCompletionData(1, 0)
+			if diff := cmp.Diff(tc.expectedCompData, data); diff != "" {
+				t.Fatalf("unexpected completion  data: %s", diff)
+			}
+		})
+	}
+}

--- a/schema/constraint_tuple.go
+++ b/schema/constraint_tuple.go
@@ -46,7 +46,7 @@ func (t Tuple) EmptyCompletionData(nextPlaceholder int, nestingLevel int) Comple
 		return CompletionData{
 			NewText:         "[]",
 			Snippet:         fmt.Sprintf("[ ${%d} ]", nextPlaceholder),
-			LastPlaceholder: nextPlaceholder + 1,
+			NextPlaceholder: nextPlaceholder + 1,
 		}
 	}
 
@@ -61,18 +61,18 @@ func (t Tuple) EmptyCompletionData(nextPlaceholder int, nestingLevel int) Comple
 				NewText:         "[]",
 				Snippet:         fmt.Sprintf("[ ${%d} ]", nextPlaceholder),
 				TriggerSuggest:  cData.TriggerSuggest,
-				LastPlaceholder: nextPlaceholder + 1,
+				NextPlaceholder: nextPlaceholder + 1,
 			}
 		}
 		elemNewText[i] = cData.NewText
 		elemSnippets[i] = cData.NewText
-		lastPlaceholder = cData.LastPlaceholder
+		lastPlaceholder = cData.NextPlaceholder
 	}
 
 	return CompletionData{
 		NewText:         fmt.Sprintf("[ %s ]", strings.Join(elemNewText, ", ")),
 		Snippet:         fmt.Sprintf("[ %s ]", strings.Join(elemSnippets, ", ")),
-		LastPlaceholder: lastPlaceholder,
+		NextPlaceholder: lastPlaceholder,
 	}
 }
 

--- a/schema/constraint_tuple.go
+++ b/schema/constraint_tuple.go
@@ -65,7 +65,7 @@ func (t Tuple) EmptyCompletionData(nextPlaceholder int, nestingLevel int) Comple
 			}
 		}
 		elemNewText[i] = cData.NewText
-		elemSnippets[i] = cData.NewText
+		elemSnippets[i] = cData.Snippet
 		lastPlaceholder = cData.NextPlaceholder
 	}
 

--- a/schema/constraint_type_declaration.go
+++ b/schema/constraint_type_declaration.go
@@ -22,6 +22,6 @@ func (td TypeDeclaration) Copy() Constraint {
 func (td TypeDeclaration) EmptyCompletionData(nextPlaceholder int, nestingLevel int) CompletionData {
 	return CompletionData{
 		TriggerSuggest:  true,
-		LastPlaceholder: nextPlaceholder,
+		NextPlaceholder: nextPlaceholder,
 	}
 }

--- a/schema/constraint_type_declaration.go
+++ b/schema/constraint_type_declaration.go
@@ -20,6 +20,8 @@ func (td TypeDeclaration) Copy() Constraint {
 }
 
 func (td TypeDeclaration) EmptyCompletionData(nextPlaceholder int, nestingLevel int) CompletionData {
-	// TODO
-	return CompletionData{}
+	return CompletionData{
+		TriggerSuggest:  true,
+		LastPlaceholder: nextPlaceholder,
+	}
 }


### PR DESCRIPTION
## Testing

Aside from reviewing the attached unit tests, this can also be tested when combined with https://github.com/hashicorp/terraform-schema/pull/174

There are two contexts in which `EmptyCompletionData()` is used, as shown below.

### Pre-filling required fields by label

![2023-02-24 18 10 53](https://user-images.githubusercontent.com/287584/221257732-032d1ae8-6e79-44d3-95b0-aa13da29896b.gif)

### Completing attribute's "empty value" (for literal types)

![2023-02-24 18 11 32](https://user-images.githubusercontent.com/287584/221257758-89fee26c-d47b-493f-9a87-6d3a2d1a3aaa.gif)

