### PR TITLE
decoder: Add support for `AnyExpression` as `Constraint`

### DIFF
--- a/decoder/expr_any.go
+++ b/decoder/expr_any.go
@@ -6,10 +6,27 @@ package decoder
 import (
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
 )
 
 type Any struct {
 	expr    hcl.Expression
 	cons    schema.AnyExpression
 	pathCtx *PathContext
+}
+
+func (a Any) InferType() (cty.Type, bool) {
+	consType, ok := a.cons.ConstraintType()
+	if !ok {
+		return consType, false
+	}
+
+	if consType == cty.DynamicPseudoType && !isEmptyExpression(a.expr) {
+		val, diags := a.expr.Value(nil)
+		if !diags.HasErrors() {
+			consType = val.Type()
+		}
+	}
+
+	return consType, true
 }

--- a/decoder/expr_any.go
+++ b/decoder/expr_any.go
@@ -18,11 +18,6 @@ type Any struct {
 	pathCtx *PathContext
 }
 
-func (a Any) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData {
-	// TODO
-	return nil
-}
-
 func (a Any) SemanticTokens(ctx context.Context) []lang.SemanticToken {
 	// TODO
 	return nil

--- a/decoder/expr_any.go
+++ b/decoder/expr_any.go
@@ -4,9 +4,6 @@
 package decoder
 
 import (
-	"context"
-
-	"github.com/hashicorp/hcl-lang/reference"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
 )
@@ -15,9 +12,4 @@ type Any struct {
 	expr    hcl.Expression
 	cons    schema.AnyExpression
 	pathCtx *PathContext
-}
-
-func (a Any) ReferenceTargets(ctx context.Context, targetCtx *TargetContext) reference.Targets {
-	// TODO
-	return nil
 }

--- a/decoder/expr_any.go
+++ b/decoder/expr_any.go
@@ -17,11 +17,6 @@ type Any struct {
 	pathCtx *PathContext
 }
 
-func (a Any) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {
-	// TODO
-	return nil
-}
-
 func (a Any) ReferenceTargets(ctx context.Context, targetCtx *TargetContext) reference.Targets {
 	// TODO
 	return nil

--- a/decoder/expr_any.go
+++ b/decoder/expr_any.go
@@ -18,11 +18,6 @@ type Any struct {
 	pathCtx *PathContext
 }
 
-func (a Any) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate {
-	// TODO
-	return nil
-}
-
 func (a Any) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData {
 	// TODO
 	return nil

--- a/decoder/expr_any.go
+++ b/decoder/expr_any.go
@@ -6,7 +6,6 @@ package decoder
 import (
 	"context"
 
-	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/reference"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
@@ -16,11 +15,6 @@ type Any struct {
 	expr    hcl.Expression
 	cons    schema.AnyExpression
 	pathCtx *PathContext
-}
-
-func (a Any) SemanticTokens(ctx context.Context) []lang.SemanticToken {
-	// TODO
-	return nil
 }
 
 func (a Any) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {

--- a/decoder/expr_any_completion.go
+++ b/decoder/expr_any_completion.go
@@ -12,7 +12,7 @@ import (
 func (a Any) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate {
 	typ := a.cons.OfType
 
-	if typ.IsListType() {
+	if !a.cons.SkipLiteralComplexTypes && typ.IsListType() {
 		expr, ok := a.expr.(*hclsyntax.TupleConsExpr)
 		if !ok {
 			return a.completeNonComplexExprAtPos(ctx, pos)
@@ -27,7 +27,7 @@ func (a Any) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate 
 		return newExpression(a.pathCtx, expr, cons).CompletionAtPos(ctx, pos)
 	}
 
-	if typ.IsSetType() {
+	if !a.cons.SkipLiteralComplexTypes && typ.IsSetType() {
 		expr, ok := a.expr.(*hclsyntax.TupleConsExpr)
 		if !ok {
 			return a.completeNonComplexExprAtPos(ctx, pos)
@@ -42,7 +42,7 @@ func (a Any) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate 
 		return newExpression(a.pathCtx, expr, cons).CompletionAtPos(ctx, pos)
 	}
 
-	if typ.IsTupleType() {
+	if !a.cons.SkipLiteralComplexTypes && typ.IsTupleType() {
 		expr, ok := a.expr.(*hclsyntax.TupleConsExpr)
 		if !ok {
 			return a.completeNonComplexExprAtPos(ctx, pos)
@@ -61,7 +61,7 @@ func (a Any) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate 
 		return newExpression(a.pathCtx, expr, cons).CompletionAtPos(ctx, pos)
 	}
 
-	if typ.IsMapType() {
+	if !a.cons.SkipLiteralComplexTypes && typ.IsMapType() {
 		expr, ok := a.expr.(*hclsyntax.ObjectConsExpr)
 		if !ok {
 			return a.completeNonComplexExprAtPos(ctx, pos)
@@ -75,7 +75,7 @@ func (a Any) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate 
 		return newExpression(a.pathCtx, expr, cons).CompletionAtPos(ctx, pos)
 	}
 
-	if typ.IsObjectType() {
+	if !a.cons.SkipLiteralComplexTypes && typ.IsObjectType() {
 		expr, ok := a.expr.(*hclsyntax.ObjectConsExpr)
 		if !ok {
 			return a.completeNonComplexExprAtPos(ctx, pos)
@@ -116,8 +116,11 @@ func (a Any) completeNonComplexExprAtPos(ctx context.Context, pos hcl.Pos) []lan
 	candidates = append(candidates, fe.CompletionAtPos(ctx, pos)...)
 
 	lt := LiteralType{
-		expr:    a.expr,
-		cons:    schema.LiteralType{Type: a.cons.OfType},
+		expr: a.expr,
+		cons: schema.LiteralType{
+			Type:             a.cons.OfType,
+			SkipComplexTypes: a.cons.SkipLiteralComplexTypes,
+		},
 		pathCtx: a.pathCtx,
 	}
 	candidates = append(candidates, lt.CompletionAtPos(ctx, pos)...)

--- a/decoder/expr_any_completion.go
+++ b/decoder/expr_any_completion.go
@@ -1,0 +1,151 @@
+package decoder
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty/function"
+)
+
+func (a Any) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate {
+	if isEmptyExpression(a.expr) {
+		editRange := hcl.Range{
+			Filename: a.expr.Range().Filename,
+			Start:    pos,
+			End:      pos,
+		}
+
+		candidates := make([]lang.Candidate, 0)
+		candidates = append(candidates, a.matchingFunctions("", editRange)...)
+		candidates = append(candidates, newExpression(a.pathCtx, a.expr, schema.Reference{OfType: a.cons.OfType}).CompletionAtPos(ctx, pos)...)
+		candidates = append(candidates, newExpression(a.pathCtx, a.expr, schema.LiteralType{Type: a.cons.OfType}).CompletionAtPos(ctx, pos)...)
+
+		return candidates
+	}
+
+	switch eType := a.expr.(type) {
+	case *hclsyntax.ScopeTraversalExpr:
+		if len(eType.Traversal) > 1 {
+			// TODO! Reference completion
+			return []lang.Candidate{}
+		}
+		prefixLen := pos.Byte - eType.Traversal.SourceRange().Start.Byte
+		prefix := eType.Traversal.RootName()[0:prefixLen]
+
+		// TODO! include references
+		return a.matchingFunctions(prefix, eType.Range())
+	case *hclsyntax.FunctionCallExpr:
+		if eType.NameRange.ContainsPos(pos) {
+			prefixLen := pos.Byte - eType.NameRange.Start.Byte
+			prefix := eType.Name[0:prefixLen]
+			editRange := eType.Range()
+			return a.matchingFunctions(prefix, editRange)
+		}
+
+		f, ok := a.pathCtx.Functions[eType.Name]
+		if !ok {
+			return []lang.Candidate{} // Unknown function
+		}
+
+		parensRange := hcl.RangeBetween(eType.OpenParenRange, eType.CloseParenRange)
+		if !parensRange.ContainsPos(pos) {
+			return []lang.Candidate{} // Not inside parenthesis
+		}
+
+		paramsLen := len(f.Params)
+		if paramsLen == 0 && f.VarParam == nil {
+			return []lang.Candidate{} // Function accepts no parameters
+		}
+
+		lastArgEndPos := eType.OpenParenRange.Start
+		lastArgIdx := 0
+		for i, arg := range eType.Args {
+			// We overshot the argument and stop
+			if arg.Range().Start.Byte > pos.Byte {
+				break
+			}
+			if arg.Range().ContainsPos(pos) || arg.Range().End.Byte == pos.Byte {
+				var param function.Parameter
+				if i < paramsLen {
+					param = f.Params[i]
+				} else if f.VarParam != nil {
+					param = *f.VarParam
+				} else {
+					// Too many arguments passed to the function
+					return []lang.Candidate{}
+				}
+
+				cons := newExpression(a.pathCtx, arg, schema.AnyExpression{OfType: param.Type})
+				return cons.CompletionAtPos(ctx, pos)
+			}
+			lastArgEndPos = arg.Range().End
+			lastArgIdx = i
+		}
+
+		fileBytes := a.pathCtx.Files[eType.Range().Filename].Bytes
+		recoveredBytes := recoverLeftBytes(fileBytes, pos, func(byteOffset int, r rune) bool {
+			return (r == ',' || r == '(') && byteOffset > lastArgEndPos.Byte
+		})
+		trimmedBytes := bytes.TrimRight(recoveredBytes, " \t\n")
+
+		activePar := 0 // default to first parameter
+		if string(trimmedBytes) == "," {
+			activePar = lastArgIdx + 1
+		}
+
+		var param function.Parameter
+		if activePar < paramsLen {
+			param = f.Params[activePar]
+		} else if f.VarParam != nil {
+			param = *f.VarParam
+		} else {
+			// Too many arguments passed to the function
+			return []lang.Candidate{}
+		}
+
+		cons := newExpression(a.pathCtx, newEmptyExpressionAtPos(eType.Range().Filename, pos), schema.AnyExpression{OfType: param.Type})
+		return cons.CompletionAtPos(ctx, pos)
+	}
+
+	return []lang.Candidate{}
+}
+
+func (a Any) matchingFunctions(prefix string, editRange hcl.Range) []lang.Candidate {
+	candidates := make([]lang.Candidate, 0)
+
+	for name, f := range a.pathCtx.Functions {
+		if !strings.HasPrefix(name, prefix) {
+			continue
+		}
+		// Only suggest functions that have a matching return type
+		if a.cons.OfType.TestConformance(f.ReturnType) != nil {
+			continue
+		}
+
+		// TODO? see why accepting a completion isn't triggering signatureHelp (it does for gopls)
+		candidates = append(candidates, lang.Candidate{
+			Label:       name,
+			Detail:      fmt.Sprintf("%s(%s) %s", name, parameterNamesAsString(f), f.ReturnType.FriendlyName()),
+			Kind:        lang.FunctionCandidateKind,
+			Description: lang.Markdown(f.Description),
+			TextEdit: lang.TextEdit{
+				NewText: fmt.Sprintf("%s()", name),
+				Snippet: fmt.Sprintf("%s(${0})", name),
+				Range:   editRange,
+			},
+		})
+	}
+
+	sort.SliceStable(candidates, func(i, j int) bool {
+		return candidates[i].Label < candidates[j].Label
+	})
+
+	return candidates
+}

--- a/decoder/expr_any_completion.go
+++ b/decoder/expr_any_completion.go
@@ -1,151 +1,126 @@
 package decoder
 
 import (
-	"bytes"
 	"context"
-	"fmt"
-	"sort"
-	"strings"
 
 	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
-	"github.com/zclconf/go-cty/cty/function"
 )
 
 func (a Any) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate {
-	if isEmptyExpression(a.expr) {
-		editRange := hcl.Range{
-			Filename: a.expr.Range().Filename,
-			Start:    pos,
-			End:      pos,
-		}
+	typ := a.cons.OfType
 
-		candidates := make([]lang.Candidate, 0)
-		candidates = append(candidates, a.matchingFunctions("", editRange)...)
-		candidates = append(candidates, newExpression(a.pathCtx, a.expr, schema.Reference{OfType: a.cons.OfType}).CompletionAtPos(ctx, pos)...)
-		candidates = append(candidates, newExpression(a.pathCtx, a.expr, schema.LiteralType{Type: a.cons.OfType}).CompletionAtPos(ctx, pos)...)
-
-		return candidates
-	}
-
-	switch eType := a.expr.(type) {
-	case *hclsyntax.ScopeTraversalExpr:
-		if len(eType.Traversal) > 1 {
-			// TODO! Reference completion
-			return []lang.Candidate{}
-		}
-		prefixLen := pos.Byte - eType.Traversal.SourceRange().Start.Byte
-		prefix := eType.Traversal.RootName()[0:prefixLen]
-
-		// TODO! include references
-		return a.matchingFunctions(prefix, eType.Range())
-	case *hclsyntax.FunctionCallExpr:
-		if eType.NameRange.ContainsPos(pos) {
-			prefixLen := pos.Byte - eType.NameRange.Start.Byte
-			prefix := eType.Name[0:prefixLen]
-			editRange := eType.Range()
-			return a.matchingFunctions(prefix, editRange)
-		}
-
-		f, ok := a.pathCtx.Functions[eType.Name]
+	if typ.IsListType() {
+		expr, ok := a.expr.(*hclsyntax.TupleConsExpr)
 		if !ok {
-			return []lang.Candidate{} // Unknown function
+			return a.completeNonComplexExprAtPos(ctx, pos)
 		}
 
-		parensRange := hcl.RangeBetween(eType.OpenParenRange, eType.CloseParenRange)
-		if !parensRange.ContainsPos(pos) {
-			return []lang.Candidate{} // Not inside parenthesis
+		cons := schema.List{
+			Elem: schema.AnyExpression{
+				OfType: typ.ElementType(),
+			},
 		}
 
-		paramsLen := len(f.Params)
-		if paramsLen == 0 && f.VarParam == nil {
-			return []lang.Candidate{} // Function accepts no parameters
-		}
-
-		lastArgEndPos := eType.OpenParenRange.Start
-		lastArgIdx := 0
-		for i, arg := range eType.Args {
-			// We overshot the argument and stop
-			if arg.Range().Start.Byte > pos.Byte {
-				break
-			}
-			if arg.Range().ContainsPos(pos) || arg.Range().End.Byte == pos.Byte {
-				var param function.Parameter
-				if i < paramsLen {
-					param = f.Params[i]
-				} else if f.VarParam != nil {
-					param = *f.VarParam
-				} else {
-					// Too many arguments passed to the function
-					return []lang.Candidate{}
-				}
-
-				cons := newExpression(a.pathCtx, arg, schema.AnyExpression{OfType: param.Type})
-				return cons.CompletionAtPos(ctx, pos)
-			}
-			lastArgEndPos = arg.Range().End
-			lastArgIdx = i
-		}
-
-		fileBytes := a.pathCtx.Files[eType.Range().Filename].Bytes
-		recoveredBytes := recoverLeftBytes(fileBytes, pos, func(byteOffset int, r rune) bool {
-			return (r == ',' || r == '(') && byteOffset > lastArgEndPos.Byte
-		})
-		trimmedBytes := bytes.TrimRight(recoveredBytes, " \t\n")
-
-		activePar := 0 // default to first parameter
-		if string(trimmedBytes) == "," {
-			activePar = lastArgIdx + 1
-		}
-
-		var param function.Parameter
-		if activePar < paramsLen {
-			param = f.Params[activePar]
-		} else if f.VarParam != nil {
-			param = *f.VarParam
-		} else {
-			// Too many arguments passed to the function
-			return []lang.Candidate{}
-		}
-
-		cons := newExpression(a.pathCtx, newEmptyExpressionAtPos(eType.Range().Filename, pos), schema.AnyExpression{OfType: param.Type})
-		return cons.CompletionAtPos(ctx, pos)
+		return newExpression(a.pathCtx, expr, cons).CompletionAtPos(ctx, pos)
 	}
 
-	return []lang.Candidate{}
+	if typ.IsSetType() {
+		expr, ok := a.expr.(*hclsyntax.TupleConsExpr)
+		if !ok {
+			return a.completeNonComplexExprAtPos(ctx, pos)
+		}
+
+		cons := schema.Set{
+			Elem: schema.AnyExpression{
+				OfType: typ.ElementType(),
+			},
+		}
+
+		return newExpression(a.pathCtx, expr, cons).CompletionAtPos(ctx, pos)
+	}
+
+	if typ.IsTupleType() {
+		expr, ok := a.expr.(*hclsyntax.TupleConsExpr)
+		if !ok {
+			return a.completeNonComplexExprAtPos(ctx, pos)
+		}
+
+		elemTypes := typ.TupleElementTypes()
+		cons := schema.Tuple{
+			Elems: make([]schema.Constraint, len(elemTypes)),
+		}
+		for i, elemType := range elemTypes {
+			cons.Elems[i] = schema.LiteralType{
+				Type: elemType,
+			}
+		}
+
+		return newExpression(a.pathCtx, expr, cons).CompletionAtPos(ctx, pos)
+	}
+
+	if typ.IsMapType() {
+		expr, ok := a.expr.(*hclsyntax.ObjectConsExpr)
+		if !ok {
+			return a.completeNonComplexExprAtPos(ctx, pos)
+		}
+
+		cons := schema.Map{
+			Elem: schema.AnyExpression{
+				OfType: typ.ElementType(),
+			},
+		}
+		return newExpression(a.pathCtx, expr, cons).CompletionAtPos(ctx, pos)
+	}
+
+	if typ.IsObjectType() {
+		expr, ok := a.expr.(*hclsyntax.ObjectConsExpr)
+		if !ok {
+			return a.completeNonComplexExprAtPos(ctx, pos)
+		}
+
+		cons := schema.Object{
+			Attributes: ctyObjectToObjectAttributes(typ),
+		}
+		return newExpression(a.pathCtx, expr, cons).CompletionAtPos(ctx, pos)
+	}
+
+	return a.completeNonComplexExprAtPos(ctx, pos)
 }
 
-func (a Any) matchingFunctions(prefix string, editRange hcl.Range) []lang.Candidate {
+func (a Any) completeNonComplexExprAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate {
 	candidates := make([]lang.Candidate, 0)
 
-	for name, f := range a.pathCtx.Functions {
-		if !strings.HasPrefix(name, prefix) {
-			continue
-		}
-		// Only suggest functions that have a matching return type
-		if a.cons.OfType.TestConformance(f.ReturnType) != nil {
-			continue
-		}
+	// TODO: Support TemplateExpr https://github.com/hashicorp/terraform-ls/issues/522
+	// TODO: Support splat expression https://github.com/hashicorp/terraform-ls/issues/526
+	// TODO: Support for-in-if expression https://github.com/hashicorp/terraform-ls/issues/527
+	// TODO: Support conditional expression https://github.com/hashicorp/terraform-ls/issues/528
+	// TODO: Support operator expresssions https://github.com/hashicorp/terraform-ls/issues/529
+	// TODO: Support complex index expressions https://github.com/hashicorp/terraform-ls/issues/531
+	// TODO: Support relative traversals https://github.com/hashicorp/terraform-ls/issues/532
 
-		// TODO? see why accepting a completion isn't triggering signatureHelp (it does for gopls)
-		candidates = append(candidates, lang.Candidate{
-			Label:       name,
-			Detail:      fmt.Sprintf("%s(%s) %s", name, parameterNamesAsString(f), f.ReturnType.FriendlyName()),
-			Kind:        lang.FunctionCandidateKind,
-			Description: lang.Markdown(f.Description),
-			TextEdit: lang.TextEdit{
-				NewText: fmt.Sprintf("%s()", name),
-				Snippet: fmt.Sprintf("%s(${0})", name),
-				Range:   editRange,
-			},
-		})
+	ref := Reference{
+		expr:    a.expr,
+		cons:    schema.Reference{OfType: a.cons.OfType},
+		pathCtx: a.pathCtx,
 	}
+	candidates = append(candidates, ref.CompletionAtPos(ctx, pos)...)
 
-	sort.SliceStable(candidates, func(i, j int) bool {
-		return candidates[i].Label < candidates[j].Label
-	})
+	fe := functionExpr{
+		expr:       a.expr,
+		returnType: a.cons.OfType,
+		pathCtx:    a.pathCtx,
+	}
+	candidates = append(candidates, fe.CompletionAtPos(ctx, pos)...)
+
+	lt := LiteralType{
+		expr:    a.expr,
+		cons:    schema.LiteralType{Type: a.cons.OfType},
+		pathCtx: a.pathCtx,
+	}
+	candidates = append(candidates, lt.CompletionAtPos(ctx, pos)...)
 
 	return candidates
 }

--- a/decoder/expr_any_completion_test.go
+++ b/decoder/expr_any_completion_test.go
@@ -1657,8 +1657,8 @@ func TestCompletionAtPos_exprAny_literalTypes(t *testing.T) {
 					Detail: "bool",
 					Kind:   lang.AttributeCandidateKind,
 					TextEdit: lang.TextEdit{
-						NewText: "\"key\" = false",
-						Snippet: "\"${1:key}\" = ${2:false}",
+						NewText: "\"key\" = ",
+						Snippet: "\"${1:key}\" = ",
 						Range: hcl.Range{
 							Filename: "test.tf",
 							Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
@@ -1689,8 +1689,8 @@ func TestCompletionAtPos_exprAny_literalTypes(t *testing.T) {
 					Detail: "bool",
 					Kind:   lang.AttributeCandidateKind,
 					TextEdit: lang.TextEdit{
-						NewText: "\"key\" = false",
-						Snippet: "\"${1:key}\" = ${2:false}",
+						NewText: "\"key\" = ",
+						Snippet: "\"${1:key}\" = ",
 						Range: hcl.Range{
 							Filename: "test.tf",
 							Start:    hcl.Pos{Line: 3, Column: 3, Byte: 26},
@@ -1722,8 +1722,8 @@ func TestCompletionAtPos_exprAny_literalTypes(t *testing.T) {
 					Detail: "bool",
 					Kind:   lang.AttributeCandidateKind,
 					TextEdit: lang.TextEdit{
-						NewText: "\"key\" = false",
-						Snippet: "\"${1:key}\" = ${2:false}",
+						NewText: "\"key\" = ",
+						Snippet: "\"${1:key}\" = ",
 						Range: hcl.Range{
 							Filename: "test.tf",
 							Start:    hcl.Pos{Line: 3, Column: 3, Byte: 26},
@@ -1757,8 +1757,8 @@ func TestCompletionAtPos_exprAny_literalTypes(t *testing.T) {
 							Start:    hcl.Pos{Line: 2, Column: 2, Byte: 10},
 							End:      hcl.Pos{Line: 2, Column: 2, Byte: 10},
 						},
-						NewText: `"key" = false`,
-						Snippet: `"${1:key}" = ${2:false}`,
+						NewText: `"key" = `,
+						Snippet: `"${1:key}" = `,
 					},
 					Kind: lang.AttributeCandidateKind,
 				},

--- a/decoder/expr_any_completion_test.go
+++ b/decoder/expr_any_completion_test.go
@@ -481,22 +481,22 @@ func TestCompletionAtPos_exprAny_functions(t *testing.T) {
 					},
 				},
 			},
-			`attr = split(var.obj.)
+			`attr = split(var.)
 `,
-			hcl.Pos{Line: 1, Column: 22, Byte: 21},
+			hcl.Pos{Line: 1, Column: 18, Byte: 17},
 			lang.CompleteCandidates([]lang.Candidate{
 				{
-					Label:  "var.obj.foo",
-					Detail: "string",
+					Label:  "var.obj",
+					Detail: "list of string",
 					Kind:   lang.TraversalCandidateKind,
 					TextEdit: lang.TextEdit{
 						Range: hcl.Range{
 							Filename: "test.tf",
 							Start:    hcl.Pos{Line: 1, Column: 14, Byte: 13},
-							End:      hcl.Pos{Line: 1, Column: 22, Byte: 21},
+							End:      hcl.Pos{Line: 1, Column: 18, Byte: 17},
 						},
-						NewText: "var.obj.foo",
-						Snippet: "var.obj.foo",
+						NewText: "var.obj",
+						Snippet: "var.obj",
 					},
 				},
 			}),

--- a/decoder/expr_any_completion_test.go
+++ b/decoder/expr_any_completion_test.go
@@ -789,7 +789,7 @@ func TestCompletionAtPos_exprAny_functions(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%2d-%s", i, tc.testName), func(t *testing.T) {
 			bodySchema := &schema.BodySchema{
 				Attributes: tc.attrSchema,
 			}

--- a/decoder/expr_any_completion_test.go
+++ b/decoder/expr_any_completion_test.go
@@ -1,0 +1,422 @@
+package decoder
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+)
+
+func TestCompletionAtPos_exprAny_functions(t *testing.T) {
+	testCases := []struct {
+		testName           string
+		attrSchema         map[string]*schema.AttributeSchema
+		cfg                string
+		pos                hcl.Pos
+		expectedCandidates lang.Candidates
+	}{
+		{
+			"list of functions",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			`attr = 
+`,
+			hcl.Pos{Line: 1, Column: 8, Byte: 7},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:       "element",
+					Detail:      "element(list dynamic, index number) dynamic",
+					Description: lang.Markdown("`element` retrieves a single element from a list."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "element()",
+						Snippet: "element(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+					},
+				},
+				{
+					Label:       "join",
+					Detail:      "join(separator string, …lists list of string) string",
+					Description: lang.Markdown("`join` produces a string by concatenating together all elements of a given list of strings with the given delimiter."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "join()",
+						Snippet: "join(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+					},
+				},
+				{
+					Label:       "keys",
+					Detail:      "keys(inputMap dynamic) dynamic",
+					Description: lang.Markdown("`keys` takes a map and returns a list containing the keys from that map."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "keys()",
+						Snippet: "keys(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+					},
+				},
+				{
+					Label:       "lower",
+					Detail:      "lower(str string) string",
+					Description: lang.Markdown("`lower` converts all cased letters in the given string to lowercase."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "lower()",
+						Snippet: "lower(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"function by prefix",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			`attr = j
+`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:       "join",
+					Detail:      "join(separator string, …lists list of string) string",
+					Description: lang.Markdown("`join` produces a string by concatenating together all elements of a given list of strings with the given delimiter."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "join()",
+						Snippet: "join(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"first argument of a function ",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			`attr = element()
+`,
+			hcl.Pos{Line: 1, Column: 14, Byte: 15},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:       "element",
+					Detail:      "element(list dynamic, index number) dynamic",
+					Description: lang.Markdown("`element` retrieves a single element from a list."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "element()",
+						Snippet: "element(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 14, Byte: 15},
+							End:      hcl.Pos{Line: 1, Column: 14, Byte: 15},
+						},
+					},
+				},
+				{
+					Label:       "keys",
+					Detail:      "keys(inputMap dynamic) dynamic",
+					Description: lang.Markdown("`keys` takes a map and returns a list containing the keys from that map."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "keys()",
+						Snippet: "keys(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 14, Byte: 15},
+							End:      hcl.Pos{Line: 1, Column: 14, Byte: 15},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"second argument of a function ",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			`attr = element(["e1", "e2"], )
+`,
+			hcl.Pos{Line: 1, Column: 28, Byte: 29},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:       "element",
+					Detail:      "element(list dynamic, index number) dynamic",
+					Description: lang.Markdown("`element` retrieves a single element from a list."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "element()",
+						Snippet: "element(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 28, Byte: 29},
+							End:      hcl.Pos{Line: 1, Column: 28, Byte: 29},
+						},
+					},
+				},
+				{
+					Label:       "keys",
+					Detail:      "keys(inputMap dynamic) dynamic",
+					Description: lang.Markdown("`keys` takes a map and returns a list containing the keys from that map."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "keys()",
+						Snippet: "keys(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 28, Byte: 29},
+							End:      hcl.Pos{Line: 1, Column: 28, Byte: 29},
+						},
+					},
+				},
+				{
+					Label:       "log",
+					Detail:      "log(num number, base number) number",
+					Description: lang.Markdown("`log` returns the logarithm of a given number in a given base."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "log()",
+						Snippet: "log(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 28, Byte: 29},
+							End:      hcl.Pos{Line: 1, Column: 28, Byte: 29},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"nested functions",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			`attr = join("-", split())
+`,
+			hcl.Pos{Line: 1, Column: 22, Byte: 23},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:       "element",
+					Detail:      "element(list dynamic, index number) dynamic",
+					Description: lang.Markdown("`element` retrieves a single element from a list."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "element()",
+						Snippet: "element(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 22, Byte: 23},
+							End:      hcl.Pos{Line: 1, Column: 22, Byte: 23},
+						},
+					},
+				},
+				{
+					Label:       "join",
+					Detail:      "join(separator string, …lists list of string) string",
+					Description: lang.Markdown("`join` produces a string by concatenating together all elements of a given list of strings with the given delimiter."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "join()",
+						Snippet: "join(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 22, Byte: 23},
+							End:      hcl.Pos{Line: 1, Column: 22, Byte: 23},
+						},
+					},
+				},
+				{
+					Label:       "keys",
+					Detail:      "keys(inputMap dynamic) dynamic",
+					Description: lang.Markdown("`keys` takes a map and returns a list containing the keys from that map."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "keys()",
+						Snippet: "keys(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 22, Byte: 23},
+							End:      hcl.Pos{Line: 1, Column: 22, Byte: 23},
+						},
+					},
+				},
+				{
+					Label:       "lower",
+					Detail:      "lower(str string) string",
+					Description: lang.Markdown("`lower` converts all cased letters in the given string to lowercase."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "lower()",
+						Snippet: "lower(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 22, Byte: 23},
+							End:      hcl.Pos{Line: 1, Column: 22, Byte: 23},
+						},
+					},
+				},
+			}),
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := &schema.BodySchema{
+				Attributes: tc.attrSchema,
+			}
+
+			f, _ := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.tf": f,
+				},
+				Functions: testFunctionSignatures(),
+			})
+
+			ctx := context.Background()
+			candidates, err := d.CandidatesAtPos(ctx, "test.tf", tc.pos)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedCandidates, candidates); diff != "" {
+				t.Fatalf("unexpected candidates: %s", diff)
+			}
+		})
+	}
+}
+
+func testFunctionSignatures() map[string]schema.FunctionSignature {
+	return map[string]schema.FunctionSignature{
+		"element": {
+			Params: []function.Parameter{
+				{
+					Name: "list",
+					Type: cty.DynamicPseudoType,
+				},
+				{
+					Name: "index",
+					Type: cty.Number,
+				},
+			},
+			ReturnType:  cty.DynamicPseudoType,
+			Description: "`element` retrieves a single element from a list.",
+		},
+		"join": {
+			Params: []function.Parameter{
+				{
+					Name:        "separator",
+					Description: "Delimiter to insert between the given strings.",
+					Type:        cty.String,
+				},
+			},
+			VarParam: &function.Parameter{
+				Name:        "lists",
+				Description: "One or more lists of strings to join.",
+				Type:        cty.List(cty.String),
+			},
+			ReturnType:  cty.String,
+			Description: "`join` produces a string by concatenating together all elements of a given list of strings with the given delimiter.",
+		},
+		"keys": {
+			Params: []function.Parameter{
+				{
+					Name:        "inputMap",
+					Description: "The map to extract keys from. May instead be an object-typed value, in which case the result is a tuple of the object attributes.",
+					Type:        cty.DynamicPseudoType,
+				},
+			},
+			ReturnType:  cty.DynamicPseudoType,
+			Description: "`keys` takes a map and returns a list containing the keys from that map.",
+		},
+		"log": {
+			Params: []function.Parameter{
+				{
+					Name: "num",
+					Type: cty.Number,
+				},
+				{
+					Name: "base",
+					Type: cty.Number,
+				},
+			},
+			ReturnType:  cty.Number,
+			Description: "`log` returns the logarithm of a given number in a given base.",
+		},
+		"lower": {
+			Params: []function.Parameter{
+				{
+					Name: "str",
+					Type: cty.String,
+				},
+			},
+			ReturnType:  cty.String,
+			Description: "`lower` converts all cased letters in the given string to lowercase.",
+		},
+		"split": {
+			Params: []function.Parameter{
+				{
+					Name: "separator",
+					Type: cty.String,
+				},
+				{
+					Name: "str",
+					Type: cty.String,
+				},
+			},
+			ReturnType:  cty.List(cty.String),
+			Description: "`split` produces a list by dividing a given string at all occurrences of a given separator.",
+		},
+	}
+}

--- a/decoder/expr_any_completion_test.go
+++ b/decoder/expr_any_completion_test.go
@@ -205,6 +205,167 @@ func TestCompletionAtPos_exprAny_functions(t *testing.T) {
 			}),
 		},
 		{
+			"reference as argument with trailing dot",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.List(cty.String),
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "obj"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 5, Byte: 27},
+						End:      hcl.Pos{Line: 2, Column: 15, Byte: 37},
+					},
+					Type: cty.List(cty.String),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "var"},
+								lang.AttrStep{Name: "obj"},
+								lang.AttrStep{Name: "foo"},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start:    hcl.Pos{Line: 2, Column: 8, Byte: 30},
+								End:      hcl.Pos{Line: 2, Column: 13, Byte: 35},
+							},
+							Type: cty.String,
+						},
+					},
+				},
+			},
+			`attr = split(var.obj.)
+`,
+			hcl.Pos{Line: 1, Column: 22, Byte: 21},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "var.obj.foo",
+					Detail: "string",
+					Kind:   lang.TraversalCandidateKind,
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 14, Byte: 13},
+							End:      hcl.Pos{Line: 1, Column: 22, Byte: 21},
+						},
+						NewText: "var.obj.foo",
+						Snippet: "var.obj.foo",
+					},
+				},
+			}),
+		},
+		{
+			"reference as argument within brackets",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "map"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 5, Byte: 27},
+						End:      hcl.Pos{Line: 2, Column: 15, Byte: 37},
+					},
+					Type: cty.List(cty.String),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "var"},
+								lang.AttrStep{Name: "map"},
+								lang.IndexStep{Key: cty.StringVal("foo")},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start:    hcl.Pos{Line: 2, Column: 8, Byte: 30},
+								End:      hcl.Pos{Line: 2, Column: 13, Byte: 35},
+							},
+							Type: cty.String,
+						},
+					},
+				},
+			},
+			`attr = split(var.map[])
+`,
+			hcl.Pos{Line: 1, Column: 22, Byte: 21},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `var.map["foo"]`,
+					Detail: "string",
+					Kind:   lang.TraversalCandidateKind,
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 14, Byte: 13},
+							End:      hcl.Pos{Line: 1, Column: 23, Byte: 22},
+						},
+						NewText: `var.map["foo"]`,
+						Snippet: `var.map["foo"]`,
+					},
+				},
+			}),
+		},
+		{
+			"reference as argument with trailing bracket",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "obj"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 5, Byte: 27},
+						End:      hcl.Pos{Line: 2, Column: 15, Byte: 37},
+					},
+					Type: cty.List(cty.String),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "var"},
+								lang.AttrStep{Name: "obj"},
+								lang.IndexStep{Key: cty.StringVal("foo")},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start:    hcl.Pos{Line: 2, Column: 8, Byte: 30},
+								End:      hcl.Pos{Line: 2, Column: 13, Byte: 35},
+							},
+							Type: cty.String,
+						},
+					},
+				},
+			},
+			`attr = split(var.map[)
+`,
+			hcl.Pos{Line: 1, Column: 22, Byte: 21},
+			lang.CompleteCandidates([]lang.Candidate{
+				// TODO: See https://github.com/hashicorp/hcl/issues/604
+			}),
+		},
+		{
 			"second argument of a function ",
 			map[string]*schema.AttributeSchema{
 				"attr": {

--- a/decoder/expr_any_completion_test.go
+++ b/decoder/expr_any_completion_test.go
@@ -817,6 +817,291 @@ func TestCompletionAtPos_exprAny_functions(t *testing.T) {
 	}
 }
 
+func TestCompletionAtPos_exprAny_combinedExpressions(t *testing.T) {
+	testCases := []struct {
+		testName           string
+		attrSchema         map[string]*schema.AttributeSchema
+		refTargets         reference.Targets
+		funcSignatures     map[string]schema.FunctionSignature
+		cfg                string
+		pos                hcl.Pos
+		expectedCandidates lang.Candidates
+	}{
+		{
+			"any matching expression empty",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Bool,
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "foo"},
+					},
+					Type: cty.Bool,
+				},
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "bar"},
+					},
+					Type: cty.Number,
+				},
+			},
+			testFunctionSignatures(),
+			`attr = 
+`,
+			hcl.Pos{Line: 1, Column: 8, Byte: 7},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "local.foo",
+					Detail: "bool",
+					Kind:   lang.TraversalCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "local.foo",
+						Snippet: "local.foo",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+					},
+				},
+				{
+					Label:       "element",
+					Detail:      "element(list dynamic, index number) dynamic",
+					Description: lang.Markdown("`element` retrieves a single element from a list."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "element()",
+						Snippet: "element(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+					},
+				},
+				{
+					Label:       "join",
+					Detail:      "join(separator string, …lists list of string) string",
+					Description: lang.Markdown("`join` produces a string by concatenating together all elements of a given list of strings with the given delimiter."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "join()",
+						Snippet: "join(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+					},
+				},
+				{
+					Label:       "keys",
+					Detail:      "keys(inputMap dynamic) dynamic",
+					Description: lang.Markdown("`keys` takes a map and returns a list containing the keys from that map."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "keys()",
+						Snippet: "keys(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+					},
+				},
+				{
+					Label:       "lower",
+					Detail:      "lower(str string) string",
+					Description: lang.Markdown("`lower` converts all cased letters in the given string to lowercase."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "lower()",
+						Snippet: "lower(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+					},
+				},
+				{
+					Label:  "false",
+					Detail: "bool",
+					Kind:   lang.BoolCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "false",
+						Snippet: "false",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+					},
+				},
+				{
+					Label:  "true",
+					Detail: "bool",
+					Kind:   lang.BoolCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "true",
+						Snippet: "true",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"any matching expression by prefix",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Bool,
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "toot"},
+						lang.AttrStep{Name: "noot"},
+					},
+					Type: cty.Bool,
+				},
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "bar"},
+					},
+					Type: cty.Bool,
+				},
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "too"},
+						lang.AttrStep{Name: "not"},
+					},
+					Type: cty.Number,
+				},
+			},
+			map[string]schema.FunctionSignature{
+				"tobool": {
+					Params: []function.Parameter{
+						{
+							Name: "v",
+							Type: cty.DynamicPseudoType,
+						},
+					},
+					ReturnType:  cty.Bool,
+					Description: "`tobool` converts its argument to a boolean value.",
+				},
+				"substr": {
+					Params: []function.Parameter{
+						{
+							Name: "str",
+							Type: cty.String,
+						},
+						{
+							Name: "offset",
+							Type: cty.Number,
+						},
+						{
+							Name: "length",
+							Type: cty.Number,
+						},
+					},
+					ReturnType:  cty.String,
+					Description: "`substr` extracts a substring from a given string by offset and (maximum) length.",
+				},
+			},
+			`attr = t
+`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "toot.noot",
+					Detail: "bool",
+					Kind:   lang.TraversalCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "toot.noot",
+						Snippet: "toot.noot",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						},
+					},
+				},
+				{
+					Label:       "tobool",
+					Detail:      "tobool(v dynamic) bool",
+					Description: lang.Markdown("`tobool` converts its argument to a boolean value."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "tobool()",
+						Snippet: "tobool(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						},
+					},
+				},
+				{
+					Label:  "true",
+					Detail: "bool",
+					Kind:   lang.BoolCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "true",
+						Snippet: "true",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						},
+					},
+				},
+			}),
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%2d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := &schema.BodySchema{
+				Attributes: tc.attrSchema,
+			}
+
+			f, _ := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.tf": f,
+				},
+				Functions:        tc.funcSignatures,
+				ReferenceTargets: tc.refTargets,
+			})
+
+			ctx := context.Background()
+			candidates, err := d.CandidatesAtPos(ctx, "test.tf", tc.pos)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedCandidates, candidates); diff != "" {
+				t.Fatalf("unexpected candidates: %s", diff)
+			}
+		})
+	}
+}
+
 func testFunctionSignatures() map[string]schema.FunctionSignature {
 	return map[string]schema.FunctionSignature{
 		"element": {
@@ -898,5 +1183,1486 @@ func testFunctionSignatures() map[string]schema.FunctionSignature {
 			ReturnType:  cty.List(cty.String),
 			Description: "`split` produces a list by dividing a given string at all occurrences of a given separator.",
 		},
+	}
+}
+
+func TestCompletionAtPos_exprAny_literalTypes(t *testing.T) {
+	testCases := []struct {
+		testName           string
+		attrSchema         map[string]*schema.AttributeSchema
+		cfg                string
+		pos                hcl.Pos
+		expectedCandidates lang.Candidates
+	}{
+		{
+			"bool",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Bool,
+					},
+				},
+			},
+			`attr = 
+`,
+			hcl.Pos{Line: 1, Column: 8, Byte: 7},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "false",
+					Detail: cty.Bool.FriendlyNameForConstraint(),
+					Kind:   lang.BoolCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "false",
+						Snippet: "false",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+					},
+				},
+				{
+					Label:  "true",
+					Detail: cty.Bool.FriendlyNameForConstraint(),
+					Kind:   lang.BoolCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "true",
+						Snippet: "true",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"bool by prefix",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Bool,
+					},
+				},
+			},
+			`attr = f
+`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "false",
+					Detail: cty.Bool.FriendlyNameForConstraint(),
+					Kind:   lang.BoolCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "false",
+						Snippet: "false",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"string",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			`attr = 
+`,
+			hcl.Pos{Line: 1, Column: 8, Byte: 7},
+			lang.CompleteCandidates([]lang.Candidate{}),
+		},
+		{
+			"list of strings",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.List(cty.String),
+					},
+				},
+			},
+			`attr = 
+`,
+			hcl.Pos{Line: 1, Column: 8, Byte: 7},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "[ string ]",
+					Detail: "list of string",
+					Kind:   lang.ListCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: `[ "" ]`,
+						Snippet: `[ "${1:value}" ]`,
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"inside list of bool",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.List(cty.Bool),
+					},
+				},
+			},
+			`attr = [  ]
+`,
+			hcl.Pos{Line: 1, Column: 10, Byte: 9},
+			lang.CompleteCandidates(boolLiteralCandidates("", hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+				End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+			})),
+		},
+		{
+			"inside list of bool multiline",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.List(cty.Bool),
+					},
+				},
+			},
+			`attr = [
+  
+]
+`,
+			hcl.Pos{Line: 2, Column: 3, Byte: 11},
+			lang.CompleteCandidates(boolLiteralCandidates("", hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+				End:      hcl.Pos{Line: 2, Column: 3, Byte: 11},
+			})),
+		},
+		{
+			"inside list next element after space",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.List(cty.Bool),
+					},
+				},
+			},
+			`attr = [ false,  ]
+`,
+			hcl.Pos{Line: 1, Column: 17, Byte: 16},
+			lang.CompleteCandidates(boolLiteralCandidates("", hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.Pos{Line: 1, Column: 17, Byte: 16},
+				End:      hcl.Pos{Line: 1, Column: 17, Byte: 16},
+			})),
+		},
+		{
+			"inside list next element after newline",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.List(cty.Bool),
+					},
+				},
+			},
+			`attr = [
+  false,
+  
+]
+`,
+			hcl.Pos{Line: 3, Column: 3, Byte: 20},
+			lang.CompleteCandidates(boolLiteralCandidates("", hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.Pos{Line: 3, Column: 3, Byte: 20},
+				End:      hcl.Pos{Line: 3, Column: 3, Byte: 20},
+			})),
+		},
+		{
+			"inside list next element after comma",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.List(cty.Bool),
+					},
+				},
+			},
+			`attr = [ false, ]
+`,
+			hcl.Pos{Line: 1, Column: 16, Byte: 15},
+			lang.CompleteCandidates(boolLiteralCandidates("", hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.Pos{Line: 1, Column: 16, Byte: 15},
+				End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+			})),
+		},
+		{
+			"inside list next element near closing bracket",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.List(cty.Bool),
+					},
+				},
+			},
+			`attr = [ false, ]
+`,
+			hcl.Pos{Line: 1, Column: 17, Byte: 16},
+			lang.CompleteCandidates(boolLiteralCandidates("", hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.Pos{Line: 1, Column: 17, Byte: 16},
+				End:      hcl.Pos{Line: 1, Column: 17, Byte: 16},
+			})),
+		},
+		{
+			"completion inside list with prefix",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.List(cty.Bool),
+					},
+				},
+			},
+			`attr = [ f ]
+`,
+			hcl.Pos{Line: 1, Column: 11, Byte: 10},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "false",
+					Detail: cty.Bool.FriendlyNameForConstraint(),
+					Kind:   lang.BoolCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "false",
+						Snippet: "false",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+							End:      hcl.Pos{Line: 1, Column: 11, Byte: 10},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"tuple",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Tuple([]cty.Type{cty.Bool}),
+					},
+				},
+			},
+			`attr = 
+`,
+			hcl.Pos{Line: 1, Column: 8, Byte: 7},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "[ bool ]",
+					Detail: "tuple",
+					Kind:   lang.TupleCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "[ false ]",
+						Snippet: "[ ${1:false} ]",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"inside tuple",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Tuple([]cty.Type{cty.Bool}),
+					},
+				},
+			},
+			`attr = [  ]
+`,
+			hcl.Pos{Line: 1, Column: 10, Byte: 9},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "false",
+					Detail: "bool",
+					Kind:   lang.BoolCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "false",
+						Snippet: "false",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+							End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+						},
+					},
+				},
+				{
+					Label:  "true",
+					Detail: "bool",
+					Kind:   lang.BoolCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "true",
+						Snippet: "true",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+							End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"inside tuple next element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Tuple([]cty.Type{cty.String, cty.Bool}),
+					},
+				},
+			},
+			`attr = [ "",  ]
+`,
+			hcl.Pos{Line: 1, Column: 14, Byte: 13},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "false",
+					Detail: "bool",
+					Kind:   lang.BoolCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "false",
+						Snippet: "false",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 14, Byte: 13},
+							End:      hcl.Pos{Line: 1, Column: 14, Byte: 13},
+						},
+					},
+				},
+				{
+					Label:  "true",
+					Detail: "bool",
+					Kind:   lang.BoolCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "true",
+						Snippet: "true",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 14, Byte: 13},
+							End:      hcl.Pos{Line: 1, Column: 14, Byte: 13},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"inside tuple next element without comma",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Tuple([]cty.Type{cty.String, cty.Bool}),
+					},
+				},
+			},
+			`attr = [ ""  ]
+`,
+			hcl.Pos{Line: 1, Column: 13, Byte: 12},
+			lang.CompleteCandidates([]lang.Candidate{}),
+		},
+		{
+			"inside tuple in space between elements",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Tuple([]cty.Type{cty.String, cty.String, cty.Bool}),
+					},
+				},
+			},
+			`attr = [ "", ""  ]
+`,
+			hcl.Pos{Line: 1, Column: 13, Byte: 12},
+			lang.CompleteCandidates([]lang.Candidate{}),
+		},
+		{
+			"inside tuple next element which does not exist",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Tuple([]cty.Type{cty.String}),
+					},
+				},
+			},
+			`attr = [ "",  ]
+`,
+			hcl.Pos{Line: 1, Column: 14, Byte: 13},
+			lang.CompleteCandidates([]lang.Candidate{}),
+		},
+		{
+			"map",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Map(cty.Bool),
+					},
+				},
+			},
+			`attr = 
+`,
+			hcl.Pos{Line: 1, Column: 8, Byte: 7},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `{ "key" = bool }`,
+					Detail: "map of bool",
+					Kind:   lang.MapCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "{\n  \"key\" = false\n}",
+						Snippet: "{\n  \"${1:key}\" = ${2:false}\n}",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"inside empty map",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Map(cty.Bool),
+					},
+				},
+			},
+			`attr = {
+  
+}
+`,
+			hcl.Pos{Line: 2, Column: 3, Byte: 11},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `"key" = bool`,
+					Detail: "bool",
+					Kind:   lang.AttributeCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "\"key\" = false",
+						Snippet: "\"${1:key}\" = ${2:false}",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+							End:      hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"inside map after first item",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Map(cty.Bool),
+					},
+				},
+			},
+			`attr = {
+  "key" = true
+  
+}
+`,
+			hcl.Pos{Line: 3, Column: 3, Byte: 26},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `"key" = bool`,
+					Detail: "bool",
+					Kind:   lang.AttributeCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "\"key\" = false",
+						Snippet: "\"${1:key}\" = ${2:false}",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 3, Column: 3, Byte: 26},
+							End:      hcl.Pos{Line: 3, Column: 3, Byte: 26},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"inside map between items",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Map(cty.Bool),
+					},
+				},
+			},
+			`attr = {
+  "key" = true
+  
+  "another" = false
+}
+`,
+			hcl.Pos{Line: 3, Column: 3, Byte: 26},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `"key" = bool`,
+					Detail: "bool",
+					Kind:   lang.AttributeCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "\"key\" = false",
+						Snippet: "\"${1:key}\" = ${2:false}",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 3, Column: 3, Byte: 26},
+							End:      hcl.Pos{Line: 3, Column: 3, Byte: 26},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"inside map before item",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Map(cty.Bool),
+					},
+				},
+			},
+			`attr = {
+  "key" = true
+}
+`,
+			hcl.Pos{Line: 2, Column: 2, Byte: 10},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `"key" = bool`,
+					Detail: "bool",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 2, Byte: 10},
+							End:      hcl.Pos{Line: 2, Column: 2, Byte: 10},
+						},
+						NewText: `"key" = false`,
+						Snippet: `"${1:key}" = ${2:false}`,
+					},
+					Kind: lang.AttributeCandidateKind,
+				},
+			}),
+		},
+		{
+			"inside map value empty",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Map(cty.Bool),
+					},
+				},
+			},
+			`attr = {
+  "key" = 
+}
+`,
+			hcl.Pos{Line: 2, Column: 11, Byte: 19},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "false",
+					Detail: "bool",
+					Kind:   lang.BoolCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "false",
+						Snippet: "false",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 11, Byte: 19},
+							End:      hcl.Pos{Line: 2, Column: 11, Byte: 19},
+						},
+					},
+				},
+				{
+					Label:  "true",
+					Detail: "bool",
+					Kind:   lang.BoolCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "true",
+						Snippet: "true",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 11, Byte: 19},
+							End:      hcl.Pos{Line: 2, Column: 11, Byte: 19},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"inside map value with prefix",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Map(cty.Bool),
+					},
+				},
+			},
+			`attr = {
+  "key" = f
+}
+`,
+			hcl.Pos{Line: 2, Column: 12, Byte: 20},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "false",
+					Detail: "bool",
+					Kind:   lang.BoolCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "false",
+						Snippet: "false",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 11, Byte: 19},
+							End:      hcl.Pos{Line: 2, Column: 12, Byte: 20},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"object",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Object(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.Bool,
+							"baz": cty.Number,
+						}),
+					},
+				},
+			},
+			`attr = 
+`,
+			hcl.Pos{Line: 1, Column: 8, Byte: 7},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `{ bar = bool, … }`,
+					Detail: "object",
+					Kind:   lang.ObjectCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "{\n  bar = false\n  baz = 1\n  foo = \"\"\n}",
+						Snippet: "{\n  bar = ${1:false}\n  baz = ${2:1}\n  foo = \"${3:value}\"\n}",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"inside empty object",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Object(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.Bool,
+							"baz": cty.Number,
+						}),
+					},
+				},
+			},
+			`attr = {
+
+}
+`,
+			hcl.Pos{Line: 2, Column: 1, Byte: 9},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `bar`,
+					Detail: "required, bool",
+					Kind:   lang.AttributeCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "bar",
+						Snippet: "bar = ${1:false}",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 1, Byte: 9},
+							End:      hcl.Pos{Line: 2, Column: 1, Byte: 9},
+						},
+					},
+				},
+				{
+					Label:  `baz`,
+					Detail: "required, number",
+					Kind:   lang.AttributeCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "baz",
+						Snippet: "baz = ${1:0}",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 1, Byte: 9},
+							End:      hcl.Pos{Line: 2, Column: 1, Byte: 9},
+						},
+					},
+				},
+				{
+					Label:  `foo`,
+					Detail: "required, string",
+					Kind:   lang.AttributeCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "foo",
+						Snippet: "foo = \"${1:value}\"",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 1, Byte: 9},
+							End:      hcl.Pos{Line: 2, Column: 1, Byte: 9},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"inside object after first item",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Object(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.Bool,
+						}),
+					},
+				},
+			},
+			`attr = {
+  foo = "baz"
+  
+}
+`,
+			hcl.Pos{Line: 3, Column: 3, Byte: 25},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `bar`,
+					Detail: "required, bool",
+					Kind:   lang.AttributeCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "bar",
+						Snippet: "bar = ${1:false}",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 3, Column: 3, Byte: 25},
+							End:      hcl.Pos{Line: 3, Column: 3, Byte: 25},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"inside object between items",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Object(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.Bool,
+							"baz": cty.Number,
+						}),
+					},
+				},
+			},
+			`attr = {
+  foo = "baz"
+  
+  baz = 42
+}
+`,
+			hcl.Pos{Line: 3, Column: 3, Byte: 25},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `bar`,
+					Detail: "required, bool",
+					Kind:   lang.AttributeCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "bar",
+						Snippet: "bar = ${1:false}",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 3, Column: 3, Byte: 25},
+							End:      hcl.Pos{Line: 3, Column: 3, Byte: 25},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"inside object before item",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Object(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.Bool,
+						}),
+					},
+				},
+			},
+			`attr = {
+  foo = "baz"
+}
+`,
+			hcl.Pos{Line: 2, Column: 2, Byte: 10},
+			lang.CompleteCandidates([]lang.Candidate{}),
+		},
+		{
+			"inside object key",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Object(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.Bool,
+							"baz": cty.Number,
+						}),
+					},
+				},
+			},
+			`attr = {
+  bar = true
+}
+`,
+			hcl.Pos{Line: 2, Column: 5, Byte: 13},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `bar`,
+					Detail: "required, bool",
+					Kind:   lang.AttributeCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "bar",
+						Snippet: "bar = ${1:false}",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+							End:      hcl.Pos{Line: 2, Column: 13, Byte: 21},
+						},
+					},
+				},
+				{
+					Label:  `baz`,
+					Detail: "required, number",
+					Kind:   lang.AttributeCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "baz",
+						Snippet: "baz = ${1:0}",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+							End:      hcl.Pos{Line: 2, Column: 13, Byte: 21},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"inside object value",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Object(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.Bool,
+							"baz": cty.Number,
+						}),
+					},
+				},
+			},
+			`attr = {
+  bar = false
+}
+`,
+			hcl.Pos{Line: 2, Column: 10, Byte: 18},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `false`,
+					Detail: "bool",
+					Kind:   lang.BoolCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "false",
+						Snippet: "false",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 9, Byte: 17},
+							End:      hcl.Pos{Line: 2, Column: 14, Byte: 22},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"inside object with incomplete key",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Object(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.Bool,
+							"baz": cty.Number,
+						}),
+					},
+				},
+			},
+			`attr = {
+  ba
+}
+`,
+			hcl.Pos{Line: 2, Column: 5, Byte: 13},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `bar`,
+					Detail: "required, bool",
+					Kind:   lang.AttributeCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "bar",
+						Snippet: "bar = ${1:false}",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+							End:      hcl.Pos{Line: 2, Column: 5, Byte: 13},
+						},
+					},
+				},
+				{
+					Label:  `baz`,
+					Detail: "required, number",
+					Kind:   lang.AttributeCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "baz",
+						Snippet: "baz = ${1:0}",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+							End:      hcl.Pos{Line: 2, Column: 5, Byte: 13},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"inside object with no value",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Object(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.Bool,
+							"baz": cty.Number,
+						}),
+					},
+				},
+			},
+			`attr = {
+  bar = 
+}
+`,
+			hcl.Pos{Line: 2, Column: 9, Byte: 17},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `false`,
+					Detail: "bool",
+					Kind:   lang.BoolCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "false",
+						Snippet: "false",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 9, Byte: 17},
+							End:      hcl.Pos{Line: 2, Column: 9, Byte: 17},
+						},
+					},
+				},
+				{
+					Label:  `true`,
+					Detail: "bool",
+					Kind:   lang.BoolCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "true",
+						Snippet: "true",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 9, Byte: 17},
+							End:      hcl.Pos{Line: 2, Column: 9, Byte: 17},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"inside object with incomplete value",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Object(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.Bool,
+							"baz": cty.Number,
+						}),
+					},
+				},
+			},
+			`attr = {
+  bar = f
+}
+`,
+			hcl.Pos{Line: 2, Column: 10, Byte: 18},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `false`,
+					Detail: "bool",
+					Kind:   lang.BoolCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "false",
+						Snippet: "false",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 9, Byte: 17},
+							End:      hcl.Pos{Line: 2, Column: 10, Byte: 18},
+						},
+					},
+				},
+			}),
+		},
+
+		{
+			"map expr inside object",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Object(map[string]cty.Type{
+							"mymap": cty.Map(cty.String),
+						}),
+					},
+				},
+			},
+			`attr = {
+
+}
+`,
+			hcl.Pos{Line: 2, Column: 1, Byte: 9},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "mymap",
+					Detail: "required, map of string",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 1, Byte: 9},
+							End:      hcl.Pos{Line: 2, Column: 1, Byte: 9},
+						},
+						NewText: "mymap",
+						Snippet: "mymap = {\n  \"${1:name}\" = \"${2:value}\"\n}",
+					},
+					Kind: lang.AttributeCandidateKind,
+				},
+			}),
+		},
+		{
+			"new map entry inside object",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Object(map[string]cty.Type{
+							"mymap": cty.Map(cty.String),
+						}),
+					},
+				},
+			},
+			`attr = {
+  mymap = 
+}
+`,
+			hcl.Pos{Line: 2, Column: 11, Byte: 19},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  `{ "key" = string }`,
+					Detail: "map of string",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 11, Byte: 19},
+							End:      hcl.Pos{Line: 2, Column: 11, Byte: 19},
+						},
+						NewText: "{\n  \"key\" = \"\"\n}",
+						Snippet: "{\n  \"${1:key}\" = \"${2:value}\"\n}",
+					},
+					Kind: lang.MapCandidateKind,
+				},
+			}),
+		},
+		{
+			"inside map expr inside object",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Object(map[string]cty.Type{
+							"mymap": cty.Map(cty.String),
+						}),
+					},
+				},
+			},
+			`attr = {
+  mymap = {
+    
+  }
+}
+`,
+			hcl.Pos{Line: 3, Column: 5, Byte: 25},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "\"key\" = string",
+					Detail: "string",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 3, Column: 5, Byte: 25},
+							End:      hcl.Pos{Line: 3, Column: 5, Byte: 25},
+						},
+						NewText: "\"key\" = \"value\"",
+						Snippet: "\"${1:key}\" = \"${2:value}\"",
+					},
+					Kind: lang.AttributeCandidateKind,
+				},
+			}),
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%2d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := &schema.BodySchema{
+				Attributes: tc.attrSchema,
+			}
+
+			f, _ := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.tf": f,
+				},
+			})
+
+			ctx := context.Background()
+			candidates, err := d.CandidatesAtPos(ctx, "test.tf", tc.pos)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedCandidates, candidates); diff != "" {
+				t.Fatalf("unexpected candidates: %s", diff)
+			}
+		})
+	}
+}
+
+func TestCompletionAtPos_exprAny_references(t *testing.T) {
+	testCases := []struct {
+		testName           string
+		attrSchema         map[string]*schema.AttributeSchema
+		refTargets         reference.Targets
+		cfg                string
+		pos                hcl.Pos
+		expectedCandidates lang.Candidates
+	}{
+		{
+			"no expression",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "foo"},
+					},
+					Type: cty.String,
+				},
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "bar"},
+					},
+					Type: cty.List(cty.Number),
+				},
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "baz"},
+					},
+					Type: cty.Number,
+				},
+			},
+			`attr = `,
+			hcl.Pos{Line: 1, Column: 8, Byte: 7},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "local.foo",
+					Detail: "string",
+					Kind:   lang.TraversalCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "local.foo",
+						Snippet: "local.foo",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+					},
+				},
+				{
+					Label:  "local.baz",
+					Detail: "number",
+					Kind:   lang.TraversalCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "local.baz",
+						Snippet: "local.baz",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"matching prefix",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Number,
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "foo"},
+					},
+					Type: cty.List(cty.String),
+				},
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "bar"},
+					},
+					Type: cty.Number,
+				},
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "data"},
+						lang.AttrStep{Name: "bar"},
+					},
+					Type: cty.Number,
+				},
+			},
+			`attr = local`,
+			hcl.Pos{Line: 1, Column: 13, Byte: 12},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "local.bar",
+					Detail: "number",
+					Kind:   lang.TraversalCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "local.bar",
+						Snippet: "local.bar",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 13, Byte: 12},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"matching prefix in the middle",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "foo"},
+					},
+					Type: cty.String,
+				},
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "bar"},
+					},
+					Type: cty.List(cty.Number),
+				},
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "data"},
+						lang.AttrStep{Name: "bar"},
+					},
+					Type: cty.Number,
+				},
+			},
+			`attr = local`,
+			hcl.Pos{Line: 1, Column: 11, Byte: 10},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "local.foo",
+					Detail: "string",
+					Kind:   lang.TraversalCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "local.foo",
+						Snippet: "local.foo",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 13, Byte: 12},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"matching prefix after trailing dot",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "foo"},
+					},
+					Type: cty.String,
+				},
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "bar"},
+					},
+					Type: cty.List(cty.Number),
+				},
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "data"},
+						lang.AttrStep{Name: "bar"},
+					},
+					Type: cty.Number,
+				},
+			},
+			`attr = local.`,
+			hcl.Pos{Line: 1, Column: 14, Byte: 13},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "local.foo",
+					Detail: "string",
+					Kind:   lang.TraversalCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "local.foo",
+						Snippet: "local.foo",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 14, Byte: 13},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"mismatching prefix",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Number,
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "foo"},
+					},
+					Type: cty.String,
+				},
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "bar"},
+					},
+					Type: cty.Number,
+				},
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "data"},
+						lang.AttrStep{Name: "bar"},
+					},
+					Type: cty.Number,
+				},
+			},
+			`attr = x`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			lang.CompleteCandidates([]lang.Candidate{}),
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := &schema.BodySchema{
+				Attributes: tc.attrSchema,
+			}
+
+			f, _ := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.tf": f,
+				},
+				ReferenceTargets: tc.refTargets,
+			})
+
+			ctx := context.Background()
+			candidates, err := d.CandidatesAtPos(ctx, "test.tf", tc.pos)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedCandidates, candidates); diff != "" {
+				t.Fatalf("unexpected candidates: %s", diff)
+			}
+		})
 	}
 }

--- a/decoder/expr_any_completion_test.go
+++ b/decoder/expr_any_completion_test.go
@@ -386,6 +386,64 @@ func TestCompletionAtPos_exprAny_functions(t *testing.T) {
 			}),
 		},
 		{
+			"reference as argument partial",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.List(cty.String),
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "lst"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 5, Byte: 27},
+						End:      hcl.Pos{Line: 2, Column: 15, Byte: 37},
+					},
+					Type: cty.List(cty.String),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "var"},
+								lang.AttrStep{Name: "lst"},
+								lang.IndexStep{Key: cty.NumberIntVal(0)},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.tf",
+								Start:    hcl.Pos{Line: 2, Column: 8, Byte: 30},
+								End:      hcl.Pos{Line: 2, Column: 13, Byte: 35},
+							},
+							Type: cty.String,
+						},
+					},
+				},
+			},
+			`attr = split(va)
+`,
+			hcl.Pos{Line: 1, Column: 16, Byte: 15},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "var.lst",
+					Detail: "list of string",
+					Kind:   lang.TraversalCandidateKind,
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 14, Byte: 13},
+							End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+						},
+						NewText: "var.lst",
+						Snippet: "var.lst",
+					},
+				},
+			}),
+		},
+		{
 			"reference as argument with trailing dot",
 			map[string]*schema.AttributeSchema{
 				"attr": {

--- a/decoder/expr_any_completion_test.go
+++ b/decoder/expr_any_completion_test.go
@@ -25,7 +25,7 @@ func TestCompletionAtPos_exprAny_functions(t *testing.T) {
 		expectedCandidates lang.Candidates
 	}{
 		{
-			"list of functions",
+			"list of string functions",
 			map[string]*schema.AttributeSchema{
 				"attr": {
 					Constraint: schema.AnyExpression{
@@ -84,6 +84,21 @@ func TestCompletionAtPos_exprAny_functions(t *testing.T) {
 					},
 				},
 				{
+					Label:       "log",
+					Detail:      "log(num number, base number) number",
+					Description: lang.Markdown("`log` returns the logarithm of a given number in a given base."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "log()",
+						Snippet: "log(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+					},
+				},
+				{
 					Label:       "lower",
 					Detail:      "lower(str string) string",
 					Description: lang.Markdown("`lower` converts all cased letters in the given string to lowercase."),
@@ -91,6 +106,112 @@ func TestCompletionAtPos_exprAny_functions(t *testing.T) {
 					TextEdit: lang.TextEdit{
 						NewText: "lower()",
 						Snippet: "lower(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"list of any functions",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.DynamicPseudoType,
+					},
+				},
+			},
+			reference.Targets{},
+			`attr = 
+`,
+			hcl.Pos{Line: 1, Column: 8, Byte: 7},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:       "element",
+					Detail:      "element(list dynamic, index number) dynamic",
+					Description: lang.Markdown("`element` retrieves a single element from a list."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "element()",
+						Snippet: "element(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+					},
+				},
+				{
+					Label:       "join",
+					Detail:      "join(separator string, …lists list of string) string",
+					Description: lang.Markdown("`join` produces a string by concatenating together all elements of a given list of strings with the given delimiter."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "join()",
+						Snippet: "join(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+					},
+				},
+				{
+					Label:       "keys",
+					Detail:      "keys(inputMap dynamic) dynamic",
+					Description: lang.Markdown("`keys` takes a map and returns a list containing the keys from that map."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "keys()",
+						Snippet: "keys(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+					},
+				},
+				{
+					Label:       "log",
+					Detail:      "log(num number, base number) number",
+					Description: lang.Markdown("`log` returns the logarithm of a given number in a given base."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "log()",
+						Snippet: "log(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+					},
+				},
+				{
+					Label:       "lower",
+					Detail:      "lower(str string) string",
+					Description: lang.Markdown("`lower` converts all cased letters in the given string to lowercase."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "lower()",
+						Snippet: "lower(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+					},
+				},
+				{
+					Label:       "split",
+					Detail:      "split(separator string, str string) list of string",
+					Description: lang.Markdown("`split` produces a list by dividing a given string at all occurrences of a given separator."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "split()",
+						Snippet: "split(${0})",
 						Range: hcl.Range{
 							Filename: "test.tf",
 							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
@@ -188,6 +309,21 @@ func TestCompletionAtPos_exprAny_functions(t *testing.T) {
 					},
 				},
 				{
+					Label:       "join",
+					Detail:      "join(separator string, …lists list of string) string",
+					Description: lang.Markdown("`join` produces a string by concatenating together all elements of a given list of strings with the given delimiter."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "join()",
+						Snippet: "join(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 14, Byte: 15},
+							End:      hcl.Pos{Line: 1, Column: 14, Byte: 15},
+						},
+					},
+				},
+				{
 					Label:       "keys",
 					Detail:      "keys(inputMap dynamic) dynamic",
 					Description: lang.Markdown("`keys` takes a map and returns a list containing the keys from that map."),
@@ -195,6 +331,51 @@ func TestCompletionAtPos_exprAny_functions(t *testing.T) {
 					TextEdit: lang.TextEdit{
 						NewText: "keys()",
 						Snippet: "keys(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 14, Byte: 15},
+							End:      hcl.Pos{Line: 1, Column: 14, Byte: 15},
+						},
+					},
+				},
+				{
+					Label:       "log",
+					Detail:      "log(num number, base number) number",
+					Description: lang.Markdown("`log` returns the logarithm of a given number in a given base."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "log()",
+						Snippet: "log(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 14, Byte: 15},
+							End:      hcl.Pos{Line: 1, Column: 14, Byte: 15},
+						},
+					},
+				},
+				{
+					Label:       "lower",
+					Detail:      "lower(str string) string",
+					Description: lang.Markdown("`lower` converts all cased letters in the given string to lowercase."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "lower()",
+						Snippet: "lower(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 14, Byte: 15},
+							End:      hcl.Pos{Line: 1, Column: 14, Byte: 15},
+						},
+					},
+				},
+				{
+					Label:       "split",
+					Detail:      "split(separator string, str string) list of string",
+					Description: lang.Markdown("`split` produces a list by dividing a given string at all occurrences of a given separator."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "split()",
+						Snippet: "split(${0})",
 						Range: hcl.Range{
 							Filename: "test.tf",
 							Start:    hcl.Pos{Line: 1, Column: 14, Byte: 15},
@@ -366,7 +547,7 @@ func TestCompletionAtPos_exprAny_functions(t *testing.T) {
 			}),
 		},
 		{
-			"second argument of a function ",
+			"second number argument of a function",
 			map[string]*schema.AttributeSchema{
 				"attr": {
 					Constraint: schema.AnyExpression{
@@ -387,6 +568,21 @@ func TestCompletionAtPos_exprAny_functions(t *testing.T) {
 					TextEdit: lang.TextEdit{
 						NewText: "element()",
 						Snippet: "element(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 28, Byte: 29},
+							End:      hcl.Pos{Line: 1, Column: 28, Byte: 29},
+						},
+					},
+				},
+				{
+					Label:       "join",
+					Detail:      "join(separator string, …lists list of string) string",
+					Description: lang.Markdown("`join` produces a string by concatenating together all elements of a given list of strings with the given delimiter."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "join()",
+						Snippet: "join(${0})",
 						Range: hcl.Range{
 							Filename: "test.tf",
 							Start:    hcl.Pos{Line: 1, Column: 28, Byte: 29},
@@ -424,10 +620,25 @@ func TestCompletionAtPos_exprAny_functions(t *testing.T) {
 						},
 					},
 				},
+				{
+					Label:       "lower",
+					Detail:      "lower(str string) string",
+					Description: lang.Markdown("`lower` converts all cased letters in the given string to lowercase."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "lower()",
+						Snippet: "lower(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 28, Byte: 29},
+							End:      hcl.Pos{Line: 1, Column: 28, Byte: 29},
+						},
+					},
+				},
 			}),
 		},
 		{
-			"nested functions",
+			"nested functions with string constraint",
 			map[string]*schema.AttributeSchema{
 				"attr": {
 					Constraint: schema.AnyExpression{
@@ -478,6 +689,21 @@ func TestCompletionAtPos_exprAny_functions(t *testing.T) {
 					TextEdit: lang.TextEdit{
 						NewText: "keys()",
 						Snippet: "keys(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 22, Byte: 23},
+							End:      hcl.Pos{Line: 1, Column: 22, Byte: 23},
+						},
+					},
+				},
+				{
+					Label:       "log",
+					Detail:      "log(num number, base number) number",
+					Description: lang.Markdown("`log` returns the logarithm of a given number in a given base."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "log()",
+						Snippet: "log(${0})",
 						Range: hcl.Range{
 							Filename: "test.tf",
 							Start:    hcl.Pos{Line: 1, Column: 22, Byte: 23},

--- a/decoder/expr_any_hover.go
+++ b/decoder/expr_any_hover.go
@@ -1,0 +1,30 @@
+package decoder
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+func (a Any) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData {
+	switch e := a.expr.(type) {
+	// TODO! Support LiteralType
+	// TODO! Support References
+	case *hclsyntax.FunctionCallExpr:
+		f, ok := a.pathCtx.Functions[e.Name]
+		if ok {
+			// TODO! check for name range
+			// TODO! loop over arguments, do hoverAtPos for that argument using the constraint
+			return &lang.HoverData{
+				// TODO? add link to docs
+				Content: lang.Markdown(fmt.Sprintf("```terraform\n%s(%s) %s\n```\n\n%s", e.Name, parameterNamesAsString(f), f.ReturnType.FriendlyName(), f.Description)),
+				Range:   a.expr.Range(),
+			}
+		}
+	}
+
+	return nil
+}

--- a/decoder/expr_any_hover.go
+++ b/decoder/expr_any_hover.go
@@ -2,29 +2,127 @@ package decoder
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 )
 
 func (a Any) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData {
-	switch e := a.expr.(type) {
-	// TODO! Support LiteralType
-	// TODO! Support References
-	case *hclsyntax.FunctionCallExpr:
-		f, ok := a.pathCtx.Functions[e.Name]
-		if ok {
-			// TODO! check for name range
-			// TODO! loop over arguments, do hoverAtPos for that argument using the constraint
-			return &lang.HoverData{
-				// TODO? add link to docs
-				Content: lang.Markdown(fmt.Sprintf("```terraform\n%s(%s) %s\n```\n\n%s", e.Name, parameterNamesAsString(f), f.ReturnType.FriendlyName(), f.Description)),
-				Range:   a.expr.Range(),
-			}
+	typ := a.cons.OfType
+
+	if typ.IsListType() {
+		expr, ok := a.expr.(*hclsyntax.TupleConsExpr)
+		if !ok {
+			return a.hoverNonComplexExprAtPos(ctx, pos)
 		}
+
+		cons := schema.List{
+			Elem: schema.AnyExpression{
+				OfType: typ.ElementType(),
+			},
+		}
+
+		return newExpression(a.pathCtx, expr, cons).HoverAtPos(ctx, pos)
 	}
 
-	return nil
+	if typ.IsSetType() {
+		expr, ok := a.expr.(*hclsyntax.TupleConsExpr)
+		if !ok {
+			return a.hoverNonComplexExprAtPos(ctx, pos)
+		}
+
+		cons := schema.Set{
+			Elem: schema.AnyExpression{
+				OfType: typ.ElementType(),
+			},
+		}
+
+		return newExpression(a.pathCtx, expr, cons).HoverAtPos(ctx, pos)
+	}
+
+	if typ.IsTupleType() {
+		expr, ok := a.expr.(*hclsyntax.TupleConsExpr)
+		if !ok {
+			return a.hoverNonComplexExprAtPos(ctx, pos)
+		}
+
+		elemTypes := typ.TupleElementTypes()
+		cons := schema.Tuple{
+			Elems: make([]schema.Constraint, len(elemTypes)),
+		}
+		for i, elemType := range elemTypes {
+			cons.Elems[i] = schema.LiteralType{
+				Type: elemType,
+			}
+		}
+
+		return newExpression(a.pathCtx, expr, cons).HoverAtPos(ctx, pos)
+	}
+
+	if typ.IsMapType() {
+		expr, ok := a.expr.(*hclsyntax.ObjectConsExpr)
+		if !ok {
+			return a.hoverNonComplexExprAtPos(ctx, pos)
+		}
+
+		cons := schema.Map{
+			Elem: schema.AnyExpression{
+				OfType: typ.ElementType(),
+			},
+		}
+		return newExpression(a.pathCtx, expr, cons).HoverAtPos(ctx, pos)
+	}
+
+	if typ.IsObjectType() {
+		expr, ok := a.expr.(*hclsyntax.ObjectConsExpr)
+		if !ok {
+			return a.hoverNonComplexExprAtPos(ctx, pos)
+		}
+
+		cons := schema.Object{
+			Attributes: ctyObjectToObjectAttributes(typ),
+		}
+		return newExpression(a.pathCtx, expr, cons).HoverAtPos(ctx, pos)
+	}
+
+	return a.hoverNonComplexExprAtPos(ctx, pos)
+}
+
+func (a Any) hoverNonComplexExprAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData {
+	// TODO: Support TemplateExpr https://github.com/hashicorp/terraform-ls/issues/522
+	// TODO: Support splat expression https://github.com/hashicorp/terraform-ls/issues/526
+	// TODO: Support for-in-if expression https://github.com/hashicorp/terraform-ls/issues/527
+	// TODO: Support conditional expression https://github.com/hashicorp/terraform-ls/issues/528
+	// TODO: Support operator expresssions https://github.com/hashicorp/terraform-ls/issues/529
+	// TODO: Support complex index expressions https://github.com/hashicorp/terraform-ls/issues/531
+	// TODO: Support relative traversals https://github.com/hashicorp/terraform-ls/issues/532
+
+	ref := Reference{
+		expr:    a.expr,
+		cons:    schema.Reference{OfType: a.cons.OfType},
+		pathCtx: a.pathCtx,
+	}
+	hoverData := ref.HoverAtPos(ctx, pos)
+	if hoverData != nil {
+		return hoverData
+	}
+
+	fe := functionExpr{
+		expr:       a.expr,
+		returnType: a.cons.OfType,
+		pathCtx:    a.pathCtx,
+	}
+	hoverData = fe.HoverAtPos(ctx, pos)
+	if hoverData != nil {
+		return hoverData
+	}
+
+	lt := LiteralType{
+		expr:    a.expr,
+		cons:    schema.LiteralType{Type: a.cons.OfType},
+		pathCtx: a.pathCtx,
+	}
+	return lt.HoverAtPos(ctx, pos)
 }

--- a/decoder/expr_any_hover_test.go
+++ b/decoder/expr_any_hover_test.go
@@ -59,10 +59,72 @@ func TestHoverAtPos_exprAny_functions(t *testing.T) {
 				},
 			},
 		},
+		{
+			"over parameter",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			`attr = join(",", ["a", "b"])
+`,
+			hcl.Pos{Line: 1, Column: 15, Byte: 14},
+			&lang.HoverData{
+				Content: lang.MarkupContent{
+					Value: "_string_",
+					Kind:  lang.MarkdownKind,
+				},
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 13, Byte: 12},
+					End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+				},
+			},
+		},
+		{
+			"over complex variadic parameter",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			`attr = join(",", ["a", "b"])
+`,
+			hcl.Pos{Line: 1, Column: 21, Byte: 20},
+			&lang.HoverData{
+				Content: lang.MarkupContent{
+					Value: "_string_",
+					Kind:  lang.MarkdownKind,
+				},
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 19, Byte: 18},
+					End:      hcl.Pos{Line: 1, Column: 22, Byte: 21},
+				},
+			},
+		},
+		{
+			"over too many arguments",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			`attr = lower("FOO", "BAR")
+`,
+			hcl.Pos{Line: 1, Column: 24, Byte: 23},
+			nil,
+		},
 	}
 
 	for i, tc := range testCases {
-		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%2d-%s", i, tc.testName), func(t *testing.T) {
 			bodySchema := &schema.BodySchema{
 				Attributes: tc.attrSchema,
 			}

--- a/decoder/expr_any_hover_test.go
+++ b/decoder/expr_any_hover_test.go
@@ -1,0 +1,91 @@
+package decoder
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestHoverAtPos_exprAny_functions(t *testing.T) {
+	testCases := []struct {
+		testName     string
+		attrSchema   map[string]*schema.AttributeSchema
+		cfg          string
+		pos          hcl.Pos
+		expectedData *lang.HoverData
+	}{
+		{
+			"over unknown function",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			`attr = unknown()
+`,
+			hcl.Pos{Line: 1, Column: 10, Byte: 9},
+			nil,
+		},
+		{
+			"over name",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			`attr = lower("FOO")
+`,
+			hcl.Pos{Line: 1, Column: 10, Byte: 9},
+			&lang.HoverData{
+				Content: lang.MarkupContent{
+					Value: "```terraform\nlower(str string) string\n```\n\n`lower` converts all cased letters in the given string to lowercase.",
+					Kind:  lang.MarkdownKind,
+				},
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 20, Byte: 19},
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := &schema.BodySchema{
+				Attributes: tc.attrSchema,
+			}
+
+			f, _ := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.tf": f,
+				},
+				Functions: testFunctionSignatures(),
+			})
+
+			ctx := context.Background()
+			data, err := d.HoverAtPos(ctx, "test.tf", tc.pos)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedData, data); diff != "" {
+				t.Fatalf("unexpected data: %s", diff)
+			}
+		})
+	}
+
+}

--- a/decoder/expr_any_hover_test.go
+++ b/decoder/expr_any_hover_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/reference"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -1285,6 +1286,181 @@ TEXT
 				Files: map[string]*hcl.File{
 					"test.tf": f,
 				},
+			})
+
+			ctx := context.Background()
+			hoverData, err := d.HoverAtPos(ctx, "test.tf", tc.pos)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedHoverData, hoverData); diff != "" {
+				t.Fatalf("unexpected hover data: %s", diff)
+			}
+		})
+	}
+}
+
+func TestHoverAtPos_exprAny_references(t *testing.T) {
+	testCases := []struct {
+		testName          string
+		attrSchema        map[string]*schema.AttributeSchema
+		refOrigins        reference.Origins
+		refTargets        reference.Targets
+		cfg               string
+		pos               hcl.Pos
+		expectedHoverData *lang.HoverData
+	}{
+		{
+			"unknown origin",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			reference.Origins{
+				reference.LocalOrigin{
+					Addr: lang.Address{
+						lang.RootStep{Name: "d"},
+						lang.AttrStep{Name: "fx"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 13, Byte: 12},
+						End:      hcl.Pos{Line: 1, Column: 17, Byte: 16},
+					},
+					Constraints: reference.OriginConstraints{
+						{
+							OfType: cty.String,
+						},
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "foo"},
+					},
+					Type: cty.String,
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 17},
+						End:      hcl.Pos{Line: 2, Column: 13, Byte: 29},
+					},
+				},
+			},
+			`attr = l.ca+d.fx
+foo = "noot"
+`,
+			hcl.Pos{Line: 1, Column: 10, Byte: 9},
+			nil,
+		},
+		{
+			"matching origin no target",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			reference.Origins{
+				reference.LocalOrigin{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "foo"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						End:      hcl.Pos{Line: 1, Column: 17, Byte: 16},
+					},
+					Constraints: reference.OriginConstraints{
+						{
+							OfType: cty.String,
+						},
+					},
+				},
+			},
+			reference.Targets{},
+			`attr = local.foo
+foo = "noot"
+`,
+			hcl.Pos{Line: 1, Column: 12, Byte: 11},
+			nil,
+		},
+		{
+			"matching origin and target",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			reference.Origins{
+				reference.LocalOrigin{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "foo"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						End:      hcl.Pos{Line: 1, Column: 17, Byte: 16},
+					},
+					Constraints: reference.OriginConstraints{
+						{
+							OfType: cty.String,
+						},
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "foo"},
+					},
+					Type: cty.String,
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 17},
+						End:      hcl.Pos{Line: 2, Column: 13, Byte: 29},
+					},
+				},
+			},
+			`attr = local.foo
+foo = "noot"
+`,
+			hcl.Pos{Line: 1, Column: 12, Byte: 11},
+			&lang.HoverData{
+				Content: lang.Markdown("`local.foo`\n_string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 17, Byte: 16},
+				},
+			},
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := &schema.BodySchema{
+				Attributes: tc.attrSchema,
+			}
+
+			f, _ := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.tf": f,
+				},
+				ReferenceOrigins: tc.refOrigins,
+				ReferenceTargets: tc.refTargets,
 			})
 
 			ctx := context.Background()

--- a/decoder/expr_any_hover_test.go
+++ b/decoder/expr_any_hover_test.go
@@ -36,7 +36,7 @@ func TestHoverAtPos_exprAny_functions(t *testing.T) {
 			nil,
 		},
 		{
-			"over name",
+			"over function name",
 			map[string]*schema.AttributeSchema{
 				"attr": {
 					Constraint: schema.AnyExpression{
@@ -60,7 +60,7 @@ func TestHoverAtPos_exprAny_functions(t *testing.T) {
 			},
 		},
 		{
-			"over parameter",
+			"over function parameter",
 			map[string]*schema.AttributeSchema{
 				"attr": {
 					Constraint: schema.AnyExpression{
@@ -119,6 +119,20 @@ func TestHoverAtPos_exprAny_functions(t *testing.T) {
 			`attr = lower("FOO", "BAR")
 `,
 			hcl.Pos{Line: 1, Column: 24, Byte: 23},
+			nil,
+		},
+		{
+			"over mismatching argument",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			`attr = lower(["FOO"])
+`,
+			hcl.Pos{Line: 1, Column: 17, Byte: 16},
 			nil,
 		},
 	}

--- a/decoder/expr_any_hover_test.go
+++ b/decoder/expr_any_hover_test.go
@@ -165,3 +165,1137 @@ func TestHoverAtPos_exprAny_functions(t *testing.T) {
 	}
 
 }
+
+func TestHoverAtPos_exprAny_literalTypes(t *testing.T) {
+	testCases := []struct {
+		testName          string
+		attrSchema        map[string]*schema.AttributeSchema
+		cfg               string
+		pos               hcl.Pos
+		expectedHoverData *lang.HoverData
+	}{
+		{
+			"any type",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.DynamicPseudoType,
+					},
+					IsOptional: true,
+				},
+			},
+			`attr = "foobar"`,
+			hcl.Pos{Line: 1, Column: 12, Byte: 11},
+			&lang.HoverData{
+				Content: lang.Markdown("_string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+				},
+			},
+		},
+
+		// primitive types
+		{
+			"boolean",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Bool,
+					},
+				},
+			},
+			`attr = false`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			&lang.HoverData{
+				Content: lang.Markdown("_bool_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 13, Byte: 12},
+				},
+			},
+		},
+		{
+			"number whole",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Number,
+					},
+				},
+			},
+			`attr = 4222"`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			&lang.HoverData{
+				Content: lang.Markdown("_number_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 12, Byte: 11},
+				},
+			},
+		},
+		{
+			"number fractional",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Number,
+					},
+				},
+			},
+			`attr = 4.222"`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			&lang.HoverData{
+				Content: lang.Markdown("_number_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 13, Byte: 12},
+				},
+			},
+		},
+		{
+			"string single-line",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			`attr = "foo"`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			&lang.HoverData{
+				Content: lang.Markdown("_string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 13, Byte: 12},
+				},
+			},
+		},
+		{
+			"string multi-line",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			`attr = <<TEXT
+foo
+bar
+TEXT
+`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			&lang.HoverData{
+				Content: lang.Markdown("_string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 4, Column: 5, Byte: 26},
+				},
+			},
+		},
+		{
+			"string template",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			`attr = "foo${bar}"`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			nil,
+		},
+
+		// list
+		{
+			"list with any element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.List(cty.DynamicPseudoType),
+					},
+				},
+			},
+			`attr = []`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			&lang.HoverData{
+				Content: lang.Markdown("_list of any type_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+				},
+			},
+		},
+		{
+			"empty single-line list with element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.List(cty.String),
+					},
+				},
+			},
+			`attr = []`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			&lang.HoverData{
+				Content: lang.Markdown("_list of string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+				},
+			},
+		},
+		{
+			"empty multi-line list with element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.List(cty.String),
+					},
+				},
+			},
+			`attr = [
+  
+]`,
+			hcl.Pos{Line: 2, Column: 2, Byte: 10},
+			&lang.HoverData{
+				Content: lang.Markdown("_list of string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 3, Column: 2, Byte: 13},
+				},
+			},
+		},
+		{
+			"single element single-line list on element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.List(cty.String),
+					},
+				},
+			},
+			`attr = ["fooba"]`,
+			hcl.Pos{Line: 1, Column: 12, Byte: 11},
+			&lang.HoverData{
+				Content: lang.Markdown("_string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+					End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+				},
+			},
+		},
+		{
+			"multi-element single-line list on list",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.List(cty.String),
+					},
+				},
+			},
+			`attr = [ "one", "two" ]`,
+			hcl.Pos{Line: 1, Column: 8, Byte: 7},
+			&lang.HoverData{
+				Content: lang.Markdown("_list of string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start: hcl.Pos{
+						Line:   1,
+						Column: 8,
+						Byte:   7,
+					},
+					End: hcl.Pos{
+						Line:   1,
+						Column: 24,
+						Byte:   23,
+					},
+				},
+			},
+		},
+		{
+			"single element multi-line list on element with custom data",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.List(cty.String),
+					},
+				},
+			},
+			`attr = [
+  "foobar",
+]`,
+			hcl.Pos{Line: 2, Column: 6, Byte: 14},
+			&lang.HoverData{
+				Content: lang.Markdown("_string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+					End:      hcl.Pos{Line: 2, Column: 11, Byte: 19},
+				},
+			},
+		},
+		{
+			"multi-element multi-line list on invalid element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.List(cty.String),
+					},
+				},
+			},
+			`attr = [
+  4223,
+  "foobar",
+]`,
+			hcl.Pos{Line: 2, Column: 6, Byte: 14},
+			nil,
+		},
+		{
+			"multi-element multi-line list on second element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.List(cty.String),
+					},
+				},
+			},
+			`attr = [
+  "foo",
+  "bar",
+]`,
+			hcl.Pos{Line: 3, Column: 4, Byte: 22},
+			&lang.HoverData{
+				Content: lang.Markdown("_string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 3, Column: 3, Byte: 20},
+					End:      hcl.Pos{Line: 3, Column: 8, Byte: 25},
+				},
+			},
+		},
+
+		// set
+		{
+			"set with any element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Set(cty.DynamicPseudoType),
+					},
+				},
+			},
+			`attr = []`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			&lang.HoverData{
+				Content: lang.Markdown("_set of any type_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+				},
+			},
+		},
+		{
+			"empty single-line set with element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Set(cty.String),
+					},
+				},
+			},
+			`attr = []`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			&lang.HoverData{
+				Content: lang.Markdown("_set of string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+				},
+			},
+		},
+		{
+			"empty multi-line set with element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Set(cty.String),
+					},
+				},
+			},
+			`attr = [
+  
+]`,
+			hcl.Pos{Line: 2, Column: 2, Byte: 10},
+			&lang.HoverData{
+				Content: lang.Markdown("_set of string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 3, Column: 2, Byte: 13},
+				},
+			},
+		},
+		{
+			"single element single-line set on element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Set(cty.String),
+					},
+				},
+			},
+			`attr = ["fooba"]`,
+			hcl.Pos{Line: 1, Column: 12, Byte: 11},
+			&lang.HoverData{
+				Content: lang.Markdown("_string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+					End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+				},
+			},
+		},
+		{
+			"multi-element single-line set on set",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Set(cty.String),
+					},
+				},
+			},
+			`attr = [ "one", "two" ]`,
+			hcl.Pos{Line: 1, Column: 8, Byte: 7},
+			&lang.HoverData{
+				Content: lang.Markdown("_set of string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start: hcl.Pos{
+						Line:   1,
+						Column: 8,
+						Byte:   7,
+					},
+					End: hcl.Pos{
+						Line:   1,
+						Column: 24,
+						Byte:   23,
+					},
+				},
+			},
+		},
+		{
+			"multi-element multi-line set on invalid element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Set(cty.String),
+					},
+				},
+			},
+			`attr = [
+  42223,
+  "foobar",
+]`,
+			hcl.Pos{Line: 2, Column: 6, Byte: 14},
+			nil,
+		},
+		{
+			"multi-element multi-line set on second element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Set(cty.String),
+					},
+				},
+			},
+			`attr = [
+  "foo",
+  "bar",
+]`,
+			hcl.Pos{Line: 3, Column: 5, Byte: 22},
+			&lang.HoverData{
+				Content: lang.Markdown("_string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 3, Column: 3, Byte: 20},
+					End:      hcl.Pos{Line: 3, Column: 8, Byte: 25},
+				},
+			},
+		},
+
+		// tuple
+		{
+			"empty single-line tuple without element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Tuple([]cty.Type{}),
+					},
+				},
+			},
+			`attr = []`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			&lang.HoverData{
+				Content: lang.Markdown("_tuple_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+				},
+			},
+		},
+		{
+			"empty multi-line tuple without element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Tuple([]cty.Type{}),
+					},
+				},
+			},
+			`attr = [
+  
+]`,
+			hcl.Pos{Line: 2, Column: 2, Byte: 10},
+			&lang.HoverData{
+				Content: lang.Markdown("_tuple_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 3, Column: 2, Byte: 13},
+				},
+			},
+		},
+		{
+			"empty single-line tuple with one element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Tuple([]cty.Type{
+							cty.String,
+							cty.Number,
+						}),
+					},
+				},
+			},
+			`attr = []`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			&lang.HoverData{
+				Content: lang.Markdown("_tuple_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+				},
+			},
+		},
+		{
+			"empty multi-line tuple with one element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Tuple([]cty.Type{
+							cty.String,
+						}),
+					},
+				},
+			},
+			`attr = [
+  
+]`,
+			hcl.Pos{Line: 2, Column: 2, Byte: 10},
+			&lang.HoverData{
+				Content: lang.Markdown("_tuple_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 3, Column: 2, Byte: 13},
+				},
+			},
+		},
+		{
+			"single element single-line tuple on element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Tuple([]cty.Type{
+							cty.String,
+							cty.Bool,
+						}),
+					},
+				},
+			},
+			`attr = ["fooba"]`,
+			hcl.Pos{Line: 1, Column: 12, Byte: 11},
+			&lang.HoverData{
+				Content: lang.Markdown("_string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+					End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+				},
+			},
+		},
+		{
+			"multi-element single-line tuple on tuple",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Tuple([]cty.Type{
+							cty.String,
+							cty.Number,
+						}),
+					},
+				},
+			},
+			`attr = [ "one", 42234 ]`,
+			hcl.Pos{Line: 1, Column: 8, Byte: 7},
+			&lang.HoverData{
+				Content: lang.Markdown("_tuple_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start: hcl.Pos{
+						Line:   1,
+						Column: 8,
+						Byte:   7,
+					},
+					End: hcl.Pos{
+						Line:   1,
+						Column: 24,
+						Byte:   23,
+					},
+				},
+			},
+		},
+		{
+			"multi-element multi-line tuple on invalid element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Tuple([]cty.Type{
+							cty.Number,
+							cty.String,
+						}),
+					},
+				},
+			},
+			`attr = [
+  "foo",
+  42223,
+]`,
+			hcl.Pos{Line: 2, Column: 6, Byte: 14},
+			nil,
+		},
+		{
+			"multi-element multi-line tuple on second element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Tuple([]cty.Type{
+							cty.String,
+							cty.String,
+						}),
+					},
+				},
+			},
+			`attr = [
+  "foobar",
+  "barfoo",
+]`,
+			hcl.Pos{Line: 3, Column: 6, Byte: 26},
+			&lang.HoverData{
+				Content: lang.Markdown("_string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 3, Column: 3, Byte: 23},
+					End:      hcl.Pos{Line: 3, Column: 11, Byte: 31},
+				},
+			},
+		},
+
+		// map
+		{
+			"empty single-line map with any element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Map(cty.DynamicPseudoType),
+					},
+				},
+			},
+			`attr = {}`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			&lang.HoverData{
+				Content: lang.Markdown("_map of any type_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+				},
+			},
+		},
+		{
+			"empty multi-line map with any element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Map(cty.DynamicPseudoType),
+					},
+				},
+			},
+			`attr = {
+  
+}`,
+			hcl.Pos{Line: 2, Column: 2, Byte: 10},
+			&lang.HoverData{
+				Content: lang.Markdown("_map of any type_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 3, Column: 2, Byte: 13},
+				},
+			},
+		},
+		{
+			"empty single-line map with element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Map(cty.String),
+					},
+				},
+			},
+			`attr = {}`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			&lang.HoverData{
+				Content: lang.Markdown("_map of string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+				},
+			},
+		},
+		{
+			"single item map on key name",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Map(cty.String),
+					},
+				},
+			},
+			`attr = {
+  foo = "bar"
+}`,
+			hcl.Pos{Line: 2, Column: 5, Byte: 13},
+			nil,
+		},
+		{
+			"single item map on invalid key type",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Map(cty.String),
+					},
+				},
+			},
+			`attr = {
+  422 = "bar"
+}`,
+			hcl.Pos{Line: 2, Column: 5, Byte: 13},
+			nil,
+		},
+		{
+			"multi item map on valid key type",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Map(cty.String),
+					},
+				},
+			},
+			`attr = {
+  422 = "foo"
+  bar = "bar"
+  432 = "baz"
+}`,
+			hcl.Pos{Line: 3, Column: 5, Byte: 27},
+			nil,
+		},
+		{
+			"multi item map on matching value",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Map(cty.String),
+					},
+				},
+			},
+			`attr = {
+  foo = invalid
+  bar = "foobar"
+  baz = "foobaz"
+}`,
+			hcl.Pos{Line: 3, Column: 13, Byte: 37},
+			&lang.HoverData{
+				Content: lang.Markdown("_string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 3, Column: 9, Byte: 33},
+					End:      hcl.Pos{Line: 3, Column: 17, Byte: 41},
+				},
+			},
+		},
+		{
+			"multi item map on mismatching value",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Map(cty.String),
+					},
+				},
+			},
+			`attr = {
+  foo = invalid
+  bar = "foobar"
+  baz = "foobaz"
+}`,
+			hcl.Pos{Line: 2, Column: 13, Byte: 21},
+			nil,
+		},
+
+		// object
+		{
+			"empty single-line object without attributes",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Object(map[string]cty.Type{}),
+					},
+				},
+			},
+			`attr = {}`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			&lang.HoverData{
+				Content: lang.Markdown("_object_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+				},
+			},
+		},
+		{
+			"empty multi-line object without attributes",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Object(map[string]cty.Type{}),
+					},
+				},
+			},
+			`attr = {
+  
+}`,
+			hcl.Pos{Line: 2, Column: 2, Byte: 10},
+			&lang.HoverData{
+				Content: lang.Markdown("_object_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 3, Column: 2, Byte: 13},
+				},
+			},
+		},
+		{
+			"empty single-line object with attributes",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+							"foo": cty.String,
+						}, []string{"foo"}),
+					},
+				},
+			},
+			`attr = {}`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			&lang.HoverData{
+				Content: lang.Markdown("```\n{\n  foo = string # optional\n}\n```\n_object_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+				},
+			},
+		},
+		{
+			"empty multi-line object with attributes",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+							"foo": cty.String,
+						}, []string{"foo"}),
+					},
+				},
+			},
+			`attr = {
+  
+}`,
+			hcl.Pos{Line: 2, Column: 2, Byte: 10},
+			&lang.HoverData{
+				Content: lang.Markdown("```\n{\n  foo = string # optional\n}\n```\n_object_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 3, Column: 2, Byte: 13},
+				},
+			},
+		},
+		{
+			"single item object on valid attribute name",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+							"foo": cty.String,
+						}, []string{"foo"}),
+					},
+				},
+			},
+			`attr = {
+  foo = "fooba"
+}`,
+			hcl.Pos{Line: 2, Column: 5, Byte: 13},
+			&lang.HoverData{
+				Content: lang.Markdown("**foo** _optional, string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+					End:      hcl.Pos{Line: 2, Column: 16, Byte: 24},
+				},
+			},
+		},
+		{
+			"single item object on invalid attribute name",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Object(map[string]cty.Type{
+							"foo": cty.String,
+						}),
+					},
+				},
+			},
+			`attr = {
+  bar = "fooba"
+}`,
+			hcl.Pos{Line: 2, Column: 5, Byte: 13},
+			&lang.HoverData{
+				Content: lang.Markdown("```" + `
+{
+  foo = string
+}
+` + "```\n" + `_object_`),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 3, Column: 2, Byte: 26},
+				},
+			},
+		},
+		{
+			"multi item object on valid attribute name",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.String,
+							"baz": cty.String,
+						}, []string{"foo", "baz"}),
+					},
+				},
+			},
+			`attr = {
+  foo = "foo"
+  bar = "bar"
+  baz = "baz"
+}`,
+			hcl.Pos{Line: 3, Column: 5, Byte: 27},
+			&lang.HoverData{
+				Content: lang.Markdown("**bar** _required, string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 3, Column: 3, Byte: 25},
+					End:      hcl.Pos{Line: 3, Column: 14, Byte: 36},
+				},
+			},
+		},
+		{
+			"multi item object on matching value",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.String,
+							"baz": cty.String,
+						}, []string{"foo", "bar", "baz"}),
+					},
+				},
+			},
+			`attr = {
+  foo = invalid
+  bar = "barbar"
+  baz = "bazbaz"
+}`,
+			hcl.Pos{Line: 3, Column: 16, Byte: 40},
+			&lang.HoverData{
+				Content: lang.Markdown("_string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 3, Column: 9, Byte: 33},
+					End:      hcl.Pos{Line: 3, Column: 17, Byte: 41},
+				},
+			},
+		},
+		{
+			"multi item object on mismatching value",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.String,
+							"baz": cty.String,
+						}, []string{"foo", "bar", "baz"}),
+					},
+				},
+			},
+			`attr = {
+  foo = invalid
+  bar = "barbar"
+  baz = "bazbaz"
+}`,
+			hcl.Pos{Line: 2, Column: 13, Byte: 21},
+			nil,
+		},
+		{
+			"multi item object in empty space",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+							"foo": cty.Number,
+							"bar": cty.String,
+							"baz": cty.String,
+						}, []string{"foo", "bar", "baz"}),
+					},
+				},
+			},
+			`attr = {
+  bar = "bar"
+  baz = "baz"
+}`,
+			hcl.Pos{Line: 2, Column: 2, Byte: 10},
+			&lang.HoverData{
+				Content: lang.Markdown("```" + `
+{
+  bar = string # optional
+  baz = string # optional
+  foo = number # optional
+}
+` + "```\n_object_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 4, Column: 2, Byte: 38},
+				},
+			},
+		},
+		{
+			"multi item nested object",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+							"foo": cty.Number,
+							"bar": cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+								"noot":   cty.Bool,
+								"animal": cty.String,
+							}, []string{"animal"}),
+							"baz": cty.String,
+						}, []string{"foo", "bar", "baz"}),
+					},
+				},
+			},
+			`attr = {
+  bar = {}
+  baz = "baz"
+}`,
+			hcl.Pos{Line: 2, Column: 2, Byte: 10},
+			&lang.HoverData{
+				Content: lang.Markdown("```" + `
+{
+  bar = {
+    animal = string # optional
+    noot = bool
+  } # optional
+  baz = string # optional
+  foo = number # optional
+}
+` + "```\n_object_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 4, Column: 2, Byte: 35},
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := &schema.BodySchema{
+				Attributes: tc.attrSchema,
+			}
+
+			f, _ := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.tf": f,
+				},
+			})
+
+			ctx := context.Background()
+			hoverData, err := d.HoverAtPos(ctx, "test.tf", tc.pos)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedHoverData, hoverData); diff != "" {
+				t.Fatalf("unexpected hover data: %s", diff)
+			}
+		})
+	}
+}

--- a/decoder/expr_any_ref_origins.go
+++ b/decoder/expr_any_ref_origins.go
@@ -1,0 +1,12 @@
+package decoder
+
+import (
+	"context"
+
+	"github.com/hashicorp/hcl-lang/reference"
+)
+
+func (a Any) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {
+	// TODO
+	return nil
+}

--- a/decoder/expr_any_ref_origins.go
+++ b/decoder/expr_any_ref_origins.go
@@ -4,9 +4,157 @@ import (
 	"context"
 
 	"github.com/hashicorp/hcl-lang/reference"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
 )
 
 func (a Any) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {
-	// TODO
-	return nil
+	typ := a.cons.OfType
+
+	if typ.IsListType() {
+		_, ok := a.expr.(*hclsyntax.TupleConsExpr)
+		if !ok {
+			return a.refOriginsForNonComplexExpr(ctx, allowSelfRefs)
+		}
+
+		list := List{
+			expr:    a.expr,
+			pathCtx: a.pathCtx,
+			cons: schema.List{
+				Elem: schema.AnyExpression{
+					OfType: typ.ElementType(),
+				},
+			},
+		}
+		return list.ReferenceOrigins(ctx, allowSelfRefs)
+	}
+
+	if typ.IsSetType() {
+		_, ok := a.expr.(*hclsyntax.TupleConsExpr)
+		if !ok {
+			return a.refOriginsForNonComplexExpr(ctx, allowSelfRefs)
+		}
+
+		set := Set{
+			expr:    a.expr,
+			pathCtx: a.pathCtx,
+			cons: schema.Set{
+				Elem: schema.AnyExpression{
+					OfType: typ.ElementType(),
+				},
+			},
+		}
+		return set.ReferenceOrigins(ctx, allowSelfRefs)
+	}
+
+	if typ.IsTupleType() {
+		_, ok := a.expr.(*hclsyntax.TupleConsExpr)
+		if !ok {
+			return a.refOriginsForNonComplexExpr(ctx, allowSelfRefs)
+		}
+
+		elemTypes := typ.TupleElementTypes()
+		cons := schema.Tuple{
+			Elems: make([]schema.Constraint, len(elemTypes)),
+		}
+		for i, elemType := range elemTypes {
+			cons.Elems[i] = schema.LiteralType{
+				Type: elemType,
+			}
+		}
+
+		tuple := Tuple{
+			expr:    a.expr,
+			pathCtx: a.pathCtx,
+			cons:    cons,
+		}
+		return tuple.ReferenceOrigins(ctx, allowSelfRefs)
+	}
+
+	if typ.IsMapType() {
+		_, ok := a.expr.(*hclsyntax.ObjectConsExpr)
+		if !ok {
+			return a.refOriginsForNonComplexExpr(ctx, allowSelfRefs)
+		}
+
+		m := Map{
+			expr:    a.expr,
+			pathCtx: a.pathCtx,
+			cons: schema.Map{
+				Elem: schema.AnyExpression{
+					OfType: typ.ElementType(),
+				},
+			},
+		}
+		return m.ReferenceOrigins(ctx, allowSelfRefs)
+	}
+
+	if typ.IsObjectType() {
+		_, ok := a.expr.(*hclsyntax.ObjectConsExpr)
+		if !ok {
+			return a.refOriginsForNonComplexExpr(ctx, allowSelfRefs)
+		}
+
+		obj := Object{
+			expr:    a.expr,
+			pathCtx: a.pathCtx,
+			cons: schema.Object{
+				Attributes: ctyObjectToObjectAttributes(typ),
+			},
+		}
+		return obj.ReferenceOrigins(ctx, allowSelfRefs)
+	}
+
+	return a.refOriginsForNonComplexExpr(ctx, allowSelfRefs)
+}
+
+func (a Any) refOriginsForNonComplexExpr(ctx context.Context, allowSelfRefs bool) reference.Origins {
+	// TODO: Support TemplateExpr https://github.com/hashicorp/terraform-ls/issues/522
+	// TODO: Support splat expression https://github.com/hashicorp/terraform-ls/issues/526
+	// TODO: Support for-in-if expression https://github.com/hashicorp/terraform-ls/issues/527
+	// TODO: Support conditional expression https://github.com/hashicorp/terraform-ls/issues/528
+	// TODO: Support operator expresssions https://github.com/hashicorp/terraform-ls/issues/529
+	// TODO: Support complex index expressions https://github.com/hashicorp/terraform-ls/issues/531
+	// TODO: Support relative traversals https://github.com/hashicorp/terraform-ls/issues/532
+
+	// attempt to get accurate constraint for the origins
+	// if we recognise the given expression
+	funcExpr := functionExpr{
+		expr:       a.expr,
+		returnType: a.cons.OfType,
+		pathCtx:    a.pathCtx,
+	}
+	origins := funcExpr.ReferenceOrigins(ctx, allowSelfRefs)
+	if len(origins) > 0 {
+		return origins
+	}
+
+	te, ok := a.expr.(*hclsyntax.ScopeTraversalExpr)
+	if ok {
+		oCons := reference.OriginConstraints{
+			{OfType: a.cons.OfType},
+		}
+		origin, ok := reference.TraversalToLocalOrigin(te.Traversal, oCons, allowSelfRefs)
+		if ok {
+			return reference.Origins{origin}
+		}
+
+		return reference.Origins{}
+	}
+
+	// if not we just collect any/all origins with vague constraint
+	// as that is safest
+	origins = make(reference.Origins, 0)
+	vars := a.expr.Variables()
+	for _, traversal := range vars {
+		oCons := reference.OriginConstraints{
+			{OfType: cty.DynamicPseudoType},
+		}
+		origin, ok := reference.TraversalToLocalOrigin(traversal, oCons, allowSelfRefs)
+		if ok {
+			origins = append(origins, origin)
+		}
+	}
+	return origins
 }

--- a/decoder/expr_any_ref_origins.go
+++ b/decoder/expr_any_ref_origins.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/hcl-lang/reference"
 	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -127,6 +128,14 @@ func (a Any) refOriginsForNonComplexExpr(ctx context.Context, allowSelfRefs bool
 	}
 	origins := funcExpr.ReferenceOrigins(ctx, allowSelfRefs)
 	if len(origins) > 0 {
+		return origins
+	}
+
+	// If we're dealing with a valid function call expression that doesn't contain
+	// any origins, there is no more work todo here and nothing below would match,
+	// so we can return early.
+	_, diags := hcl.ExprCall(a.expr)
+	if !diags.HasErrors() {
 		return origins
 	}
 

--- a/decoder/expr_any_ref_origins_test.go
+++ b/decoder/expr_any_ref_origins_test.go
@@ -1,0 +1,727 @@
+package decoder
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/reference"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/json"
+	"github.com/zclconf/go-cty-debug/ctydebug"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestCollectRefOrigins_exprAny_references_hcl(t *testing.T) {
+	testCases := []struct {
+		testName           string
+		attrSchema         map[string]*schema.AttributeSchema
+		cfg                string
+		expectedRefOrigins reference.Origins
+	}{
+		{
+			"no traversal",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+					IsOptional: true,
+				},
+			},
+			`attr = "foo"`,
+			reference.Origins{},
+		},
+		{
+			"wrapped traversal",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+					IsOptional: true,
+				},
+			},
+			`attr = "${foo}"`,
+			reference.Origins{
+				reference.LocalOrigin{
+					Addr: lang.Address{
+						lang.RootStep{Name: "foo"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 11, Byte: 10},
+						End:      hcl.Pos{Line: 1, Column: 14, Byte: 13},
+					},
+					Constraints: reference.OriginConstraints{
+						{
+							OfType: cty.DynamicPseudoType,
+						},
+					},
+				},
+			},
+		},
+		{
+			"traversal with string",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+					IsOptional: true,
+				},
+			},
+			`attr = "${foo}-bar"`,
+			reference.Origins{
+				reference.LocalOrigin{
+					Addr: lang.Address{
+						lang.RootStep{Name: "foo"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 11, Byte: 10},
+						End:      hcl.Pos{Line: 1, Column: 14, Byte: 13},
+					},
+					Constraints: reference.OriginConstraints{
+						{
+							OfType: cty.DynamicPseudoType,
+						},
+					},
+				},
+			},
+		},
+		{
+			"simple traversal",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+					IsOptional: true,
+				},
+			},
+			`attr = foo`,
+			reference.Origins{
+				reference.LocalOrigin{
+					Addr: lang.Address{
+						lang.RootStep{Name: "foo"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						End:      hcl.Pos{Line: 1, Column: 11, Byte: 10},
+					},
+					Constraints: reference.OriginConstraints{
+						{
+							OfType: cty.String,
+						},
+					},
+				},
+			},
+		},
+		{
+			"traversal with index steps",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+					IsOptional: true,
+				},
+			},
+			`attr = one.two["key"].attr[0]`,
+			reference.Origins{
+				reference.LocalOrigin{
+					Addr: lang.Address{
+						lang.RootStep{Name: "one"},
+						lang.AttrStep{Name: "two"},
+						lang.IndexStep{Key: cty.StringVal("key")},
+						lang.AttrStep{Name: "attr"},
+						lang.IndexStep{Key: cty.NumberIntVal(0)},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						End:      hcl.Pos{Line: 1, Column: 30, Byte: 29},
+					},
+					Constraints: reference.OriginConstraints{
+						{
+							OfType: cty.String,
+						},
+					},
+				},
+			},
+		},
+		{
+			"string which happens to match address",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+					IsOptional: true,
+				},
+			},
+			`attr = "foo"`,
+			reference.Origins{
+				// This should only work in JSON
+			},
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := &schema.BodySchema{
+				Attributes: tc.attrSchema,
+			}
+
+			f, diags := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+			if len(diags) > 0 {
+				t.Error(diags)
+			}
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.tf": f,
+				},
+			})
+
+			origins, err := d.CollectReferenceOrigins()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedRefOrigins, origins, ctydebug.CmpOptions); diff != "" {
+				t.Fatalf("unexpected origins: %s", diff)
+			}
+		})
+	}
+}
+
+func TestCollectRefOrigins_exprAny_references_json(t *testing.T) {
+	testCases := []struct {
+		testName           string
+		attrSchema         map[string]*schema.AttributeSchema
+		cfg                string
+		expectedRefOrigins reference.Origins
+	}{
+		{
+			"no traversal",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+					IsOptional: true,
+				},
+			},
+			`{"attr": 422}`,
+			reference.Origins{},
+		},
+		{
+			"traversal with string",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+					IsOptional: true,
+				},
+			},
+			`{"attr": "${foo}-bar"}`,
+			reference.Origins{
+				reference.LocalOrigin{
+					Addr: lang.Address{
+						lang.RootStep{Name: "foo"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf.json",
+						Start:    hcl.Pos{Line: 1, Column: 13, Byte: 12},
+						End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+					},
+					Constraints: reference.OriginConstraints{
+						{
+							OfType: cty.DynamicPseudoType,
+						},
+					},
+				},
+			},
+		},
+		{
+			"simple traversal",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+					IsOptional: true,
+				},
+			},
+			`{"attr": "${foo}"}`,
+			reference.Origins{
+				reference.LocalOrigin{
+					Addr: lang.Address{
+						lang.RootStep{Name: "foo"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf.json",
+						Start:    hcl.Pos{Line: 1, Column: 13, Byte: 12},
+						End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+					},
+					Constraints: reference.OriginConstraints{
+						{
+							OfType: cty.DynamicPseudoType,
+						},
+					},
+				},
+			},
+		},
+		{
+			"traversal with numeric index steps",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+					IsOptional: true,
+				},
+			},
+			`{"attr": "${one.two[42].attr[0]}"}`,
+			reference.Origins{
+				reference.LocalOrigin{
+					Addr: lang.Address{
+						lang.RootStep{Name: "one"},
+						lang.AttrStep{Name: "two"},
+						lang.IndexStep{Key: cty.NumberIntVal(42)},
+						lang.AttrStep{Name: "attr"},
+						lang.IndexStep{Key: cty.NumberIntVal(0)},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf.json",
+						Start:    hcl.Pos{Line: 1, Column: 13, Byte: 12},
+						End:      hcl.Pos{Line: 1, Column: 32, Byte: 31},
+					},
+					Constraints: reference.OriginConstraints{
+						{
+							OfType: cty.DynamicPseudoType,
+						},
+					},
+				},
+			},
+		},
+		{
+			"traversal with string index steps",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+					IsOptional: true,
+				},
+			},
+			`{"attr": "${one.two[\"key\"].attr[\"foo\"]}"}`,
+			reference.Origins{
+				reference.LocalOrigin{
+					Addr: lang.Address{
+						lang.RootStep{Name: "one"},
+						lang.AttrStep{Name: "two"},
+						lang.IndexStep{Key: cty.StringVal("key")},
+						lang.AttrStep{Name: "attr"},
+						lang.IndexStep{Key: cty.StringVal("foo")},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf.json",
+						// HCL misreports traversals' range w/ string keys in JSON
+						// See https://github.com/hashicorp/hcl/issues/598
+						Start: hcl.Pos{Line: 1, Column: 13, Byte: 12},
+						End:   hcl.Pos{Line: 1, Column: 39, Byte: 38 /* 42 */},
+					},
+					Constraints: reference.OriginConstraints{
+						{
+							OfType: cty.DynamicPseudoType,
+						},
+					},
+				},
+			},
+		},
+		{ // Terraform uses this in most places where it expects references only
+			"legacy style string",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+					IsOptional: true,
+				},
+			},
+			`{"attr": "foo.bar"}`,
+			reference.Origins{},
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := &schema.BodySchema{
+				Attributes: tc.attrSchema,
+			}
+
+			f, diags := json.ParseWithStartPos([]byte(tc.cfg), "test.tf.json", hcl.InitialPos)
+			if len(diags) > 0 {
+				t.Error(diags)
+			}
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.tf.json": f,
+				},
+			})
+
+			origins, err := d.CollectReferenceOrigins()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedRefOrigins, origins, ctydebug.CmpOptions); diff != "" {
+				t.Fatalf("unexpected origins: %s", diff)
+			}
+		})
+	}
+}
+
+func TestCollectRefOrigins_exprAny_functions_hcl(t *testing.T) {
+	testCases := []struct {
+		testName           string
+		attrSchema         map[string]*schema.AttributeSchema
+		cfg                string
+		expectedRefOrigins reference.Origins
+	}{
+		{
+			"unknown function",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			`attr = unknown(var.foo)
+`,
+			reference.Origins{},
+		},
+		{
+			"known function parameter",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			`attr = lower(var.foo)
+`,
+			reference.Origins{
+				reference.LocalOrigin{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "foo"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 14, Byte: 13},
+						End:      hcl.Pos{Line: 1, Column: 21, Byte: 20},
+					},
+					Constraints: reference.OriginConstraints{
+						{
+							OfType: cty.String,
+						},
+					},
+				},
+			},
+		},
+		{
+			"known function variadic parameter",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			`attr = join(",", [var.foo])
+`,
+			reference.Origins{
+				reference.LocalOrigin{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "foo"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 19, Byte: 18},
+						End:      hcl.Pos{Line: 1, Column: 26, Byte: 25},
+					},
+					Constraints: reference.OriginConstraints{
+						{
+							OfType: cty.String,
+						},
+					},
+				},
+			},
+		},
+		{
+			"too many arguments",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			`attr = lower("FOO", var.foo)
+`,
+			reference.Origins{},
+		}, {
+			"(unsupported) expression in function parameter",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			`attr = lower("${var.foo}")
+`,
+			reference.Origins{
+				reference.LocalOrigin{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "foo"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 17, Byte: 16},
+						End:      hcl.Pos{Line: 1, Column: 24, Byte: 23},
+					},
+					Constraints: reference.OriginConstraints{
+						{
+							OfType: cty.DynamicPseudoType,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := &schema.BodySchema{
+				Attributes: tc.attrSchema,
+			}
+
+			f, diags := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+			if len(diags) > 0 {
+				t.Error(diags)
+			}
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.tf": f,
+				},
+				Functions: testFunctionSignatures(),
+			})
+
+			origins, err := d.CollectReferenceOrigins()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedRefOrigins, origins, ctydebug.CmpOptions); diff != "" {
+				t.Fatalf("unexpected origins: %s", diff)
+			}
+		})
+	}
+}
+
+func TestCollectRefOrigins_exprAny_functions_json(t *testing.T) {
+	testCases := []struct {
+		testName           string
+		attrSchema         map[string]*schema.AttributeSchema
+		cfg                string
+		expectedRefOrigins reference.Origins
+	}{
+		{
+			"unknown function",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			`{"attr": "${unknown(var.foo)}"}`,
+			reference.Origins{
+				reference.LocalOrigin{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "foo"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf.json",
+						Start:    hcl.Pos{Line: 1, Column: 21, Byte: 20},
+						End:      hcl.Pos{Line: 1, Column: 28, Byte: 27},
+					},
+					Constraints: reference.OriginConstraints{
+						{
+							OfType: cty.DynamicPseudoType,
+						},
+					},
+				},
+			},
+		},
+		{
+			"known function parameter",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			`{"attr": "${lower(var.foo)}"}`,
+			reference.Origins{
+				reference.LocalOrigin{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "foo"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf.json",
+						Start:    hcl.Pos{Line: 1, Column: 19, Byte: 18},
+						End:      hcl.Pos{Line: 1, Column: 26, Byte: 25},
+					},
+					Constraints: reference.OriginConstraints{
+						{
+							OfType: cty.DynamicPseudoType,
+						},
+					},
+				},
+			},
+		},
+		{
+			"known function variadic parameter",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			`{"attr": "${join(\",\", [var.foo])}"}`,
+			reference.Origins{
+				reference.LocalOrigin{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "foo"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf.json",
+						Start:    hcl.Pos{Line: 1, Column: 24, Byte: 23},
+						End:      hcl.Pos{Line: 1, Column: 31, Byte: 30},
+					},
+					Constraints: reference.OriginConstraints{
+						{
+							OfType: cty.DynamicPseudoType,
+						},
+					},
+				},
+			},
+		},
+		{
+			"too many arguments",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			`{"attr": "${lower(\"FOO\", var.foo)}"}`,
+			reference.Origins{
+				reference.LocalOrigin{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "foo"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf.json",
+						Start:    hcl.Pos{Line: 1, Column: 26, Byte: 25},
+						End:      hcl.Pos{Line: 1, Column: 33, Byte: 32},
+					},
+					Constraints: reference.OriginConstraints{
+						{
+							OfType: cty.DynamicPseudoType,
+						},
+					},
+				},
+			},
+		}, {
+			"(unsupported) expression in function parameter",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			`{"attr": "${lower(\"${var.foo}\")}"}`,
+			reference.Origins{
+				reference.LocalOrigin{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "foo"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf.json",
+						Start:    hcl.Pos{Line: 1, Column: 22, Byte: 21},
+						End:      hcl.Pos{Line: 1, Column: 29, Byte: 28},
+					},
+					Constraints: reference.OriginConstraints{
+						{
+							OfType: cty.DynamicPseudoType,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := &schema.BodySchema{
+				Attributes: tc.attrSchema,
+			}
+
+			f, diags := json.ParseWithStartPos([]byte(tc.cfg), "test.tf.json", hcl.InitialPos)
+			if len(diags) > 0 {
+				t.Error(diags)
+			}
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.tf.json": f,
+				},
+				Functions: testFunctionSignatures(),
+			})
+
+			origins, err := d.CollectReferenceOrigins()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedRefOrigins, origins, ctydebug.CmpOptions); diff != "" {
+				t.Fatalf("unexpected origins: %s", diff)
+			}
+		})
+	}
+}

--- a/decoder/expr_any_ref_targets.go
+++ b/decoder/expr_any_ref_targets.go
@@ -1,0 +1,12 @@
+package decoder
+
+import (
+	"context"
+
+	"github.com/hashicorp/hcl-lang/reference"
+)
+
+func (a Any) ReferenceTargets(ctx context.Context, targetCtx *TargetContext) reference.Targets {
+	// TODO
+	return nil
+}

--- a/decoder/expr_any_ref_targets.go
+++ b/decoder/expr_any_ref_targets.go
@@ -4,9 +4,18 @@ import (
 	"context"
 
 	"github.com/hashicorp/hcl-lang/reference"
+	"github.com/hashicorp/hcl-lang/schema"
 )
 
 func (a Any) ReferenceTargets(ctx context.Context, targetCtx *TargetContext) reference.Targets {
-	// TODO
-	return nil
+	expr := OneOf{
+		pathCtx: a.pathCtx,
+		expr:    a.expr,
+		cons: schema.OneOf{
+			schema.Reference{OfType: a.cons.OfType},
+			schema.LiteralType{Type: a.cons.OfType},
+		},
+	}
+
+	return expr.ReferenceTargets(ctx, targetCtx)
 }

--- a/decoder/expr_any_ref_targets_test.go
+++ b/decoder/expr_any_ref_targets_test.go
@@ -1,0 +1,159 @@
+package decoder
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/reference"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/json"
+	"github.com/zclconf/go-cty-debug/ctydebug"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestCollectRefTargets_exprAny_hcl(t *testing.T) {
+	testCases := []struct {
+		testName           string
+		attrSchema         map[string]*schema.AttributeSchema
+		cfg                string
+		expectedRefTargets reference.Targets
+	}{
+		{
+			"string",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{OfType: cty.String},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`attr = "foobar"`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					Type: cty.String,
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := &schema.BodySchema{
+				Attributes: tc.attrSchema,
+			}
+
+			f, diags := hclsyntax.ParseConfig([]byte(tc.cfg), "test.hcl", hcl.InitialPos)
+			if len(diags) > 0 {
+				t.Error(diags)
+			}
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.hcl": f,
+				},
+			})
+
+			targets, err := d.CollectReferenceTargets()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedRefTargets, targets, ctydebug.CmpOptions); diff != "" {
+				t.Fatalf("unexpected targets: %s", diff)
+			}
+		})
+	}
+}
+
+func TestCollectRefTargets_exprAny_json(t *testing.T) {
+	testCases := []struct {
+		testName           string
+		attrSchema         map[string]*schema.AttributeSchema
+		cfg                string
+		expectedRefTargets reference.Targets
+	}{
+		{
+			"string",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{OfType: cty.String},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`{"attr": "foobar"}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					Type: cty.String,
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 18, Byte: 17},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					},
+				},
+			},
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := &schema.BodySchema{
+				Attributes: tc.attrSchema,
+			}
+
+			f, diags := json.ParseWithStartPos([]byte(tc.cfg), "test.hcl.json", hcl.InitialPos)
+			if len(diags) > 0 {
+				t.Error(diags)
+			}
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.hcl.json": f,
+				},
+			})
+
+			targets, err := d.CollectReferenceTargets()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedRefTargets, targets, ctydebug.CmpOptions); diff != "" {
+				t.Fatalf("unexpected targets: %s", diff)
+			}
+		})
+	}
+}

--- a/decoder/expr_any_semtok.go
+++ b/decoder/expr_any_semtok.go
@@ -4,28 +4,124 @@ import (
 	"context"
 
 	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 )
 
 func (a Any) SemanticTokens(ctx context.Context) []lang.SemanticToken {
-	switch e := a.expr.(type) {
-	// TODO! Support LiteralType
-	// TODO! Support References
-	case *hclsyntax.FunctionCallExpr:
-		_, ok := a.pathCtx.Functions[e.Name]
-		if ok {
-			// TODO! check for name range
-			// TODO! loop over arguments, do SemanticTokens for that argument using the constraint
-			// TODO? if we introduce a new token type, we need to add it in the extension's package.json and docs
-			return []lang.SemanticToken{
-				{
-					Type:      lang.TokenAttrName,
-					Modifiers: []lang.SemanticTokenModifier{},
-					// Range:     eType.Range(),
-				},
-			}
+	typ := a.cons.OfType
+
+	if typ.IsListType() {
+		expr, ok := a.expr.(*hclsyntax.TupleConsExpr)
+		if !ok {
+			return []lang.SemanticToken{}
 		}
+
+		cons := schema.List{
+			Elem: schema.AnyExpression{
+				OfType: typ.ElementType(),
+			},
+		}
+
+		return newExpression(a.pathCtx, expr, cons).SemanticTokens(ctx)
 	}
 
-	return nil
+	if typ.IsSetType() {
+		expr, ok := a.expr.(*hclsyntax.TupleConsExpr)
+		if !ok {
+			return []lang.SemanticToken{}
+		}
+
+		cons := schema.Set{
+			Elem: schema.AnyExpression{
+				OfType: typ.ElementType(),
+			},
+		}
+
+		return newExpression(a.pathCtx, expr, cons).SemanticTokens(ctx)
+	}
+
+	if typ.IsTupleType() {
+		expr, ok := a.expr.(*hclsyntax.TupleConsExpr)
+		if !ok {
+			return []lang.SemanticToken{}
+		}
+
+		elemTypes := typ.TupleElementTypes()
+		cons := schema.Tuple{
+			Elems: make([]schema.Constraint, len(elemTypes)),
+		}
+		for i, elemType := range elemTypes {
+			cons.Elems[i] = schema.AnyExpression{
+				OfType: elemType,
+			}
+		}
+
+		return newExpression(a.pathCtx, expr, cons).SemanticTokens(ctx)
+	}
+
+	if typ.IsMapType() {
+		expr, ok := a.expr.(*hclsyntax.ObjectConsExpr)
+		if !ok {
+			return []lang.SemanticToken{}
+		}
+
+		cons := schema.Map{
+			Elem: schema.AnyExpression{
+				OfType: typ.ElementType(),
+			},
+		}
+		return newExpression(a.pathCtx, expr, cons).SemanticTokens(ctx)
+	}
+
+	if typ.IsObjectType() {
+		expr, ok := a.expr.(*hclsyntax.ObjectConsExpr)
+		if !ok {
+			return []lang.SemanticToken{}
+		}
+
+		cons := schema.Object{
+			Attributes: ctyObjectToObjectAttributes(typ),
+		}
+		return newExpression(a.pathCtx, expr, cons).SemanticTokens(ctx)
+	}
+
+	return a.semanticTokensForNonComplexExpr(ctx)
+}
+
+func (a Any) semanticTokensForNonComplexExpr(ctx context.Context) []lang.SemanticToken {
+	// TODO: Support TemplateExpr https://github.com/hashicorp/terraform-ls/issues/522
+	// TODO: Support splat expression https://github.com/hashicorp/terraform-ls/issues/526
+	// TODO: Support for-in-if expression https://github.com/hashicorp/terraform-ls/issues/527
+	// TODO: Support conditional expression https://github.com/hashicorp/terraform-ls/issues/528
+	// TODO: Support operator expresssions https://github.com/hashicorp/terraform-ls/issues/529
+	// TODO: Support complex index expressions https://github.com/hashicorp/terraform-ls/issues/531
+	// TODO: Support relative traversals https://github.com/hashicorp/terraform-ls/issues/532
+
+	ref := Reference{
+		expr:    a.expr,
+		cons:    schema.Reference{OfType: a.cons.OfType},
+		pathCtx: a.pathCtx,
+	}
+	tokens := ref.SemanticTokens(ctx)
+	if tokens != nil {
+		return tokens
+	}
+
+	fe := functionExpr{
+		expr:       a.expr,
+		returnType: a.cons.OfType,
+		pathCtx:    a.pathCtx,
+	}
+	tokens = fe.SemanticTokens(ctx)
+	if tokens != nil {
+		return tokens
+	}
+
+	lt := LiteralType{
+		expr:    a.expr,
+		cons:    schema.LiteralType{Type: a.cons.OfType},
+		pathCtx: a.pathCtx,
+	}
+	return lt.SemanticTokens(ctx)
 }

--- a/decoder/expr_any_semtok.go
+++ b/decoder/expr_any_semtok.go
@@ -1,0 +1,31 @@
+package decoder
+
+import (
+	"context"
+
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+func (a Any) SemanticTokens(ctx context.Context) []lang.SemanticToken {
+	switch e := a.expr.(type) {
+	// TODO! Support LiteralType
+	// TODO! Support References
+	case *hclsyntax.FunctionCallExpr:
+		_, ok := a.pathCtx.Functions[e.Name]
+		if ok {
+			// TODO! check for name range
+			// TODO! loop over arguments, do SemanticTokens for that argument using the constraint
+			// TODO? if we introduce a new token type, we need to add it in the extension's package.json and docs
+			return []lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: []lang.SemanticTokenModifier{},
+					// Range:     eType.Range(),
+				},
+			}
+		}
+	}
+
+	return nil
+}

--- a/decoder/expr_any_semtok.go
+++ b/decoder/expr_any_semtok.go
@@ -14,7 +14,7 @@ func (a Any) SemanticTokens(ctx context.Context) []lang.SemanticToken {
 	if typ.IsListType() {
 		expr, ok := a.expr.(*hclsyntax.TupleConsExpr)
 		if !ok {
-			return []lang.SemanticToken{}
+			return a.semanticTokensForNonComplexExpr(ctx)
 		}
 
 		cons := schema.List{
@@ -29,7 +29,7 @@ func (a Any) SemanticTokens(ctx context.Context) []lang.SemanticToken {
 	if typ.IsSetType() {
 		expr, ok := a.expr.(*hclsyntax.TupleConsExpr)
 		if !ok {
-			return []lang.SemanticToken{}
+			return a.semanticTokensForNonComplexExpr(ctx)
 		}
 
 		cons := schema.Set{
@@ -44,7 +44,7 @@ func (a Any) SemanticTokens(ctx context.Context) []lang.SemanticToken {
 	if typ.IsTupleType() {
 		expr, ok := a.expr.(*hclsyntax.TupleConsExpr)
 		if !ok {
-			return []lang.SemanticToken{}
+			return a.semanticTokensForNonComplexExpr(ctx)
 		}
 
 		elemTypes := typ.TupleElementTypes()
@@ -63,7 +63,7 @@ func (a Any) SemanticTokens(ctx context.Context) []lang.SemanticToken {
 	if typ.IsMapType() {
 		expr, ok := a.expr.(*hclsyntax.ObjectConsExpr)
 		if !ok {
-			return []lang.SemanticToken{}
+			return a.semanticTokensForNonComplexExpr(ctx)
 		}
 
 		cons := schema.Map{
@@ -77,7 +77,7 @@ func (a Any) SemanticTokens(ctx context.Context) []lang.SemanticToken {
 	if typ.IsObjectType() {
 		expr, ok := a.expr.(*hclsyntax.ObjectConsExpr)
 		if !ok {
-			return []lang.SemanticToken{}
+			return a.semanticTokensForNonComplexExpr(ctx)
 		}
 
 		cons := schema.Object{
@@ -104,7 +104,7 @@ func (a Any) semanticTokensForNonComplexExpr(ctx context.Context) []lang.Semanti
 		pathCtx: a.pathCtx,
 	}
 	tokens := ref.SemanticTokens(ctx)
-	if tokens != nil {
+	if len(tokens) > 0 {
 		return tokens
 	}
 
@@ -114,7 +114,7 @@ func (a Any) semanticTokensForNonComplexExpr(ctx context.Context) []lang.Semanti
 		pathCtx:    a.pathCtx,
 	}
 	tokens = fe.SemanticTokens(ctx)
-	if tokens != nil {
+	if len(tokens) > 0 {
 		return tokens
 	}
 

--- a/decoder/expr_any_semtok_test.go
+++ b/decoder/expr_any_semtok_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/reference"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -222,6 +223,2269 @@ func TestSemanticTokens_exprAny_functions(t *testing.T) {
 					"test.tf": f,
 				},
 				Functions: testFunctionSignatures(),
+			})
+
+			ctx := context.Background()
+			tokens, err := d.SemanticTokensInFile(ctx, "test.tf")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedSemanticTokens, tokens); diff != "" {
+				t.Fatalf("unexpected tokens: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSemanticTokens_exprAny_literalTypes(t *testing.T) {
+	testCases := []struct {
+		testName               string
+		attrSchema             map[string]*schema.AttributeSchema
+		cfg                    string
+		expectedSemanticTokens []lang.SemanticToken
+	}{
+		{
+			"any type",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.DynamicPseudoType,
+					},
+				},
+			},
+			`attr = "foobar"`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+					},
+				},
+			},
+		},
+
+		// bool
+		{
+			"boolean",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Bool,
+					},
+				},
+			},
+			`attr = false`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenBool,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						End:      hcl.Pos{Line: 1, Column: 13, Byte: 12},
+					},
+				},
+			},
+		},
+
+		// string
+		{
+			"single-line string",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			`attr = "foobar"`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+					},
+				},
+			},
+		},
+		{
+			"multi-line string",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			`attr = <<TEXT
+foo
+bar
+TEXT
+`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						End:      hcl.Pos{Line: 4, Column: 5, Byte: 26},
+					},
+				},
+			},
+		},
+
+		// number
+		{
+			"number whole",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Number,
+					},
+				},
+			},
+			`attr = 4223`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenNumber,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						End:      hcl.Pos{Line: 1, Column: 12, Byte: 11},
+					},
+				},
+			},
+		},
+		{
+			"number fractional",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Number,
+					},
+				},
+			},
+			`attr = 4.222`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenNumber,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						End:      hcl.Pos{Line: 1, Column: 13, Byte: 12},
+					},
+				},
+			},
+		},
+
+		// list
+		{
+			"empty list with any element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.List(cty.DynamicPseudoType),
+					},
+				},
+			},
+			`attr = []`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+			},
+		},
+		{
+			"empty list with element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.List(cty.String),
+					},
+				},
+			},
+			`attr = []`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+			},
+		},
+		{
+			"single element list",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.List(cty.String),
+					},
+				},
+			},
+			`attr = ["foobar"]`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						End:      hcl.Pos{Line: 1, Column: 17, Byte: 16},
+					},
+				},
+			},
+		},
+		{
+			"single element multi-line list",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.List(cty.String),
+					},
+				},
+			},
+			`attr = [
+  "foobar",
+]`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						End:      hcl.Pos{Line: 2, Column: 11, Byte: 19},
+					},
+				},
+			},
+		},
+		{
+			"multi-element multi-line list",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.List(cty.String),
+					},
+				},
+			},
+			`attr = [
+  "foobar",
+  "barfoo",
+]`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						End:      hcl.Pos{Line: 2, Column: 11, Byte: 19},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 3, Column: 3, Byte: 23},
+						End:      hcl.Pos{Line: 3, Column: 11, Byte: 31},
+					},
+				},
+			},
+		},
+		{
+			"multi-element multi-line list with invalid element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.List(cty.String),
+					},
+				},
+			},
+			`attr = [
+  "fooba",
+  invalid,
+  "fooba",
+]`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						End:      hcl.Pos{Line: 2, Column: 10, Byte: 18},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 4, Column: 3, Byte: 33},
+						End:      hcl.Pos{Line: 4, Column: 10, Byte: 40},
+					},
+				},
+			},
+		},
+
+		// set
+		{
+			"empty set with any element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Set(cty.DynamicPseudoType),
+					},
+				},
+			},
+			`attr = []`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+			},
+		},
+		{
+			"empty set with element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Set(cty.String),
+					},
+				},
+			},
+			`attr = []`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+			},
+		},
+		{
+			"single element set",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Set(cty.String),
+					},
+				},
+			},
+			`attr = ["fooba"]`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+					},
+				},
+			},
+		},
+		{
+			"single element multi-line set",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Set(cty.String),
+					},
+				},
+			},
+			`attr = [
+  "fooba",
+]`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						End:      hcl.Pos{Line: 2, Column: 10, Byte: 18},
+					},
+				},
+			},
+		},
+		{
+			"multi-element multi-line set",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Set(cty.String),
+					},
+				},
+			},
+			`attr = [
+  "fooba",
+  "fooba",
+]`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						End:      hcl.Pos{Line: 2, Column: 10, Byte: 18},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 3, Column: 3, Byte: 22},
+						End:      hcl.Pos{Line: 3, Column: 10, Byte: 29},
+					},
+				},
+			},
+		},
+		{
+			"multi-element multi-line set with invalid element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Set(cty.String),
+					},
+				},
+			},
+			`attr = [
+  "fooba",
+  invalid,
+  "fooba",
+]`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						End:      hcl.Pos{Line: 2, Column: 10, Byte: 18},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 4, Column: 3, Byte: 33},
+						End:      hcl.Pos{Line: 4, Column: 10, Byte: 40},
+					},
+				},
+			},
+		},
+
+		// tuple
+		{
+			"empty tuple without element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Tuple([]cty.Type{}),
+					},
+				},
+			},
+			`attr = []`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+			},
+		},
+		{
+			"empty tuple with element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Tuple([]cty.Type{
+							cty.String,
+						}),
+					},
+				},
+			},
+			`attr = []`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+			},
+		},
+		{
+			"single element tuple",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Tuple([]cty.Type{
+							cty.String,
+						}),
+					},
+				},
+			},
+			`attr = ["fooba"]`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+					},
+				},
+			},
+		},
+		{
+			"single element multi-line tuple",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Tuple([]cty.Type{
+							cty.String,
+						}),
+					},
+				},
+			},
+			`attr = [
+  "fooba",
+]`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						End:      hcl.Pos{Line: 2, Column: 10, Byte: 18},
+					},
+				},
+			},
+		},
+		{
+			"multi-element multi-line tuple",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Tuple([]cty.Type{
+							cty.String,
+							cty.Number,
+						}),
+					},
+				},
+			},
+			`attr = [
+  "fooba",
+  1234567,
+]`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						End:      hcl.Pos{Line: 2, Column: 10, Byte: 18},
+					},
+				},
+				{
+					Type:      lang.TokenNumber,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 3, Column: 3, Byte: 22},
+						End:      hcl.Pos{Line: 3, Column: 10, Byte: 29},
+					},
+				},
+			},
+		},
+		{
+			"multi-element multi-line tuple with invalid element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Tuple([]cty.Type{
+							cty.String,
+							cty.String,
+							cty.Number,
+						}),
+					},
+				},
+			},
+			`attr = [
+  "fooba",
+  invalid,
+  1234567,
+]`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						End:      hcl.Pos{Line: 2, Column: 10, Byte: 18},
+					},
+				},
+				{
+					Type:      lang.TokenNumber,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 4, Column: 3, Byte: 33},
+						End:      hcl.Pos{Line: 4, Column: 10, Byte: 40},
+					},
+				},
+			},
+		},
+
+		// map
+		{
+			"any element constraint",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Map(cty.DynamicPseudoType),
+					},
+				},
+			},
+			`attr = {}`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+			},
+		},
+		{
+			"single-line with mismatching expression",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Map(cty.String),
+					},
+				},
+			},
+			`attr = [ foobar ]`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+			},
+		},
+		{
+			"single-line with mismatching key type",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Map(cty.String),
+					},
+				},
+			},
+			`attr = { 422 = foobar }`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+			},
+		},
+		{
+			"single-line with valid item",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Map(cty.String),
+					},
+				},
+			},
+			`attr = { foo = "noot" }`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenMapKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+						End:      hcl.Pos{Line: 1, Column: 13, Byte: 12},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 16, Byte: 15},
+						End:      hcl.Pos{Line: 1, Column: 22, Byte: 21},
+					},
+				},
+			},
+		},
+		{
+			"single-line with valid multiple items",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Map(cty.String),
+					},
+				},
+			},
+			`attr = { foo = "noot", bar = "noot" }`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenMapKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+						End:      hcl.Pos{Line: 1, Column: 13, Byte: 12},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 16, Byte: 15},
+						End:      hcl.Pos{Line: 1, Column: 22, Byte: 21},
+					},
+				},
+				{
+					Type:      lang.TokenMapKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 24, Byte: 23},
+						End:      hcl.Pos{Line: 1, Column: 27, Byte: 26},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 30, Byte: 29},
+						End:      hcl.Pos{Line: 1, Column: 36, Byte: 35},
+					},
+				},
+			},
+		},
+		{
+			"single-line with valid multiple items with quoted keys",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Map(cty.String),
+					},
+				},
+			},
+			`attr = { "foo" = "noot", "bar" = "noot" }`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenMapKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+						End:      hcl.Pos{Line: 1, Column: 15, Byte: 14},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 18, Byte: 17},
+						End:      hcl.Pos{Line: 1, Column: 24, Byte: 23},
+					},
+				},
+				{
+					Type:      lang.TokenMapKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 26, Byte: 25},
+						End:      hcl.Pos{Line: 1, Column: 31, Byte: 30},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 34, Byte: 33},
+						End:      hcl.Pos{Line: 1, Column: 40, Byte: 39},
+					},
+				},
+			},
+		},
+		{
+			"single-line with multiple items and one mismatch",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Map(cty.String),
+					},
+				},
+			},
+			`attr = { foo = bar, bar = "noot" }`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenMapKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+						End:      hcl.Pos{Line: 1, Column: 13, Byte: 12},
+					},
+				},
+				{
+					Type:      lang.TokenMapKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 21, Byte: 20},
+						End:      hcl.Pos{Line: 1, Column: 24, Byte: 23},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 27, Byte: 26},
+						End:      hcl.Pos{Line: 1, Column: 33, Byte: 32},
+					},
+				},
+			},
+		},
+		{
+			"multi-line with valid item",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Map(cty.String),
+					},
+				},
+			},
+			`attr = {
+  foo = "noot"
+}`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenMapKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						End:      hcl.Pos{Line: 2, Column: 6, Byte: 14},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 9, Byte: 17},
+						End:      hcl.Pos{Line: 2, Column: 15, Byte: 23},
+					},
+				},
+			},
+		},
+		{
+			"multi-line with valid multiple items",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Map(cty.String),
+					},
+				},
+			},
+			`attr = {
+  foo = "noot"
+  bar = "toot"
+}`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenMapKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						End:      hcl.Pos{Line: 2, Column: 6, Byte: 14},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 9, Byte: 17},
+						End:      hcl.Pos{Line: 2, Column: 15, Byte: 23},
+					},
+				},
+				{
+					Type:      lang.TokenMapKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 3, Column: 3, Byte: 26},
+						End:      hcl.Pos{Line: 3, Column: 6, Byte: 29},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 3, Column: 9, Byte: 32},
+						End:      hcl.Pos{Line: 3, Column: 15, Byte: 38},
+					},
+				},
+			},
+		},
+		{
+			"multi-line with multiple items and one mismatch",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Map(cty.String),
+					},
+				},
+			},
+			`attr = {
+  foo = bar
+  bar = "noot"
+}`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenMapKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						End:      hcl.Pos{Line: 2, Column: 6, Byte: 14},
+					},
+				},
+				{
+					Type:      lang.TokenMapKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 3, Column: 3, Byte: 23},
+						End:      hcl.Pos{Line: 3, Column: 6, Byte: 26},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 3, Column: 9, Byte: 29},
+						End:      hcl.Pos{Line: 3, Column: 15, Byte: 35},
+					},
+				},
+			},
+		},
+
+		// object
+		{
+			"undefined attributes",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Object(map[string]cty.Type{}),
+					},
+				},
+			},
+			`attr = {}`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+			},
+		},
+		{
+			"single-line with mismatching expression",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Object(map[string]cty.Type{
+							"foo": cty.String,
+						}),
+					},
+				},
+			},
+			`attr = [ foobar ]`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+			},
+		},
+		{
+			"single-line with mismatching key type",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Object(map[string]cty.Type{
+							"foo": cty.String,
+						}),
+					},
+				},
+			},
+			`attr = { 422 = "noot" }`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+			},
+		},
+		{
+			"single-line with valid item",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Object(map[string]cty.Type{
+							"foo": cty.String,
+						}),
+					},
+				},
+			},
+			`attr = { foo = "noot" }`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenObjectKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+						End:      hcl.Pos{Line: 1, Column: 13, Byte: 12},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 16, Byte: 15},
+						End:      hcl.Pos{Line: 1, Column: 22, Byte: 21},
+					},
+				},
+			},
+		},
+		{
+			"single-line with valid multiple items",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Object(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.String,
+						}),
+					},
+				},
+			},
+			`attr = { foo = "noot", bar = "toot" }`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenObjectKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+						End:      hcl.Pos{Line: 1, Column: 13, Byte: 12},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 16, Byte: 15},
+						End:      hcl.Pos{Line: 1, Column: 22, Byte: 21},
+					},
+				},
+				{
+					Type:      lang.TokenObjectKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 24, Byte: 23},
+						End:      hcl.Pos{Line: 1, Column: 27, Byte: 26},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 30, Byte: 29},
+						End:      hcl.Pos{Line: 1, Column: 36, Byte: 35},
+					},
+				},
+			},
+		},
+		{
+			"single-line with valid multiple items with valid quoted attributes",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Object(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.String,
+						}),
+					},
+				},
+			},
+			`attr = { "foo" = "noot", "bar" = "toot" }`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenObjectKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+						End:      hcl.Pos{Line: 1, Column: 15, Byte: 14},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 18, Byte: 17},
+						End:      hcl.Pos{Line: 1, Column: 24, Byte: 23},
+					},
+				},
+				{
+					Type:      lang.TokenObjectKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 26, Byte: 25},
+						End:      hcl.Pos{Line: 1, Column: 31, Byte: 30},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 34, Byte: 33},
+						End:      hcl.Pos{Line: 1, Column: 40, Byte: 39},
+					},
+				},
+			},
+		},
+		{
+			"single-line with multiple items with invalid quoted attribute",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Object(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.String,
+						}),
+					},
+				},
+			},
+			`attr = { "foo" = "noot", "baz" = "noot" }`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenObjectKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+						End:      hcl.Pos{Line: 1, Column: 15, Byte: 14},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 18, Byte: 17},
+						End:      hcl.Pos{Line: 1, Column: 24, Byte: 23},
+					},
+				},
+			},
+		},
+		{
+			"single-line with multiple items and one value mismatch",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Object(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.String,
+						}),
+					},
+				},
+			},
+			`attr = { foo = bar, bar = "noot" }`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenObjectKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+						End:      hcl.Pos{Line: 1, Column: 13, Byte: 12},
+					},
+				},
+				{
+					Type:      lang.TokenObjectKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 21, Byte: 20},
+						End:      hcl.Pos{Line: 1, Column: 24, Byte: 23},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 27, Byte: 26},
+						End:      hcl.Pos{Line: 1, Column: 33, Byte: 32},
+					},
+				},
+			},
+		},
+		{
+			"multi-line with valid item",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Object(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.String,
+						}),
+					},
+				},
+			},
+			`attr = {
+  foo = "noot"
+}`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenObjectKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						End:      hcl.Pos{Line: 2, Column: 6, Byte: 14},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 9, Byte: 17},
+						End:      hcl.Pos{Line: 2, Column: 15, Byte: 23},
+					},
+				},
+			},
+		},
+		{
+			"multi-line with valid multiple items",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Object(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.String,
+						}),
+					},
+				},
+			},
+			`attr = {
+  foo = "noot"
+  bar = "toot"
+}`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenObjectKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						End:      hcl.Pos{Line: 2, Column: 6, Byte: 14},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 9, Byte: 17},
+						End:      hcl.Pos{Line: 2, Column: 15, Byte: 23},
+					},
+				},
+				{
+					Type:      lang.TokenObjectKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 3, Column: 3, Byte: 26},
+						End:      hcl.Pos{Line: 3, Column: 6, Byte: 29},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 3, Column: 9, Byte: 32},
+						End:      hcl.Pos{Line: 3, Column: 15, Byte: 38},
+					},
+				},
+			},
+		},
+		{
+			"multi-line with multiple items and one value mismatch",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Object(map[string]cty.Type{
+							"foo": cty.Number,
+							"bar": cty.String,
+						}),
+					},
+				},
+			},
+			`attr = {
+  foo = bar
+  bar = "noot"
+}`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenObjectKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						End:      hcl.Pos{Line: 2, Column: 6, Byte: 14},
+					},
+				},
+				{
+					Type:      lang.TokenObjectKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 3, Column: 3, Byte: 23},
+						End:      hcl.Pos{Line: 3, Column: 6, Byte: 26},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 3, Column: 9, Byte: 29},
+						End:      hcl.Pos{Line: 3, Column: 15, Byte: 35},
+					},
+				},
+			},
+		},
+		{
+			"multi-line with multiple items and one attribute mismatch",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Object(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.String,
+						}),
+					},
+				},
+			},
+			`attr = {
+  foo = "x"
+  baz = "x"
+}`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenObjectKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						End:      hcl.Pos{Line: 2, Column: 6, Byte: 14},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 9, Byte: 17},
+						End:      hcl.Pos{Line: 2, Column: 12, Byte: 20},
+					},
+				},
+			},
+		},
+		{
+			"multi-line with nested object",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Object(map[string]cty.Type{
+							"foo": cty.Object(map[string]cty.Type{
+								"noot": cty.String,
+							}),
+							"bar": cty.String,
+						}),
+					},
+				},
+			},
+			`attr = {
+  foo = {
+    noot = "to"
+  }
+  bar = "noot"
+}`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenObjectKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+						End:      hcl.Pos{Line: 2, Column: 6, Byte: 14},
+					},
+				},
+				{
+					Type:      lang.TokenObjectKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 3, Column: 5, Byte: 23},
+						End:      hcl.Pos{Line: 3, Column: 9, Byte: 27},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 3, Column: 12, Byte: 30},
+						End:      hcl.Pos{Line: 3, Column: 16, Byte: 34},
+					},
+				},
+				{
+					Type:      lang.TokenObjectKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 5, Column: 3, Byte: 41},
+						End:      hcl.Pos{Line: 5, Column: 6, Byte: 44},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 5, Column: 9, Byte: 47},
+						End:      hcl.Pos{Line: 5, Column: 15, Byte: 53},
+					},
+				},
+			},
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%2d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := &schema.BodySchema{
+				Attributes: tc.attrSchema,
+			}
+
+			f, _ := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.tf": f,
+				},
+			})
+
+			ctx := context.Background()
+			tokens, err := d.SemanticTokensInFile(ctx, "test.tf")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedSemanticTokens, tokens); diff != "" {
+				t.Fatalf("unexpected tokens: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSemanticTokens_exprAny_references(t *testing.T) {
+	testCases := []struct {
+		testName               string
+		attrSchema             map[string]*schema.AttributeSchema
+		refOrigins             reference.Origins
+		refTargets             reference.Targets
+		cfg                    string
+		expectedSemanticTokens []lang.SemanticToken
+	}{
+		{
+			"unknown origin",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			reference.Origins{
+				reference.LocalOrigin{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "foo"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 13, Byte: 12},
+						End:      hcl.Pos{Line: 1, Column: 17, Byte: 16},
+					},
+					Constraints: reference.OriginConstraints{
+						{
+							OfType: cty.String,
+						},
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "foo"},
+					},
+					Type: cty.String,
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 17},
+						End:      hcl.Pos{Line: 2, Column: 13, Byte: 29},
+					},
+				},
+			},
+			`attr = local.foox
+foo = "noot"
+`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+			},
+		},
+		{
+			"matching origin with no target",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			reference.Origins{
+				reference.LocalOrigin{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "foo"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						End:      hcl.Pos{Line: 1, Column: 17, Byte: 16},
+					},
+					Constraints: reference.OriginConstraints{
+						{
+							OfType: cty.String,
+						},
+					},
+				},
+			},
+			reference.Targets{},
+			`attr = local.foo
+foo = "noot"
+`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+			},
+		},
+		{
+			"matching origin and target",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			reference.Origins{
+				reference.LocalOrigin{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "foo"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						End:      hcl.Pos{Line: 1, Column: 17, Byte: 16},
+					},
+					Constraints: reference.OriginConstraints{
+						{
+							OfType: cty.String,
+						},
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "foo"},
+					},
+					Type: cty.String,
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 17},
+						End:      hcl.Pos{Line: 2, Column: 13, Byte: 29},
+					},
+				},
+			},
+			`attr = local.foo
+foo = "noot"
+`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenTraversalStep,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						End:      hcl.Pos{Line: 1, Column: 13, Byte: 12},
+					},
+				},
+				{
+					Type:      lang.TokenTraversalStep,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 14, Byte: 13},
+						End:      hcl.Pos{Line: 1, Column: 17, Byte: 16},
+					},
+				},
+			},
+		},
+		{
+			"matching reference with numerical index",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			reference.Origins{
+				reference.LocalOrigin{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "foo"},
+						lang.IndexStep{Key: cty.NumberIntVal(42)},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						End:      hcl.Pos{Line: 1, Column: 21, Byte: 20},
+					},
+					Constraints: reference.OriginConstraints{
+						{
+							OfType: cty.String,
+						},
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "foo"},
+						lang.IndexStep{Key: cty.NumberIntVal(42)},
+					},
+					Type: cty.String,
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 21},
+						End:      hcl.Pos{Line: 2, Column: 13, Byte: 33},
+					},
+				},
+			},
+			`attr = local.foo[42]
+foo = "noot"
+`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenTraversalStep,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						End:      hcl.Pos{Line: 1, Column: 13, Byte: 12},
+					},
+				},
+				{
+					Type:      lang.TokenTraversalStep,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 14, Byte: 13},
+						End:      hcl.Pos{Line: 1, Column: 17, Byte: 16},
+					},
+				},
+				{
+					Type:      lang.TokenNumber,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 18, Byte: 17},
+						End:      hcl.Pos{Line: 1, Column: 20, Byte: 19},
+					},
+				},
+			},
+		},
+		{
+			"matching reference with string index",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			reference.Origins{
+				reference.LocalOrigin{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "foo"},
+						lang.IndexStep{Key: cty.StringVal("bar")},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						End:      hcl.Pos{Line: 1, Column: 24, Byte: 23},
+					},
+					Constraints: reference.OriginConstraints{
+						{
+							OfType: cty.String,
+						},
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "foo"},
+						lang.IndexStep{Key: cty.StringVal("bar")},
+					},
+					Type: cty.String,
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 24},
+						End:      hcl.Pos{Line: 2, Column: 13, Byte: 36},
+					},
+				},
+			},
+			`attr = local.foo["bar"]
+foo = "noot"
+`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenTraversalStep,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						End:      hcl.Pos{Line: 1, Column: 13, Byte: 12},
+					},
+				},
+				{
+					Type:      lang.TokenTraversalStep,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 14, Byte: 13},
+						End:      hcl.Pos{Line: 1, Column: 17, Byte: 16},
+					},
+				},
+				{
+					Type:      lang.TokenMapKey,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 18, Byte: 17},
+						End:      hcl.Pos{Line: 1, Column: 23, Byte: 22},
+					},
+				},
+			},
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := &schema.BodySchema{
+				Attributes: tc.attrSchema,
+			}
+
+			f, _ := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.tf": f,
+				},
+				ReferenceOrigins: tc.refOrigins,
+				ReferenceTargets: tc.refTargets,
 			})
 
 			ctx := context.Background()

--- a/decoder/expr_any_semtok_test.go
+++ b/decoder/expr_any_semtok_test.go
@@ -175,6 +175,38 @@ func TestSemanticTokens_exprAny_functions(t *testing.T) {
 				},
 			},
 		},
+		{
+			"function with too mismatching arguments",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			`attr = lower(["FOO"])
+`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenFunctionName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						End:      hcl.Pos{Line: 1, Column: 13, Byte: 12},
+					},
+				},
+			},
+		},
 	}
 
 	for i, tc := range testCases {

--- a/decoder/expr_any_semtok_test.go
+++ b/decoder/expr_any_semtok_test.go
@@ -1,0 +1,206 @@
+package decoder
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestSemanticTokens_exprAny_functions(t *testing.T) {
+	testCases := []struct {
+		testName               string
+		attrSchema             map[string]*schema.AttributeSchema
+		cfg                    string
+		expectedSemanticTokens []lang.SemanticToken
+	}{
+		{
+			"unknown function",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			`attr = unknown()
+`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+			},
+		},
+		{
+			"function without arguments",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			`attr = lower()
+`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenFunctionName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						End:      hcl.Pos{Line: 1, Column: 13, Byte: 12},
+					},
+				},
+			},
+		},
+		{
+			"function with arguments",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			`attr = join(",", ["a", "b"])
+`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenFunctionName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						End:      hcl.Pos{Line: 1, Column: 12, Byte: 11},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 13, Byte: 12},
+						End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 19, Byte: 18},
+						End:      hcl.Pos{Line: 1, Column: 22, Byte: 21},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 24, Byte: 23},
+						End:      hcl.Pos{Line: 1, Column: 27, Byte: 26},
+					},
+				},
+			},
+		},
+		{
+			"function with too many arguments",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			`attr = lower("FOO", "BAR")
+`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenFunctionName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						End:      hcl.Pos{Line: 1, Column: 13, Byte: 12},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 14, Byte: 13},
+						End:      hcl.Pos{Line: 1, Column: 19, Byte: 18},
+					},
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%2d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := &schema.BodySchema{
+				Attributes: tc.attrSchema,
+			}
+
+			f, _ := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.tf": f,
+				},
+				Functions: testFunctionSignatures(),
+			})
+
+			ctx := context.Background()
+			tokens, err := d.SemanticTokensInFile(ctx, "test.tf")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedSemanticTokens, tokens); diff != "" {
+				t.Fatalf("unexpected tokens: %s", diff)
+			}
+		})
+	}
+}

--- a/decoder/expr_function.go
+++ b/decoder/expr_function.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
 	"github.com/zclconf/go-cty/cty/function"
 )
 
@@ -264,8 +265,8 @@ func (fe functionExpr) matchingFunctions(prefix string, editRange hcl.Range) []l
 		if !strings.HasPrefix(name, prefix) {
 			continue
 		}
-		// Only suggest functions that have a matching return type
-		if fe.returnType.TestConformance(f.ReturnType) != nil {
+		// Reject functions that have a non-convertible return type
+		if _, err := convert.Convert(cty.UnknownVal(f.ReturnType), fe.returnType); err != nil {
 			continue
 		}
 

--- a/decoder/expr_function.go
+++ b/decoder/expr_function.go
@@ -148,7 +148,6 @@ func (fe functionExpr) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverD
 
 	if funcExpr.NameRange.ContainsPos(pos) {
 		return &lang.HoverData{
-			// TODO? add link to docs
 			Content: lang.Markdown(fmt.Sprintf("```terraform\n%s(%s) %s\n```\n\n%s",
 				funcExpr.Name, parameterNamesAsString(funcSig), funcSig.ReturnType.FriendlyName(), funcSig.Description)),
 			Range: fe.expr.Range(),
@@ -248,7 +247,6 @@ func (fe functionExpr) ReferenceOrigins(ctx context.Context, allowSelfRefs bool)
 			param = *funcSig.VarParam
 		} else {
 			// Too many arguments passed to the function
-			// TODO: report as 'any' constraint?
 			break
 		}
 
@@ -277,7 +275,6 @@ func (fe functionExpr) matchingFunctions(prefix string, editRange hcl.Range) []l
 			continue
 		}
 
-		// TODO? see why accepting a completion isn't triggering signatureHelp (it does for gopls)
 		candidates = append(candidates, lang.Candidate{
 			Label:       name,
 			Detail:      fmt.Sprintf("%s(%s) %s", name, parameterNamesAsString(f), f.ReturnType.FriendlyName()),

--- a/decoder/expr_function.go
+++ b/decoder/expr_function.go
@@ -37,6 +37,7 @@ func (fe functionExpr) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.
 	switch eType := fe.expr.(type) {
 	case *hclsyntax.ScopeTraversalExpr:
 		if len(eType.Traversal) > 1 {
+			// We assume that function names cannot contain dots
 			return []lang.Candidate{}
 		}
 		prefixLen := pos.Byte - eType.Traversal.SourceRange().Start.Byte

--- a/decoder/expr_function.go
+++ b/decoder/expr_function.go
@@ -186,9 +186,7 @@ func (fe functionExpr) SemanticTokens(ctx context.Context) []lang.SemanticToken 
 	tokens := make([]lang.SemanticToken, 0)
 
 	tokens = append(tokens, lang.SemanticToken{
-		// TODO? if we introduce a new token type, we need to add it in the extension's package.json and docs
-		// Type:      lang.TokenFuncCall,
-		Type:      lang.TokenAttrName,
+		Type:      lang.TokenFunctionName,
 		Modifiers: []lang.SemanticTokenModifier{},
 		Range:     funcExpr.NameRange,
 	})

--- a/decoder/expr_function.go
+++ b/decoder/expr_function.go
@@ -40,9 +40,17 @@ func (fe functionExpr) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.
 			// We assume that function names cannot contain dots
 			return []lang.Candidate{}
 		}
-		prefixLen := pos.Byte - eType.Traversal.SourceRange().Start.Byte
-		prefix := eType.Traversal.RootName()[0:prefixLen]
 
+		prefixLen := pos.Byte - eType.Traversal.SourceRange().Start.Byte
+		rootName := eType.Traversal.RootName()
+
+		// There can be a single segment with trailing dot which cannot
+		// be a function anymore as functions cannot contain dots.
+		if prefixLen > len(rootName) {
+			return []lang.Candidate{}
+		}
+
+		prefix := rootName[0:prefixLen]
 		return fe.matchingFunctions(prefix, eType.Range())
 	case *hclsyntax.FunctionCallExpr:
 		if eType.NameRange.ContainsPos(pos) {

--- a/decoder/expr_function.go
+++ b/decoder/expr_function.go
@@ -1,0 +1,285 @@
+package decoder
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/reference"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+)
+
+type functionExpr struct {
+	expr       hcl.Expression
+	returnType cty.Type
+	pathCtx    *PathContext
+}
+
+func (fe functionExpr) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate {
+	if isEmptyExpression(fe.expr) {
+		editRange := hcl.Range{
+			Filename: fe.expr.Range().Filename,
+			Start:    pos,
+			End:      pos,
+		}
+
+		return fe.matchingFunctions("", editRange)
+	}
+
+	switch eType := fe.expr.(type) {
+	case *hclsyntax.ScopeTraversalExpr:
+		if len(eType.Traversal) > 1 {
+			return []lang.Candidate{}
+		}
+		prefixLen := pos.Byte - eType.Traversal.SourceRange().Start.Byte
+		prefix := eType.Traversal.RootName()[0:prefixLen]
+
+		return fe.matchingFunctions(prefix, eType.Range())
+	case *hclsyntax.FunctionCallExpr:
+		if eType.NameRange.ContainsPos(pos) {
+			prefixLen := pos.Byte - eType.NameRange.Start.Byte
+			prefix := eType.Name[0:prefixLen]
+			editRange := eType.Range()
+			return fe.matchingFunctions(prefix, editRange)
+		}
+
+		f, ok := fe.pathCtx.Functions[eType.Name]
+		if !ok {
+			return []lang.Candidate{} // Unknown function
+		}
+
+		parensRange := hcl.RangeBetween(eType.OpenParenRange, eType.CloseParenRange)
+		if !parensRange.ContainsPos(pos) {
+			return []lang.Candidate{} // Not inside parenthesis
+		}
+
+		paramsLen := len(f.Params)
+		if paramsLen == 0 && f.VarParam == nil {
+			return []lang.Candidate{} // Function accepts no parameters
+		}
+
+		lastArgEndPos := eType.OpenParenRange.Start
+		lastArgIdx := 0
+		for i, arg := range eType.Args {
+			// We overshot the argument and stop
+			if arg.Range().Start.Byte > pos.Byte {
+				break
+			}
+			if arg.Range().ContainsPos(pos) || arg.Range().End.Byte == pos.Byte {
+				var param function.Parameter
+				if i < paramsLen {
+					param = f.Params[i]
+				} else if f.VarParam != nil {
+					param = *f.VarParam
+				} else {
+					// Too many arguments passed to the function
+					return []lang.Candidate{}
+				}
+
+				cons := newExpression(fe.pathCtx, arg, schema.AnyExpression{OfType: param.Type})
+				return cons.CompletionAtPos(ctx, pos)
+			}
+			lastArgEndPos = arg.Range().End
+			lastArgIdx = i
+		}
+
+		fileBytes := fe.pathCtx.Files[eType.Range().Filename].Bytes
+		recoveredBytes := recoverLeftBytes(fileBytes, pos, func(byteOffset int, r rune) bool {
+			return (r == ',' || r == '(') && byteOffset > lastArgEndPos.Byte
+		})
+		trimmedBytes := bytes.TrimRight(recoveredBytes, " \t\n")
+
+		activePar := 0 // default to first parameter
+		if string(trimmedBytes) == "," {
+			activePar = lastArgIdx + 1
+		}
+
+		var param function.Parameter
+		if activePar < paramsLen {
+			param = f.Params[activePar]
+		} else if f.VarParam != nil {
+			param = *f.VarParam
+		} else {
+			// Too many arguments passed to the function
+			return []lang.Candidate{}
+		}
+
+		// TODO: Check whether we may be near incomplete expression (e.g. dot)
+
+		cons := newExpression(fe.pathCtx, newEmptyExpressionAtPos(eType.Range().Filename, pos), schema.AnyExpression{OfType: param.Type})
+		return cons.CompletionAtPos(ctx, pos)
+	}
+	return []lang.Candidate{}
+}
+
+func (fe functionExpr) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData {
+	funcExpr, ok := fe.expr.(*hclsyntax.FunctionCallExpr)
+	if !ok {
+		return nil
+	}
+
+	funcSig, ok := fe.pathCtx.Functions[funcExpr.Name]
+	if !ok {
+		return nil
+	}
+
+	if funcExpr.NameRange.ContainsPos(pos) {
+		return &lang.HoverData{
+			// TODO? add link to docs
+			Content: lang.Markdown(fmt.Sprintf("```terraform\n%s(%s) %s\n```\n\n%s",
+				funcExpr.Name, parameterNamesAsString(funcSig), funcSig.ReturnType.FriendlyName(), funcSig.Description)),
+			Range: fe.expr.Range(),
+		}
+	}
+
+	paramsLen := len(funcSig.Params)
+	if paramsLen == 0 && funcSig.VarParam == nil {
+		return nil // Function accepts no parameters
+	}
+
+	for i, arg := range funcExpr.Args {
+		var param function.Parameter
+		if i < paramsLen {
+			param = funcSig.Params[i]
+		} else if funcSig.VarParam != nil {
+			param = *funcSig.VarParam
+		} else {
+			// Too many arguments passed to the function
+			return nil
+		}
+
+		if arg.Range().ContainsPos(pos) {
+			return newExpression(fe.pathCtx, arg, schema.AnyExpression{
+				OfType: param.Type,
+			}).HoverAtPos(ctx, pos)
+		}
+	}
+
+	return nil
+}
+
+func (fe functionExpr) SemanticTokens(ctx context.Context) []lang.SemanticToken {
+	funcExpr, ok := fe.expr.(*hclsyntax.FunctionCallExpr)
+	if !ok {
+		return []lang.SemanticToken{}
+	}
+	funcSig, ok := fe.pathCtx.Functions[funcExpr.Name]
+	if !ok {
+		return []lang.SemanticToken{}
+	}
+
+	tokens := make([]lang.SemanticToken, 0)
+
+	tokens = append(tokens, lang.SemanticToken{
+		// TODO? if we introduce a new token type, we need to add it in the extension's package.json and docs
+		// Type:      lang.TokenFuncCall,
+		Type:      lang.TokenAttrName,
+		Modifiers: []lang.SemanticTokenModifier{},
+		Range:     funcExpr.NameRange,
+	})
+
+	paramsLen := len(funcSig.Params)
+	if paramsLen == 0 && funcSig.VarParam == nil {
+		return tokens // Function accepts no parameters
+	}
+
+	for i, arg := range funcExpr.Args {
+		var param function.Parameter
+		if i < paramsLen {
+			param = funcSig.Params[i]
+		} else if funcSig.VarParam != nil {
+			param = *funcSig.VarParam
+		} else {
+			// Too many arguments passed to the function
+			break
+		}
+
+		tokens = append(tokens, newExpression(fe.pathCtx, arg, schema.AnyExpression{
+			OfType: param.Type,
+		}).SemanticTokens(ctx)...)
+	}
+
+	return tokens
+}
+
+func (fe functionExpr) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {
+	funcExpr, diags := hcl.ExprCall(fe.expr)
+	if diags.HasErrors() {
+		return reference.Origins{}
+	}
+
+	funcSig, ok := fe.pathCtx.Functions[funcExpr.Name]
+	if !ok {
+		return nil
+	}
+
+	paramsLen := len(funcSig.Params)
+	if paramsLen == 0 && funcSig.VarParam == nil {
+		return nil // Function accepts no parameters
+	}
+
+	origins := make(reference.Origins, 0)
+	for i, arg := range funcExpr.Arguments {
+		var param function.Parameter
+		if i < paramsLen {
+			param = funcSig.Params[i]
+		} else if funcSig.VarParam != nil {
+			param = *funcSig.VarParam
+		} else {
+			// Too many arguments passed to the function
+			// TODO: report as 'any' constraint?
+			break
+		}
+
+		expr := Any{
+			pathCtx: fe.pathCtx,
+			expr:    arg,
+			cons: schema.AnyExpression{
+				OfType: param.Type,
+			},
+		}
+		origins = append(origins, expr.ReferenceOrigins(ctx, allowSelfRefs)...)
+	}
+
+	return origins
+}
+
+func (fe functionExpr) matchingFunctions(prefix string, editRange hcl.Range) []lang.Candidate {
+	candidates := make([]lang.Candidate, 0)
+
+	for name, f := range fe.pathCtx.Functions {
+		if !strings.HasPrefix(name, prefix) {
+			continue
+		}
+		// Only suggest functions that have a matching return type
+		if fe.returnType.TestConformance(f.ReturnType) != nil {
+			continue
+		}
+
+		// TODO? see why accepting a completion isn't triggering signatureHelp (it does for gopls)
+		candidates = append(candidates, lang.Candidate{
+			Label:       name,
+			Detail:      fmt.Sprintf("%s(%s) %s", name, parameterNamesAsString(f), f.ReturnType.FriendlyName()),
+			Kind:        lang.FunctionCandidateKind,
+			Description: lang.Markdown(f.Description),
+			TextEdit: lang.TextEdit{
+				NewText: fmt.Sprintf("%s()", name),
+				Snippet: fmt.Sprintf("%s(${0})", name),
+				Range:   editRange,
+			},
+		})
+	}
+
+	sort.SliceStable(candidates, func(i, j int) bool {
+		return candidates[i].Label < candidates[j].Label
+	})
+
+	return candidates
+}

--- a/decoder/expr_literal_type_completion.go
+++ b/decoder/expr_literal_type_completion.go
@@ -35,6 +35,10 @@ func (lt LiteralType) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.C
 			return []lang.Candidate{}
 		}
 
+		if lt.cons.SkipComplexTypes {
+			return []lang.Candidate{}
+		}
+
 		return []lang.Candidate{
 			{
 				Label:  labelForLiteralType(typ),
@@ -53,7 +57,7 @@ func (lt LiteralType) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.C
 		return lt.completeBoolAtPos(ctx, pos)
 	}
 
-	if typ.IsListType() {
+	if !lt.cons.SkipComplexTypes && typ.IsListType() {
 		expr, ok := lt.expr.(*hclsyntax.TupleConsExpr)
 		if !ok {
 			return []lang.Candidate{}
@@ -68,7 +72,7 @@ func (lt LiteralType) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.C
 		return newExpression(lt.pathCtx, expr, cons).CompletionAtPos(ctx, pos)
 	}
 
-	if typ.IsSetType() {
+	if !lt.cons.SkipComplexTypes && typ.IsSetType() {
 		expr, ok := lt.expr.(*hclsyntax.TupleConsExpr)
 		if !ok {
 			return []lang.Candidate{}
@@ -83,7 +87,7 @@ func (lt LiteralType) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.C
 		return newExpression(lt.pathCtx, expr, cons).CompletionAtPos(ctx, pos)
 	}
 
-	if typ.IsTupleType() {
+	if !lt.cons.SkipComplexTypes && typ.IsTupleType() {
 		expr, ok := lt.expr.(*hclsyntax.TupleConsExpr)
 		if !ok {
 			return []lang.Candidate{}
@@ -102,7 +106,7 @@ func (lt LiteralType) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.C
 		return newExpression(lt.pathCtx, expr, cons).CompletionAtPos(ctx, pos)
 	}
 
-	if typ.IsMapType() {
+	if !lt.cons.SkipComplexTypes && typ.IsMapType() {
 		expr, ok := lt.expr.(*hclsyntax.ObjectConsExpr)
 		if !ok {
 			return []lang.Candidate{}
@@ -116,7 +120,7 @@ func (lt LiteralType) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.C
 		return newExpression(lt.pathCtx, expr, cons).CompletionAtPos(ctx, pos)
 	}
 
-	if typ.IsObjectType() {
+	if !lt.cons.SkipComplexTypes && typ.IsObjectType() {
 		expr, ok := lt.expr.(*hclsyntax.ObjectConsExpr)
 		if !ok {
 			return []lang.Candidate{}

--- a/decoder/expr_reference_ref_origins.go
+++ b/decoder/expr_reference_ref_origins.go
@@ -93,7 +93,7 @@ func originConstraintsFromCons(cons schema.Reference) reference.OriginConstraint
 		return reference.OriginConstraints{}
 	}
 
-	return []reference.OriginConstraint{
+	return reference.OriginConstraints{
 		{
 			OfType:    cons.OfType,
 			OfScopeId: cons.OfScopeId,

--- a/lang/candidate.go
+++ b/lang/candidate.go
@@ -26,6 +26,7 @@ const (
 	StringCandidateKind
 	TupleCandidateKind
 	TraversalCandidateKind
+	FunctionCandidateKind
 )
 
 //go:generate go run golang.org/x/tools/cmd/stringer -type=CandidateKind -output=candidate_kind_string.go

--- a/lang/candidate_kind_string.go
+++ b/lang/candidate_kind_string.go
@@ -22,11 +22,12 @@ func _() {
 	_ = x[StringCandidateKind-11]
 	_ = x[TupleCandidateKind-12]
 	_ = x[TraversalCandidateKind-13]
+	_ = x[FunctionCandidateKind-14]
 }
 
-const _CandidateKind_name = "NilCandidateKindAttributeCandidateKindBlockCandidateKindLabelCandidateKindBoolCandidateKindKeywordCandidateKindListCandidateKindMapCandidateKindNumberCandidateKindObjectCandidateKindSetCandidateKindStringCandidateKindTupleCandidateKindTraversalCandidateKind"
+const _CandidateKind_name = "NilCandidateKindAttributeCandidateKindBlockCandidateKindLabelCandidateKindBoolCandidateKindKeywordCandidateKindListCandidateKindMapCandidateKindNumberCandidateKindObjectCandidateKindSetCandidateKindStringCandidateKindTupleCandidateKindTraversalCandidateKindFunctionCandidateKind"
 
-var _CandidateKind_index = [...]uint16{0, 16, 38, 56, 74, 91, 111, 128, 144, 163, 182, 198, 217, 235, 257}
+var _CandidateKind_index = [...]uint16{0, 16, 38, 56, 74, 91, 111, 128, 144, 163, 182, 198, 217, 235, 257, 278}
 
 func (i CandidateKind) String() string {
 	if i >= CandidateKind(len(_CandidateKind_index)-1) {

--- a/lang/semantic_token.go
+++ b/lang/semantic_token.go
@@ -33,6 +33,7 @@ const (
 	TokenTraversalStep SemanticTokenType = "hcl-traversalStep"
 	TokenTypeCapsule   SemanticTokenType = "hcl-typeCapsule"
 	TokenTypePrimitive SemanticTokenType = "hcl-typePrimitive"
+	TokenFunctionName  SemanticTokenType = "hcl-functionName"
 )
 
 var SupportedSemanticTokenTypes = SemanticTokenTypes{
@@ -48,6 +49,7 @@ var SupportedSemanticTokenTypes = SemanticTokenTypes{
 	TokenTraversalStep,
 	TokenTypeCapsule,
 	TokenTypePrimitive,
+	TokenFunctionName,
 }
 
 type SemanticTokenModifier string

--- a/reference/traversal.go
+++ b/reference/traversal.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 )
 
-func TraversalToLocalOrigin(traversal hcl.Traversal, cons schema.Reference, allowSelfRefs bool) (LocalOrigin, bool) {
+func TraversalToLocalOrigin(traversal hcl.Traversal, cons OriginConstraints, allowSelfRefs bool) (LocalOrigin, bool) {
 	// traversal should not be relative here, since the input to this
 	// function `expr.Variables()` only returns absolute traversals
 	if !traversal.IsRelative() && traversal.RootName() == "self" && !allowSelfRefs {
@@ -26,22 +26,8 @@ func TraversalToLocalOrigin(traversal hcl.Traversal, cons schema.Reference, allo
 	return LocalOrigin{
 		Addr:        addr,
 		Range:       traversal.SourceRange(),
-		Constraints: refrenceConstraintToOriginConstraints(cons),
+		Constraints: cons,
 	}, true
-}
-
-func refrenceConstraintToOriginConstraints(cons schema.Reference) OriginConstraints {
-	if cons.Address != nil {
-		// skip traversals which are targets by themselves (not origins)
-		return OriginConstraints{}
-	}
-
-	return []OriginConstraint{
-		{
-			OfType:    cons.OfType,
-			OfScopeId: cons.OfScopeId,
-		},
-	}
 }
 
 func LegacyTraversalsToLocalOrigins(traversals []hcl.Traversal, tes schema.TraversalExprs, allowSelfRefs bool) Origins {

--- a/schema/constraint_any_expression.go
+++ b/schema/constraint_any_expression.go
@@ -17,6 +17,10 @@ import (
 type AnyExpression struct {
 	// OfType defines the type which the outermost expression is constrained to
 	OfType cty.Type
+
+	// SkipLiteralComplexTypes avoids descending into complex literal types, such as {} and [].
+	// It might be required when AnyExpression is used in OneOf to avoid duplicates.
+	SkipLiteralComplexTypes bool
 }
 
 func (AnyExpression) isConstraintImpl() constraintSigil {
@@ -29,7 +33,8 @@ func (ae AnyExpression) FriendlyName() string {
 
 func (ae AnyExpression) Copy() Constraint {
 	return AnyExpression{
-		OfType: ae.OfType,
+		OfType:                  ae.OfType,
+		SkipLiteralComplexTypes: ae.SkipLiteralComplexTypes,
 	}
 }
 
@@ -37,7 +42,8 @@ func (ae AnyExpression) EmptyCompletionData(ctx context.Context, nextPlaceholder
 	// if prefilling is enabled, then it is desirable to treat this as literal
 	if prefillRequiredFields(ctx) {
 		lt := LiteralType{
-			Type: ae.OfType,
+			Type:             ae.OfType,
+			SkipComplexTypes: ae.SkipLiteralComplexTypes,
 		}
 		return lt.EmptyCompletionData(ctx, nextPlaceholder, nestingLevel)
 	}

--- a/schema/constraint_literal_type.go
+++ b/schema/constraint_literal_type.go
@@ -25,6 +25,10 @@ import (
 type LiteralType struct {
 	Type cty.Type
 	// TODO: object defaults
+
+	// SkipComplexTypes avoids descending into complex literal types, such as {} and [].
+	// It might be required when LiteralType is used in OneOf to avoid duplicates.
+	SkipComplexTypes bool
 }
 
 func (LiteralType) isConstraintImpl() constraintSigil {
@@ -37,7 +41,8 @@ func (lt LiteralType) FriendlyName() string {
 
 func (lt LiteralType) Copy() Constraint {
 	return LiteralType{
-		Type: lt.Type,
+		Type:             lt.Type,
+		SkipComplexTypes: lt.SkipComplexTypes,
 	}
 }
 


### PR DESCRIPTION
* Depends on https://github.com/hashicorp/hcl-lang/pull/246

--- 

## UX
We provide completion of references, function and literals for all expressions

![2023-04-06 12 03 54](https://user-images.githubusercontent.com/45985/230379635-ad811f8c-70cf-49e5-b78c-a80efa4f8a71.gif)

Completion, hover and semantic tokens also work for nested expressions, like within objects or function calls.
![2023-04-06 14 50 08](https://user-images.githubusercontent.com/45985/230383746-ba5b6351-e1b4-45ac-83d6-e019cb08ef28.gif)


---

* Part of https://github.com/hashicorp/terraform-ls/issues/496
* Part of https://github.com/hashicorp/terraform-ls/issues/37