### PR TITLE
schema: Avoid creating empty `Expr` slice if `Constraint` is set

### DIFF
--- a/schema/attribute_schema.go
+++ b/schema/attribute_schema.go
@@ -145,7 +145,6 @@ func (as *AttributeSchema) Copy() *AttributeSchema {
 		IsSensitive:            as.IsSensitive,
 		IsDepKey:               as.IsDepKey,
 		Description:            as.Description,
-		Expr:                   as.Expr.Copy(),
 		Address:                as.Address.Copy(),
 		OriginForTarget:        as.OriginForTarget.Copy(),
 		SemanticTokenModifiers: as.SemanticTokenModifiers.Copy(),
@@ -154,6 +153,8 @@ func (as *AttributeSchema) Copy() *AttributeSchema {
 
 	if as.Constraint != nil {
 		newAs.Constraint = as.Constraint.Copy()
+	} else {
+		newAs.Expr = as.Expr.Copy()
 	}
 
 	return newAs


### PR DESCRIPTION
This is to (a) avoid some unnecessary memory allocations and (b) make testing easier with `Constraint`, as discovered in https://github.com/hashicorp/terraform-schema/actions/runs/4621591413/jobs/8173199515#step:8:1184