### PR TITLE
decoder: fix test name

### DIFF
--- a/decoder/expr_one_of_semtok_test.go
+++ b/decoder/expr_one_of_semtok_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 )
 
-func TestSemanticTokens_exprTypeDeclaration(t *testing.T) {
+func TestSemanticTokens_exprOneOf(t *testing.T) {
 	testCases := []struct {
 		testName       string
 		attrSchema     map[string]*schema.AttributeSchema


### PR DESCRIPTION
The existing test name is incorrect and caused conflict in https://github.com/hashicorp/hcl-lang/pull/183