### PR TITLE
decoder: fix Map test name

### DIFF
--- a/decoder/expr_map_completion_test.go
+++ b/decoder/expr_map_completion_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 )
 
-func TestCompletionAtPos_exprTypeDeclaration(t *testing.T) {
+func TestCompletionAtPos_exprMap(t *testing.T) {
 	testCases := []struct {
 		testName           string
 		attrSchema         map[string]*schema.AttributeSchema


### PR DESCRIPTION
This fixes an earlier copy-paste error similar to https://github.com/hashicorp/hcl-lang/pull/223