### PR TITLE
reference: Update type matching to align w/ Terraform's

### DIFF
--- a/decoder/expr_reference_completion_test.go
+++ b/decoder/expr_reference_completion_test.go
@@ -48,6 +48,13 @@ func TestCompletionAtPos_exprReference(t *testing.T) {
 						lang.RootStep{Name: "local"},
 						lang.AttrStep{Name: "bar"},
 					},
+					Type: cty.List(cty.Number),
+				},
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "baz"},
+					},
 					Type: cty.Number,
 				},
 			},
@@ -61,6 +68,20 @@ func TestCompletionAtPos_exprReference(t *testing.T) {
 					TextEdit: lang.TextEdit{
 						NewText: "local.foo",
 						Snippet: "local.foo",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+					},
+				},
+				{
+					Label:  "local.baz",
+					Detail: "number",
+					Kind:   lang.TraversalCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "local.baz",
+						Snippet: "local.baz",
 						Range: hcl.Range{
 							Filename: "test.tf",
 							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
@@ -85,7 +106,7 @@ func TestCompletionAtPos_exprReference(t *testing.T) {
 						lang.RootStep{Name: "local"},
 						lang.AttrStep{Name: "foo"},
 					},
-					Type: cty.String,
+					Type: cty.List(cty.String),
 				},
 				{
 					Addr: lang.Address{
@@ -143,7 +164,7 @@ func TestCompletionAtPos_exprReference(t *testing.T) {
 						lang.RootStep{Name: "local"},
 						lang.AttrStep{Name: "bar"},
 					},
-					Type: cty.Number,
+					Type: cty.List(cty.Number),
 				},
 				{
 					Addr: lang.Address{
@@ -194,7 +215,7 @@ func TestCompletionAtPos_exprReference(t *testing.T) {
 						lang.RootStep{Name: "local"},
 						lang.AttrStep{Name: "bar"},
 					},
-					Type: cty.Number,
+					Type: cty.List(cty.Number),
 				},
 				{
 					Addr: lang.Address{

--- a/decoder/expression_candidates_legacy_test.go
+++ b/decoder/expression_candidates_legacy_test.go
@@ -1478,7 +1478,7 @@ func TestLegacyDecoder_CandidateAtPos_traversalExpressions(t *testing.T) {
 				Attributes: map[string]*schema.AttributeSchema{
 					"attr": {
 						Expr: schema.ExprConstraints{
-							schema.TraversalExpr{OfType: cty.String},
+							schema.TraversalExpr{OfType: cty.List(cty.String)},
 						},
 					},
 				},
@@ -1521,7 +1521,7 @@ func TestLegacyDecoder_CandidateAtPos_traversalExpressions(t *testing.T) {
 						lang.RootStep{Name: "var"},
 						lang.AttrStep{Name: "first"},
 					},
-					Type: cty.Bool,
+					Type: cty.List(cty.Number),
 				},
 				reference.Target{
 					Addr: lang.Address{

--- a/decoder/hover_expressions_legacy_test.go
+++ b/decoder/hover_expressions_legacy_test.go
@@ -1410,7 +1410,7 @@ func TestLegacyDecoder_HoverAtPos_traversalExpressions(t *testing.T) {
 						lang.RootStep{Name: "var"},
 						lang.AttrStep{Name: "blah"},
 					},
-					Type: cty.Bool,
+					Type: cty.List(cty.Bool),
 				},
 			},
 			reference.Origins{

--- a/decoder/semantic_tokens_expr_legacy_test.go
+++ b/decoder/semantic_tokens_expr_legacy_test.go
@@ -1481,7 +1481,7 @@ func TestLegacyDecoder_SemanticTokensInFile_traversalExpression(t *testing.T) {
 						lang.RootStep{Name: "var"},
 						lang.AttrStep{Name: "blah"},
 					},
-					Type: cty.Bool,
+					Type: cty.List(cty.Bool),
 				},
 			},
 			reference.Origins{

--- a/reference/targets_test.go
+++ b/reference/targets_test.go
@@ -738,6 +738,13 @@ func TestTargets_LegacyMatchWalk(t *testing.T) {
 					},
 					Type: cty.String,
 				},
+				Target{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "another"},
+					},
+					Type: cty.List(cty.String),
+				},
 			},
 			schema.TraversalExpr{
 				OfType: cty.String,
@@ -754,6 +761,13 @@ func TestTargets_LegacyMatchWalk(t *testing.T) {
 				End:      hcl.InitialPos,
 			},
 			Targets{
+				Target{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "first"},
+					},
+					Type: cty.Bool,
+				},
 				Target{
 					Addr: lang.Address{
 						lang.RootStep{Name: "var"},


### PR DESCRIPTION
Terraform itself basically doesn't use cty's TestConformance, but instead uses the convert.Convert function. This makes the type comparison a lot more lenient, where it accepts basically any primitive type for any other. It does however reject mismatch between complex types.

Other products / language servers may benefit from the stricter comparison (as implemented by `TestConformance`) but we do not have enough data to understand this problem space and so we optimise for Terraform for now. This should not hurt other products unless they have a lot of references to filter. At worst they'll get *more* completion items and hover/semtokens for references which are not relevant, but should still get the ones which are relevant. They may also happen to implement type comparison same way as Terraform. 🤷🏻 

## Why now?

Because https://github.com/hashicorp/hcl-lang/pull/232 is introducing support for functions and needs to decide how to compare constraints with return types, which is a similar problem to comparing references and so I believe the two places should agree on how to do this.

The alternative would be reusing the strict `TestConformance` there, which is what I first attempted, but it had some other odd edge cases, where `cty.DynamicPseudoType` [function return type] is considered mismatch for `cty.String` constraint.

## Example

```hcl
variable "test" {
  type    = string
  default = "42"
}

output "test" {
  value = abs(var.test)
}
```
^ this is valid configuration which produces `42` (number)

--- 

There is a wider conversation to have about promoting best practice by suppressing (but accepting) patterns which do not follow best practice. This could mean not providing completion for examples such as the one above, but providing hover, semantic tokens, go-to-* etc. This has two pre-requisites though:

 - We'd have to use different matching logic for completion than for all other methods
 - We should have other (more obvious and visible) ways to communicate this, rather than *just* suppressing completion items.
   - This could be addressed as part of https://github.com/hashicorp/hcl-lang/issues/57 but we'll need to make sure we fully understand the impact of precise comparisons there and the edge cases (e.g. by running a lot of existing configuration through the validation logic).