### PR TITLE
decoder/schema: Pass `PrefillRequiredFields` around via context

### DIFF
--- a/decoder/attribute_candidates.go
+++ b/decoder/attribute_candidates.go
@@ -1,6 +1,7 @@
 package decoder
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -11,11 +12,11 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-func attributeSchemaToCandidate(name string, attr *schema.AttributeSchema, rng hcl.Range) lang.Candidate {
+func attributeSchemaToCandidate(ctx context.Context, name string, attr *schema.AttributeSchema, rng hcl.Range) lang.Candidate {
 	var snippet string
 	var triggerSuggest bool
 	if attr.Constraint != nil {
-		cData := attr.Constraint.EmptyCompletionData(1, 0)
+		cData := attr.Constraint.EmptyCompletionData(ctx, 1, 0)
 		snippet = fmt.Sprintf("%s = %s", name, cData.Snippet)
 		triggerSuggest = cData.TriggerSuggest
 	} else {

--- a/decoder/body_candidates.go
+++ b/decoder/body_candidates.go
@@ -1,6 +1,7 @@
 package decoder
 
 import (
+	"context"
 	"sort"
 	"strings"
 
@@ -11,7 +12,7 @@ import (
 )
 
 // bodySchemaCandidates returns candidates for completion of fields inside a body or block.
-func (d *PathDecoder) bodySchemaCandidates(body *hclsyntax.Body, schema *schema.BodySchema, prefixRng, editRng hcl.Range) lang.Candidates {
+func (d *PathDecoder) bodySchemaCandidates(ctx context.Context, body *hclsyntax.Body, schema *schema.BodySchema, prefixRng, editRng hcl.Range) lang.Candidates {
 	prefix, _ := d.bytesFromRange(prefixRng)
 
 	candidates := lang.NewCandidates()
@@ -23,7 +24,7 @@ func (d *PathDecoder) bodySchemaCandidates(body *hclsyntax.Body, schema *schema.
 			// check if count attribute is already declared, so we don't
 			// suggest a duplicate
 			if _, ok := body.Attributes["count"]; !ok {
-				candidates.List = append(candidates.List, attributeSchemaToCandidate("count", countAttributeSchema(), editRng))
+				candidates.List = append(candidates.List, attributeSchemaToCandidate(ctx, "count", countAttributeSchema(), editRng))
 			}
 		}
 
@@ -31,7 +32,7 @@ func (d *PathDecoder) bodySchemaCandidates(body *hclsyntax.Body, schema *schema.
 			// check if for_each attribute is already declared, so we don't
 			// suggest a duplicate
 			if _, present := body.Attributes["for_each"]; !present {
-				candidates.List = append(candidates.List, attributeSchemaToCandidate("for_each", forEachAttributeSchema(), editRng))
+				candidates.List = append(candidates.List, attributeSchemaToCandidate(ctx, "for_each", forEachAttributeSchema(), editRng))
 			}
 		}
 	}
@@ -51,7 +52,7 @@ func (d *PathDecoder) bodySchemaCandidates(body *hclsyntax.Body, schema *schema.
 				return candidates
 			}
 
-			candidates.List = append(candidates.List, attributeSchemaToCandidate(name, attr, editRng))
+			candidates.List = append(candidates.List, attributeSchemaToCandidate(ctx, name, attr, editRng))
 			count++
 		}
 	} else if attr := schema.AnyAttribute; attr != nil && len(prefix) == 0 {
@@ -59,7 +60,7 @@ func (d *PathDecoder) bodySchemaCandidates(body *hclsyntax.Body, schema *schema.
 			return candidates
 		}
 
-		candidates.List = append(candidates.List, attributeSchemaToCandidate("name", attr, editRng))
+		candidates.List = append(candidates.List, attributeSchemaToCandidate(ctx, "name", attr, editRng))
 		count++
 	}
 

--- a/decoder/candidates.go
+++ b/decoder/candidates.go
@@ -38,6 +38,8 @@ func (d *PathDecoder) CandidatesAtPos(ctx context.Context, filename string, pos 
 		outerBodyRng = ob.Range()
 	}
 
+	ctx = schema.WithPrefillRequiredFields(ctx, d.PrefillRequiredFields)
+
 	return d.candidatesAtPos(ctx, rootBody, outerBodyRng, d.pathCtx.Schema, pos)
 }
 
@@ -71,7 +73,7 @@ func (d *PathDecoder) candidatesAtPos(ctx context.Context, body *hclsyntax.Body,
 		if attr.NameRange.ContainsPos(pos) {
 			prefixRng := attr.NameRange
 			prefixRng.End = pos
-			return d.bodySchemaCandidates(body, bodySchema, prefixRng, attr.Range()), nil
+			return d.bodySchemaCandidates(ctx, body, bodySchema, prefixRng, attr.Range()), nil
 		}
 		if attr.EqualsRange.ContainsPos(pos) {
 			return lang.ZeroCandidates(), nil
@@ -98,7 +100,7 @@ func (d *PathDecoder) candidatesAtPos(ctx context.Context, body *hclsyntax.Body,
 			if block.TypeRange.ContainsPos(pos) {
 				prefixRng := block.TypeRange
 				prefixRng.End = pos
-				return d.bodySchemaCandidates(body, bodySchema, prefixRng, block.Range()), nil
+				return d.bodySchemaCandidates(ctx, body, bodySchema, prefixRng, block.Range()), nil
 			}
 
 			for i, labelRange := range block.LabelRanges {
@@ -152,7 +154,7 @@ func (d *PathDecoder) candidatesAtPos(ctx context.Context, body *hclsyntax.Body,
 		rng = tokenRng
 	}
 
-	return d.bodySchemaCandidates(body, bodySchema, rng, rng), nil
+	return d.bodySchemaCandidates(ctx, body, bodySchema, rng, rng), nil
 }
 
 func (d *PathDecoder) isPosInsideAttrExpr(attr *hclsyntax.Attribute, pos hcl.Pos) bool {

--- a/decoder/expr_list_completion.go
+++ b/decoder/expr_list_completion.go
@@ -17,7 +17,7 @@ func (list List) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candid
 			label = fmt.Sprintf("[ %s ]", list.cons.Elem.FriendlyName())
 		}
 
-		d := list.cons.EmptyCompletionData(1, 0)
+		d := list.cons.EmptyCompletionData(ctx, 1, 0)
 
 		return []lang.Candidate{
 			{

--- a/decoder/expr_map_completion.go
+++ b/decoder/expr_map_completion.go
@@ -18,7 +18,7 @@ func (m Map) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate 
 			label = fmt.Sprintf(`{ "key" = %s }`, m.cons.Elem.FriendlyName())
 		}
 
-		cData := m.cons.EmptyCompletionData(1, 0)
+		cData := m.cons.EmptyCompletionData(ctx, 1, 0)
 
 		return []lang.Candidate{
 			{
@@ -62,7 +62,7 @@ func (m Map) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate 
 			return []lang.Candidate{}
 		}
 
-		cData := m.cons.Elem.EmptyCompletionData(2, 0)
+		cData := m.cons.Elem.EmptyCompletionData(ctx, 2, 0)
 		kind := lang.AttributeCandidateKind
 		// TODO: replace "attribute" kind w/ Elem type
 

--- a/decoder/expr_object.go
+++ b/decoder/expr_object.go
@@ -39,33 +39,3 @@ func (obj Object) ReferenceTargets(ctx context.Context, targetCtx *TargetContext
 	// TODO
 	return nil
 }
-
-type ObjectAttributes struct {
-	expr hcl.Expression
-	cons schema.ObjectAttributes
-}
-
-func (oa ObjectAttributes) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate {
-	// TODO
-	return nil
-}
-
-func (oa ObjectAttributes) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData {
-	// TODO
-	return nil
-}
-
-func (oa ObjectAttributes) SemanticTokens(ctx context.Context) []lang.SemanticToken {
-	// TODO
-	return nil
-}
-
-func (oa ObjectAttributes) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {
-	// TODO
-	return nil
-}
-
-func (oa ObjectAttributes) ReferenceTargets(ctx context.Context, targetCtx *TargetContext) reference.Targets {
-	// TODO
-	return nil
-}

--- a/decoder/expr_set_completion.go
+++ b/decoder/expr_set_completion.go
@@ -17,7 +17,7 @@ func (set Set) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidat
 			label = fmt.Sprintf("[ %s ]", set.cons.Elem.FriendlyName())
 		}
 
-		d := set.cons.EmptyCompletionData(1, 0)
+		d := set.cons.EmptyCompletionData(ctx, 1, 0)
 
 		return []lang.Candidate{
 			{

--- a/decoder/expr_tuple_completion.go
+++ b/decoder/expr_tuple_completion.go
@@ -28,7 +28,7 @@ func (tuple Tuple) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Cand
 			label = fmt.Sprintf("[ %s ]", elemLabel)
 		}
 
-		d := tuple.cons.EmptyCompletionData(1, 0)
+		d := tuple.cons.EmptyCompletionData(ctx, 1, 0)
 
 		return []lang.Candidate{
 			{

--- a/decoder/expression_test.go
+++ b/decoder/expression_test.go
@@ -18,7 +18,6 @@ var (
 	_ Expression = LiteralType{}
 	_ Expression = LiteralValue{}
 	_ Expression = Map{}
-	_ Expression = ObjectAttributes{}
 	_ Expression = Object{}
 	_ Expression = Set{}
 	_ Expression = Reference{}
@@ -29,7 +28,6 @@ var (
 	_ ReferenceOriginsExpression = List{}
 	_ ReferenceOriginsExpression = LiteralType{}
 	_ ReferenceOriginsExpression = Map{}
-	_ ReferenceOriginsExpression = ObjectAttributes{}
 	_ ReferenceOriginsExpression = Object{}
 	_ ReferenceOriginsExpression = Set{}
 	_ ReferenceOriginsExpression = Reference{}
@@ -39,7 +37,6 @@ var (
 	_ ReferenceTargetsExpression = List{}
 	_ ReferenceTargetsExpression = LiteralType{}
 	_ ReferenceTargetsExpression = Map{}
-	_ ReferenceTargetsExpression = ObjectAttributes{}
 	_ ReferenceTargetsExpression = Object{}
 	_ ReferenceTargetsExpression = Reference{}
 	_ ReferenceTargetsExpression = Tuple{}

--- a/decoder/label_candidates.go
+++ b/decoder/label_candidates.go
@@ -1,6 +1,7 @@
 package decoder
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -164,7 +165,8 @@ func requiredFieldsSnippet(bodySchema *schema.BodySchema, placeholder int, inden
 
 		var snippet string
 		if attr.Constraint != nil {
-			snippet = attr.Constraint.EmptyCompletionData(placeholder, indentCount).Snippet
+			ctx := schema.WithPrefillRequiredFields(context.Background(), true)
+			snippet = attr.Constraint.EmptyCompletionData(ctx, placeholder, indentCount).Snippet
 		} else {
 			snippet = snippetForExprContraint(uint(placeholder), attr.Expr)
 		}

--- a/decoder/label_candidates.go
+++ b/decoder/label_candidates.go
@@ -165,6 +165,9 @@ func requiredFieldsSnippet(bodySchema *schema.BodySchema, placeholder int, inden
 
 		var snippet string
 		if attr.Constraint != nil {
+			// We already know we want to do pre-filling at this point
+			// We could plumb through the context here, but it saves us
+			// an argument in multiple functions above.
 			ctx := schema.WithPrefillRequiredFields(context.Background(), true)
 			snippet = attr.Constraint.EmptyCompletionData(ctx, placeholder, indentCount).Snippet
 		} else {

--- a/schema/constraint.go
+++ b/schema/constraint.go
@@ -1,6 +1,8 @@
 package schema
 
 import (
+	"context"
+
 	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -16,7 +18,7 @@ type Constraint interface {
 	// there is no corresponding configuration, such as when the Constraint
 	// is part of another and it is desirable to complete
 	// the parent constraint as whole.
-	EmptyCompletionData(nextPlaceholder int, nestingLevel int) CompletionData
+	EmptyCompletionData(ctx context.Context, nextPlaceholder int, nestingLevel int) CompletionData
 }
 
 type ConstraintWithHoverData interface {

--- a/schema/constraint_any_expression.go
+++ b/schema/constraint_any_expression.go
@@ -1,6 +1,8 @@
 package schema
 
 import (
+	"context"
+
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -28,7 +30,7 @@ func (ae AnyExpression) Copy() Constraint {
 	}
 }
 
-func (ae AnyExpression) EmptyCompletionData(nextPlaceholder int, nestingLevel int) CompletionData {
+func (ae AnyExpression) EmptyCompletionData(ctx context.Context, nextPlaceholder int, nestingLevel int) CompletionData {
 	// TODO
 	return CompletionData{}
 }

--- a/schema/constraint_keyword.go
+++ b/schema/constraint_keyword.go
@@ -1,6 +1,8 @@
 package schema
 
 import (
+	"context"
+
 	"github.com/hashicorp/hcl-lang/lang"
 )
 
@@ -36,7 +38,7 @@ func (k Keyword) Copy() Constraint {
 	}
 }
 
-func (k Keyword) EmptyCompletionData(nextPlaceholder int, nestingLevel int) CompletionData {
+func (k Keyword) EmptyCompletionData(ctx context.Context, nextPlaceholder int, nestingLevel int) CompletionData {
 	return CompletionData{
 		TriggerSuggest:  true,
 		NextPlaceholder: nextPlaceholder,

--- a/schema/constraint_list.go
+++ b/schema/constraint_list.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hashicorp/hcl-lang/lang"
@@ -48,7 +49,7 @@ func (l List) Copy() Constraint {
 	}
 }
 
-func (l List) EmptyCompletionData(nextPlaceholder int, nestingLevel int) CompletionData {
+func (l List) EmptyCompletionData(ctx context.Context, nextPlaceholder int, nestingLevel int) CompletionData {
 	if l.Elem == nil {
 		return CompletionData{
 			NewText:         "[ ]",
@@ -57,7 +58,7 @@ func (l List) EmptyCompletionData(nextPlaceholder int, nestingLevel int) Complet
 		}
 	}
 
-	elemData := l.Elem.EmptyCompletionData(nextPlaceholder, nestingLevel)
+	elemData := l.Elem.EmptyCompletionData(ctx, nextPlaceholder, nestingLevel)
 	if elemData.NewText == "" || elemData.Snippet == "" {
 		return CompletionData{
 			NewText:         "[ ]",

--- a/schema/constraint_literal_type.go
+++ b/schema/constraint_literal_type.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hashicorp/hcl-lang/lang"
@@ -36,7 +37,7 @@ func (lt LiteralType) Copy() Constraint {
 	}
 }
 
-func (lt LiteralType) EmptyCompletionData(nextPlaceholder int, nestingLevel int) CompletionData {
+func (lt LiteralType) EmptyCompletionData(ctx context.Context, nextPlaceholder int, nestingLevel int) CompletionData {
 	if lt.Type.IsPrimitiveType() {
 		var newText, snippet string
 
@@ -69,7 +70,7 @@ func (lt LiteralType) EmptyCompletionData(nextPlaceholder int, nestingLevel int)
 				Type: lt.Type.ElementType(),
 			},
 		}
-		return listCons.EmptyCompletionData(nextPlaceholder, nestingLevel)
+		return listCons.EmptyCompletionData(ctx, nextPlaceholder, nestingLevel)
 	}
 	if lt.Type.IsSetType() {
 		setCons := Set{
@@ -77,7 +78,7 @@ func (lt LiteralType) EmptyCompletionData(nextPlaceholder int, nestingLevel int)
 				Type: lt.Type.ElementType(),
 			},
 		}
-		return setCons.EmptyCompletionData(nextPlaceholder, nestingLevel)
+		return setCons.EmptyCompletionData(ctx, nextPlaceholder, nestingLevel)
 	}
 	if lt.Type.IsMapType() {
 		mapCons := Map{
@@ -85,7 +86,7 @@ func (lt LiteralType) EmptyCompletionData(nextPlaceholder int, nestingLevel int)
 				Type: lt.Type.ElementType(),
 			},
 		}
-		return mapCons.EmptyCompletionData(nextPlaceholder, nestingLevel)
+		return mapCons.EmptyCompletionData(ctx, nextPlaceholder, nestingLevel)
 	}
 	if lt.Type.IsTupleType() {
 		types := lt.Type.TupleElementTypes()
@@ -95,7 +96,7 @@ func (lt LiteralType) EmptyCompletionData(nextPlaceholder int, nestingLevel int)
 				Type: typ,
 			}
 		}
-		return tupleCons.EmptyCompletionData(nextPlaceholder, nestingLevel)
+		return tupleCons.EmptyCompletionData(ctx, nextPlaceholder, nestingLevel)
 	}
 	if lt.Type.IsObjectType() {
 		attrTypes := lt.Type.AttributeTypes()
@@ -117,7 +118,7 @@ func (lt LiteralType) EmptyCompletionData(nextPlaceholder int, nestingLevel int)
 		cons := Object{
 			Attributes: attrs,
 		}
-		return cons.EmptyCompletionData(nextPlaceholder, nestingLevel)
+		return cons.EmptyCompletionData(ctx, nextPlaceholder, nestingLevel)
 	}
 
 	return CompletionData{

--- a/schema/constraint_literal_value.go
+++ b/schema/constraint_literal_value.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strconv"
@@ -38,7 +39,7 @@ func (lv LiteralValue) Copy() Constraint {
 	}
 }
 
-func (lv LiteralValue) EmptyCompletionData(nextPlaceholder int, nestingLevel int) CompletionData {
+func (lv LiteralValue) EmptyCompletionData(ctx context.Context, nextPlaceholder int, nestingLevel int) CompletionData {
 	if lv.Value.Type().IsPrimitiveType() {
 		var value string
 		switch lv.Value.Type() {
@@ -75,7 +76,7 @@ func (lv LiteralValue) EmptyCompletionData(nextPlaceholder int, nestingLevel int
 			c := LiteralValue{
 				Value: val,
 			}
-			cData := c.EmptyCompletionData(lastPlaceholder, nestingLevel)
+			cData := c.EmptyCompletionData(ctx, lastPlaceholder, nestingLevel)
 			if cData.NewText == "" || cData.Snippet == "" {
 				return CompletionData{
 					NextPlaceholder: lastPlaceholder,
@@ -103,7 +104,7 @@ func (lv LiteralValue) EmptyCompletionData(nextPlaceholder int, nestingLevel int
 			c := LiteralValue{
 				Value: val,
 			}
-			cData := c.EmptyCompletionData(lastPlaceholder, nestingLevel)
+			cData := c.EmptyCompletionData(ctx, lastPlaceholder, nestingLevel)
 			if cData.NewText == "" || cData.Snippet == "" {
 				return CompletionData{
 					NextPlaceholder: lastPlaceholder,
@@ -131,7 +132,7 @@ func (lv LiteralValue) EmptyCompletionData(nextPlaceholder int, nestingLevel int
 			c := LiteralValue{
 				Value: val,
 			}
-			cData := c.EmptyCompletionData(lastPlaceholder, nestingLevel)
+			cData := c.EmptyCompletionData(ctx, lastPlaceholder, nestingLevel)
 			if cData.NewText == "" || cData.Snippet == "" {
 				return CompletionData{
 					NextPlaceholder: lastPlaceholder,
@@ -163,7 +164,7 @@ func (lv LiteralValue) EmptyCompletionData(nextPlaceholder int, nestingLevel int
 				Value: val,
 			}
 
-			cData := cons.EmptyCompletionData(lastPlaceholder, nestingLevel+1)
+			cData := cons.EmptyCompletionData(ctx, lastPlaceholder, nestingLevel+1)
 			if cData.NewText == "" || cData.Snippet == "" {
 				return CompletionData{
 					NextPlaceholder: lastPlaceholder,
@@ -206,7 +207,7 @@ func (lv LiteralValue) EmptyCompletionData(nextPlaceholder int, nestingLevel int
 		cons := Object{
 			Attributes: attrs,
 		}
-		return cons.EmptyCompletionData(nextPlaceholder, nestingLevel)
+		return cons.EmptyCompletionData(ctx, nextPlaceholder, nestingLevel)
 	}
 
 	return CompletionData{

--- a/schema/constraint_map.go
+++ b/schema/constraint_map.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -56,7 +57,7 @@ func (m Map) Copy() Constraint {
 	}
 }
 
-func (m Map) EmptyCompletionData(nextPlaceholder int, nestingLevel int) CompletionData {
+func (m Map) EmptyCompletionData(ctx context.Context, nextPlaceholder int, nestingLevel int) CompletionData {
 	rootNesting := strings.Repeat("  ", nestingLevel)
 	insideNesting := strings.Repeat("  ", nestingLevel+1)
 
@@ -68,7 +69,7 @@ func (m Map) EmptyCompletionData(nextPlaceholder int, nestingLevel int) Completi
 		}
 	}
 
-	elemData := m.Elem.EmptyCompletionData(nextPlaceholder+1, nestingLevel+1)
+	elemData := m.Elem.EmptyCompletionData(ctx, nextPlaceholder+1, nestingLevel+1)
 	if elemData.NewText == "" || elemData.Snippet == "" {
 		return CompletionData{
 			NewText:         fmt.Sprintf("{\n%s\n%s}", insideNesting, rootNesting),

--- a/schema/constraint_object.go
+++ b/schema/constraint_object.go
@@ -74,6 +74,10 @@ func (o Object) EmptyCompletionData(ctx context.Context, placeholder int, nestin
 		TriggerSuggest:  triggerSuggest,
 	}
 
+	if !prefillRequiredFields(ctx) {
+		return emptyObjectData
+	}
+
 	attrData, ok := o.attributesCompletionData(ctx, placeholder, nestingLevel)
 	if !ok {
 		return emptyObjectData

--- a/schema/constraint_object.go
+++ b/schema/constraint_object.go
@@ -39,7 +39,7 @@ func (o Object) FriendlyName() string {
 
 func (o Object) Copy() Constraint {
 	return Object{
-		Attributes:  o.Attributes.Copy().(ObjectAttributes),
+		Attributes:  o.Attributes.Copy(),
 		Name:        o.Name,
 		Description: o.Description,
 	}
@@ -196,28 +196,10 @@ func (o Object) ConstraintType() (cty.Type, bool) {
 	return cty.Object(objAttributes), true
 }
 
-func (ObjectAttributes) isConstraintImpl() constraintSigil {
-	return constraintSigil{}
-}
-
-func (oa ObjectAttributes) FriendlyName() string {
-	return "attributes"
-}
-
-func (oa ObjectAttributes) Copy() Constraint {
+func (oa ObjectAttributes) Copy() ObjectAttributes {
 	m := make(ObjectAttributes, 0)
 	for name, aSchema := range oa {
 		m[name] = aSchema.Copy()
 	}
 	return m
-}
-
-func (oa ObjectAttributes) EmptyCompletionData(ctx context.Context, nextPlaceholder int, nestingLevel int) CompletionData {
-	// TODO
-	return CompletionData{}
-}
-
-func (oa ObjectAttributes) EmptyHoverData(nestingLevel int) *HoverData {
-	// TODO
-	return nil
 }

--- a/schema/constraint_object.go
+++ b/schema/constraint_object.go
@@ -60,10 +60,13 @@ func prefillRequiredFields(ctx context.Context) bool {
 }
 
 func (o Object) EmptyCompletionData(ctx context.Context, placeholder int, nestingLevel int) CompletionData {
+	rootNesting := strings.Repeat("  ", nestingLevel)
+	attrNesting := strings.Repeat("  ", nestingLevel+1)
+
 	if len(o.Attributes) == 0 {
 		return CompletionData{
-			NewText:         "{}",
-			Snippet:         fmt.Sprintf("{ ${%d} }", placeholder),
+			NewText:         fmt.Sprintf("{\n%s\n%s}", attrNesting, rootNesting),
+			Snippet:         fmt.Sprintf("{\n%s${%d}\n%s}", attrNesting, placeholder, rootNesting),
 			NextPlaceholder: placeholder + 1,
 		}
 	}
@@ -71,7 +74,6 @@ func (o Object) EmptyCompletionData(ctx context.Context, placeholder int, nestin
 	newText := "{\n"
 	snippet := "{\n"
 
-	nesting := strings.Repeat("  ", nestingLevel+1)
 	lastPlaceholder := placeholder
 
 	attrNames := sortedObjectExprAttrNames(o.Attributes)
@@ -81,15 +83,15 @@ func (o Object) EmptyCompletionData(ctx context.Context, placeholder int, nestin
 		cData := attr.Constraint.EmptyCompletionData(ctx, lastPlaceholder, nestingLevel+1)
 		if cData.NewText == "" || cData.Snippet == "" {
 			return CompletionData{
-				NewText:         "{}",
-				Snippet:         fmt.Sprintf("{ ${%d} }", placeholder),
+				NewText:         fmt.Sprintf("{\n%s\n%s}", attrNesting, rootNesting),
+				Snippet:         fmt.Sprintf("{\n%s${%d}\n%s}", attrNesting, placeholder, rootNesting),
 				TriggerSuggest:  cData.TriggerSuggest,
 				NextPlaceholder: placeholder + 1,
 			}
 		}
 
-		newText += fmt.Sprintf("%s%s = %s\n", nesting, name, cData.NewText)
-		snippet += fmt.Sprintf("%s%s = %s\n", nesting, name, cData.Snippet)
+		newText += fmt.Sprintf("%s%s = %s\n", attrNesting, name, cData.NewText)
+		snippet += fmt.Sprintf("%s%s = %s\n", attrNesting, name, cData.Snippet)
 		lastPlaceholder = cData.NextPlaceholder
 	}
 

--- a/schema/constraint_one_of.go
+++ b/schema/constraint_one_of.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -74,14 +75,14 @@ func namesContain(names []string, name string) bool {
 	return false
 }
 
-func (o OneOf) EmptyCompletionData(nextPlaceholder int, nestingLevel int) CompletionData {
+func (o OneOf) EmptyCompletionData(ctx context.Context, nextPlaceholder int, nestingLevel int) CompletionData {
 	if len(o) == 0 {
 		return CompletionData{
 			NextPlaceholder: nextPlaceholder,
 		}
 	}
 
-	cData := o[0].EmptyCompletionData(nextPlaceholder, nestingLevel)
+	cData := o[0].EmptyCompletionData(ctx, nextPlaceholder, nestingLevel)
 
 	return CompletionData{
 		NewText:         cData.NewText,

--- a/schema/constraint_reference.go
+++ b/schema/constraint_reference.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"context"
 	"errors"
 
 	"github.com/hashicorp/hcl-lang/lang"
@@ -65,7 +66,7 @@ func (ref Reference) Copy() Constraint {
 	}
 }
 
-func (ref Reference) EmptyCompletionData(nextPlaceholder int, nestingLevel int) CompletionData {
+func (ref Reference) EmptyCompletionData(ctx context.Context, nextPlaceholder int, nestingLevel int) CompletionData {
 	// TODO
 	return CompletionData{}
 }

--- a/schema/constraint_set.go
+++ b/schema/constraint_set.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hashicorp/hcl-lang/lang"
@@ -48,7 +49,7 @@ func (s Set) Copy() Constraint {
 	}
 }
 
-func (s Set) EmptyCompletionData(nextPlaceholder int, nestingLevel int) CompletionData {
+func (s Set) EmptyCompletionData(ctx context.Context, nextPlaceholder int, nestingLevel int) CompletionData {
 	if s.Elem == nil {
 		return CompletionData{
 			NewText:         "[ ]",
@@ -57,7 +58,7 @@ func (s Set) EmptyCompletionData(nextPlaceholder int, nestingLevel int) Completi
 		}
 	}
 
-	elemData := s.Elem.EmptyCompletionData(nextPlaceholder, nestingLevel)
+	elemData := s.Elem.EmptyCompletionData(ctx, nextPlaceholder, nestingLevel)
 	if elemData.NewText == "" || elemData.Snippet == "" {
 		return CompletionData{
 			NewText:         "[ ]",

--- a/schema/constraint_test.go
+++ b/schema/constraint_test.go
@@ -17,7 +17,6 @@ var (
 	_ Constraint = LiteralType{}
 	_ Constraint = LiteralValue{}
 	_ Constraint = Map{}
-	_ Constraint = ObjectAttributes{}
 	_ Constraint = Object{}
 	_ Constraint = Set{}
 	_ Constraint = Reference{}
@@ -28,7 +27,6 @@ var (
 	_ ConstraintWithHoverData = LiteralType{}
 	_ ConstraintWithHoverData = LiteralValue{}
 	_ ConstraintWithHoverData = Map{}
-	_ ConstraintWithHoverData = ObjectAttributes{}
 	_ ConstraintWithHoverData = Object{}
 	_ ConstraintWithHoverData = Set{}
 	_ ConstraintWithHoverData = Tuple{}

--- a/schema/constraint_test.go
+++ b/schema/constraint_test.go
@@ -325,13 +325,15 @@ tomap({
 
 func TestConstraint_EmptyCompletionData(t *testing.T) {
 	testCases := []struct {
-		cons             Constraint
-		expectedCompData CompletionData
+		cons                  Constraint
+		prefillRequiredFields bool
+		expectedCompData      CompletionData
 	}{
 		{
 			LiteralType{
 				Type: cty.String,
 			},
+			false,
 			CompletionData{
 				NewText:         `"value"`,
 				Snippet:         `"${1:value}"`,
@@ -344,6 +346,7 @@ func TestConstraint_EmptyCompletionData(t *testing.T) {
 					Type: cty.String,
 				},
 			},
+			false,
 			CompletionData{
 				NewText:         `[ "value" ]`,
 				Snippet:         `[ "${1:value}" ]`,
@@ -354,6 +357,7 @@ func TestConstraint_EmptyCompletionData(t *testing.T) {
 			LiteralType{
 				Type: cty.List(cty.String),
 			},
+			false,
 			CompletionData{
 				NewText:         `[ "value" ]`,
 				Snippet:         `[ "${1:value}" ]`,
@@ -366,6 +370,7 @@ func TestConstraint_EmptyCompletionData(t *testing.T) {
 					Type: cty.String,
 				},
 			},
+			false,
 			CompletionData{
 				NewText:         `[ "value" ]`,
 				Snippet:         `[ "${1:value}" ]`,
@@ -376,6 +381,7 @@ func TestConstraint_EmptyCompletionData(t *testing.T) {
 			LiteralType{
 				Type: cty.Set(cty.String),
 			},
+			false,
 			CompletionData{
 				NewText:         `[ "value" ]`,
 				Snippet:         `[ "${1:value}" ]`,
@@ -390,6 +396,7 @@ func TestConstraint_EmptyCompletionData(t *testing.T) {
 					"baz": cty.List(cty.String),
 				}),
 			},
+			true,
 			CompletionData{
 				NewText: `{
   bar = 0
@@ -415,6 +422,7 @@ func TestConstraint_EmptyCompletionData(t *testing.T) {
 					}),
 				}),
 			},
+			true,
 			CompletionData{
 				NewText: `{
   bar = 0
@@ -439,6 +447,7 @@ func TestConstraint_EmptyCompletionData(t *testing.T) {
 			LiteralValue{
 				Value: cty.StringVal("foobar"),
 			},
+			false,
 			CompletionData{
 				NewText:         `"foobar"`,
 				Snippet:         `"foobar"`,
@@ -449,6 +458,7 @@ func TestConstraint_EmptyCompletionData(t *testing.T) {
 			LiteralValue{
 				Value: cty.StringVal("foo\nbar"),
 			},
+			false,
 			CompletionData{
 				NewText: `<<<STRING
 foo
@@ -467,6 +477,7 @@ STRING
 			LiteralValue{
 				Value: cty.NumberIntVal(42),
 			},
+			false,
 			CompletionData{
 				NewText:         "42",
 				Snippet:         "42",
@@ -481,6 +492,7 @@ STRING
 					"baz": cty.ListVal([]cty.Value{cty.StringVal("toot")}),
 				}),
 			},
+			true,
 			CompletionData{
 				NewText: `{
   bar = 42
@@ -502,6 +514,7 @@ STRING
 					"bar": cty.StringVal("boo"),
 				}),
 			},
+			false,
 			CompletionData{
 				NewText: `{
   "bar" = "boo"
@@ -525,6 +538,7 @@ STRING
 					}),
 				}),
 			},
+			false,
 			CompletionData{
 				NewText: `{
   "bar" = {
@@ -556,6 +570,7 @@ STRING
 					}),
 				}),
 			},
+			true,
 			CompletionData{
 				NewText: `{
   bar = 43
@@ -587,6 +602,7 @@ STRING
 					}),
 				}),
 			},
+			true,
 			CompletionData{
 				NewText: `{
   bar = 43
@@ -613,6 +629,7 @@ STRING
 					Keyword: "kw",
 				},
 			},
+			false,
 			CompletionData{
 				NewText:         "[ ]",
 				Snippet:         "[ ${1} ]",
@@ -626,6 +643,7 @@ STRING
 					Keyword: "kw",
 				},
 			},
+			false,
 			CompletionData{
 				NewText:         "[ ]",
 				Snippet:         "[ ${1} ]",
@@ -641,6 +659,7 @@ STRING
 					},
 				},
 			},
+			false,
 			CompletionData{
 				NewText:         "[ ]",
 				Snippet:         "[ ${1} ]",
@@ -654,6 +673,7 @@ STRING
 					Keyword: "kw",
 				},
 			},
+			false,
 			CompletionData{
 				NewText: `{
   
@@ -673,6 +693,7 @@ STRING
 					},
 				},
 			},
+			false,
 			CompletionData{
 				NewText: `{
   "name" = {
@@ -696,6 +717,7 @@ STRING
 					},
 				},
 			},
+			false,
 			CompletionData{
 				NewText: `{
   "name" = {
@@ -720,6 +742,7 @@ STRING
 					},
 				},
 			},
+			false,
 			CompletionData{
 				NewText: `{
   
@@ -748,6 +771,7 @@ STRING
 					},
 				},
 			},
+			true,
 			CompletionData{
 				NewText: `{
   bar = "value"
@@ -758,6 +782,35 @@ STRING
   foo = ${2:false}
 }`,
 				NextPlaceholder: 3,
+			},
+		},
+		{
+			Object{
+				Attributes: map[string]*AttributeSchema{
+					"foo": {
+						Constraint: LiteralType{
+							Type: cty.Bool,
+						},
+						IsRequired: true,
+					},
+					"bar": {
+						Constraint: LiteralType{
+							Type: cty.String,
+						},
+						IsRequired: true,
+					},
+				},
+			},
+			false,
+			CompletionData{
+				NewText: `{
+  
+}`,
+				Snippet: `{
+  ${1}
+}`,
+				NextPlaceholder: 2,
+				TriggerSuggest:  true,
 			},
 		},
 		{
@@ -784,6 +837,7 @@ STRING
 					},
 				},
 			},
+			true,
 			CompletionData{
 				NewText: `{
   bar = {
@@ -804,6 +858,7 @@ STRING
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%2d", i), func(t *testing.T) {
 			ctx := context.Background()
+			ctx = WithPrefillRequiredFields(ctx, tc.prefillRequiredFields)
 			data := tc.cons.EmptyCompletionData(ctx, 1, 0)
 			if diff := cmp.Diff(tc.expectedCompData, data); diff != "" {
 				t.Fatalf("unexpected completion  data: %s", diff)

--- a/schema/constraint_test.go
+++ b/schema/constraint_test.go
@@ -738,11 +738,13 @@ STRING
 						Constraint: LiteralType{
 							Type: cty.Bool,
 						},
+						IsRequired: true,
 					},
 					"bar": {
 						Constraint: LiteralType{
 							Type: cty.String,
 						},
+						IsRequired: true,
 					},
 				},
 			},
@@ -765,6 +767,7 @@ STRING
 						Constraint: LiteralType{
 							Type: cty.Bool,
 						},
+						IsRequired: true,
 					},
 					"bar": {
 						Constraint: Object{
@@ -773,9 +776,11 @@ STRING
 									Constraint: LiteralType{
 										Type: cty.String,
 									},
+									IsRequired: true,
 								},
 							},
 						},
+						IsRequired: true,
 					},
 				},
 			},
@@ -797,7 +802,7 @@ STRING
 		},
 	}
 	for i, tc := range testCases {
-		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%2d", i), func(t *testing.T) {
 			ctx := context.Background()
 			data := tc.cons.EmptyCompletionData(ctx, 1, 0)
 			if diff := cmp.Diff(tc.expectedCompData, data); diff != "" {

--- a/schema/constraint_test.go
+++ b/schema/constraint_test.go
@@ -721,10 +721,78 @@ STRING
 				},
 			},
 			CompletionData{
-				NewText:         `{}`,
-				Snippet:         `{ ${1} }`,
+				NewText: `{
+  
+}`,
+				Snippet: `{
+  ${1}
+}`,
 				TriggerSuggest:  true,
 				NextPlaceholder: 2,
+			},
+		},
+		{
+			Object{
+				Attributes: map[string]*AttributeSchema{
+					"foo": {
+						Constraint: LiteralType{
+							Type: cty.Bool,
+						},
+					},
+					"bar": {
+						Constraint: LiteralType{
+							Type: cty.String,
+						},
+					},
+				},
+			},
+			CompletionData{
+				NewText: `{
+  bar = "value"
+  foo = false
+}`,
+				Snippet: `{
+  bar = "${1:value}"
+  foo = ${2:false}
+}`,
+				NextPlaceholder: 3,
+			},
+		},
+		{
+			Object{
+				Attributes: map[string]*AttributeSchema{
+					"foo": {
+						Constraint: LiteralType{
+							Type: cty.Bool,
+						},
+					},
+					"bar": {
+						Constraint: Object{
+							Attributes: map[string]*AttributeSchema{
+								"baz": {
+									Constraint: LiteralType{
+										Type: cty.String,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			CompletionData{
+				NewText: `{
+  bar = {
+    baz = "value"
+  }
+  foo = false
+}`,
+				Snippet: `{
+  bar = {
+    baz = "${1:value}"
+  }
+  foo = ${2:false}
+}`,
+				NextPlaceholder: 3,
 			},
 		},
 	}

--- a/schema/constraint_test.go
+++ b/schema/constraint_test.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -731,7 +732,8 @@ STRING
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			data := tc.cons.EmptyCompletionData(1, 0)
+			ctx := context.Background()
+			data := tc.cons.EmptyCompletionData(ctx, 1, 0)
 			if diff := cmp.Diff(tc.expectedCompData, data); diff != "" {
 				t.Fatalf("unexpected completion  data: %s", diff)
 			}

--- a/schema/constraint_tuple.go
+++ b/schema/constraint_tuple.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -41,7 +42,7 @@ func (t Tuple) Copy() Constraint {
 	return newTuple
 }
 
-func (t Tuple) EmptyCompletionData(nextPlaceholder int, nestingLevel int) CompletionData {
+func (t Tuple) EmptyCompletionData(ctx context.Context, nextPlaceholder int, nestingLevel int) CompletionData {
 	if len(t.Elems) == 0 {
 		return CompletionData{
 			NewText:         "[ ]",
@@ -55,7 +56,7 @@ func (t Tuple) EmptyCompletionData(nextPlaceholder int, nestingLevel int) Comple
 	lastPlaceholder := nextPlaceholder
 
 	for i, elem := range t.Elems {
-		cData := elem.EmptyCompletionData(lastPlaceholder, nestingLevel)
+		cData := elem.EmptyCompletionData(ctx, lastPlaceholder, nestingLevel)
 		if cData.NewText == "" || cData.Snippet == "" {
 			return CompletionData{
 				NewText:         "[ ]",

--- a/schema/constraint_type_declaration.go
+++ b/schema/constraint_type_declaration.go
@@ -1,5 +1,7 @@
 package schema
 
+import "context"
+
 // TypeDeclaration represents a type declaration as
 // interpreted by HCL's ext/typeexpr package,
 // i.e. declaration of cty.Type in HCL
@@ -19,7 +21,7 @@ func (td TypeDeclaration) Copy() Constraint {
 	return TypeDeclaration{}
 }
 
-func (td TypeDeclaration) EmptyCompletionData(nextPlaceholder int, nestingLevel int) CompletionData {
+func (td TypeDeclaration) EmptyCompletionData(ctx context.Context, nextPlaceholder int, nestingLevel int) CompletionData {
 	return CompletionData{
 		TriggerSuggest:  true,
 		NextPlaceholder: nextPlaceholder,


### PR DESCRIPTION
It was discovered while implementing https://github.com/hashicorp/hcl-lang/pull/203 that `schema.Object.EmptyCompletionData()` _always_ pre-fills _all_ attributes, which is undesirable.

 - if we need to pre-fill any attributes, it should only be the required ones, not all
 - pre-filling attributes has historically been gated via `PrefillRequiredFields`, and this should be reflected in objects as well

I also did a little bit of refactoring to (hopefully) make the code more readable, in spite of the additional complexity.

All commits are also part of https://github.com/hashicorp/hcl-lang/pull/203 but I decoupled them here to make it easier to review.

--- 

## Side note

This will also enable us to later customise the existing literal type/value pre-filling like `attr = "value"` or `attr = false` - maybe put it behind a similar feature toggle or do any A/B testing etc.

--- 

I wanted to attach some GIFs but this is unfortunately hard to demo without the remaining work in https://github.com/hashicorp/hcl-lang/pull/203
