### PR TITLE
schema: Implement `EmptyCompletionData` for `AnyExpression`

### DIFF
--- a/schema/constraint_any_expression.go
+++ b/schema/constraint_any_expression.go
@@ -34,8 +34,20 @@ func (ae AnyExpression) Copy() Constraint {
 }
 
 func (ae AnyExpression) EmptyCompletionData(ctx context.Context, nextPlaceholder int, nestingLevel int) CompletionData {
-	// TODO
-	return CompletionData{}
+	// if prefilling is enabled, then it is desirable to treat this as literal
+	if prefillRequiredFields(ctx) {
+		lt := LiteralType{
+			Type: ae.OfType,
+		}
+		return lt.EmptyCompletionData(ctx, nextPlaceholder, nestingLevel)
+	}
+
+	// otherwise (which can just be when completing attribute)
+	// we assume the user will more likely want reference-like behaviour
+	ref := Reference{
+		OfType: ae.OfType,
+	}
+	return ref.EmptyCompletionData(ctx, nextPlaceholder, nestingLevel)
 }
 
 func (ae AnyExpression) ConstraintType() (cty.Type, bool) {


### PR DESCRIPTION
I'm not sure if this is the best solution, but it mostly mimics the existing behaviours of `TraversalExpr` (legacy `Reference`) and `LiteralTypeExpr` (legacy `LiteralType`).

That is, we produce pre-filling, when enabled:
![2023-04-05 20 13 48](https://user-images.githubusercontent.com/287584/230182138-0ba954ad-0493-4de7-8f7b-c26e861bb43d.gif)

the (perhaps undesirable?) side effect though is that we also pre-fill on attribute completion:
![2023-04-05 20 14 27](https://user-images.githubusercontent.com/287584/230182289-7f8f9105-2002-4e0f-8665-fc0c16402364.gif)

where it might be more appropriate to trigger completion and bring up functions/references:
![2023-04-05 20 14 56](https://user-images.githubusercontent.com/287584/230182393-b4f16add-30e3-4e58-b071-323183200cd3.gif)

--- 

So one better solution I can think of would involve attaching another context value somewhere here https://github.com/hashicorp/hcl-lang/blob/fba9786f3c123b25fd1d213716e385cb9b5b36a9/decoder/attribute_candidates.go#L21-L24 and add that to the condition, such that for `LiteralType`-like behaviour (pre-filling empty values) we not only expect the prefilling to be toggled on, but also to _not_ be providing completion for an attribute.