### PR TITLE
Collect implied reference targets for complex types

### DIFF
--- a/decoder/expr_list_ref_targets_test.go
+++ b/decoder/expr_list_ref_targets_test.go
@@ -369,7 +369,148 @@ func TestCollectRefTargets_exprList_hcl(t *testing.T) {
 
 			f, diags := hclsyntax.ParseConfig([]byte(tc.cfg), "test.hcl", hcl.InitialPos)
 			if len(diags) > 0 {
-				t.Error(diags)
+				t.Log(diags)
+			}
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.hcl": f,
+				},
+			})
+
+			targets, err := d.CollectReferenceTargets()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedRefTargets, targets, ctydebug.CmpOptions); diff != "" {
+				t.Fatalf("unexpected targets: %s", diff)
+			}
+		})
+	}
+}
+
+func TestCollectRefTargets_exprList_implied_hcl(t *testing.T) {
+	testCases := []struct {
+		testName           string
+		bodySchema         *schema.BodySchema
+		cfg                string
+		expectedRefTargets reference.Targets
+	}{
+		{
+			"undeclared implied as type",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"blk": {
+						Address: &schema.BlockAddrSchema{
+							Steps: schema.Address{
+								schema.StaticStep{Name: "blk"},
+							},
+							BodyAsData: true,
+							InferBody:  true,
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"attr": {
+									Constraint: schema.List{
+										Elem: schema.LiteralType{Type: cty.Bool},
+									},
+									IsOptional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			`blk {}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "blk"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 7, Byte: 6},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 4, Byte: 3},
+					},
+					Type: cty.Object(map[string]cty.Type{
+						"attr": cty.List(cty.Bool),
+					}),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "blk"},
+								lang.AttrStep{Name: "attr"},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 1, Column: 5, Byte: 4},
+								End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+							},
+							Type: cty.List(cty.Bool),
+						},
+					},
+				},
+			},
+		},
+		{
+			"undeclared as reference",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"blk": {
+						Address: &schema.BlockAddrSchema{
+							Steps: schema.Address{
+								schema.StaticStep{Name: "blk"},
+							},
+							AsReference: true,
+							ScopeId:     lang.ScopeId("foo"),
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"attr": {
+									Constraint: schema.List{
+										Elem: schema.LiteralType{Type: cty.Bool},
+									},
+									IsOptional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			`blk {}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "blk"},
+					},
+					ScopeId: lang.ScopeId("foo"),
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 7, Byte: 6},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 4, Byte: 3},
+					},
+				},
+			},
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := tc.bodySchema
+
+			f, diags := hclsyntax.ParseConfig([]byte(tc.cfg), "test.hcl", hcl.InitialPos)
+			if len(diags) > 0 {
+				t.Log(diags)
 			}
 			d := testPathDecoder(t, &PathContext{
 				Schema: bodySchema,
@@ -397,6 +538,44 @@ func TestCollectRefTargets_exprList_json(t *testing.T) {
 		cfg                string
 		expectedRefTargets reference.Targets
 	}{
+		{
+			"undeclared implied as type",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.List{
+						Elem: schema.LiteralType{Type: cty.Bool},
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`{"attr": null}`,
+			reference.Targets{},
+		},
+		{
+			"undeclared implied as reference",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.List{
+						Elem: schema.LiteralType{Type: cty.Bool},
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsReference: true,
+					},
+				},
+			},
+			`{"attr": null}`,
+			reference.Targets{},
+		},
 		{
 			"constraint mismatch",
 			map[string]*schema.AttributeSchema{
@@ -742,6 +921,147 @@ func TestCollectRefTargets_exprList_json(t *testing.T) {
 			bodySchema := &schema.BodySchema{
 				Attributes: tc.attrSchema,
 			}
+
+			f, diags := json.ParseWithStartPos([]byte(tc.cfg), "test.hcl.json", hcl.InitialPos)
+			if len(diags) > 0 {
+				t.Error(diags)
+			}
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.hcl.json": f,
+				},
+			})
+
+			targets, err := d.CollectReferenceTargets()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedRefTargets, targets, ctydebug.CmpOptions); diff != "" {
+				t.Fatalf("unexpected targets: %s", diff)
+			}
+		})
+	}
+}
+
+func TestCollectRefTargets_exprList_implied_json(t *testing.T) {
+	testCases := []struct {
+		testName           string
+		bodySchema         *schema.BodySchema
+		cfg                string
+		expectedRefTargets reference.Targets
+	}{
+		{
+			"undeclared implied as type",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"blk": {
+						Address: &schema.BlockAddrSchema{
+							Steps: schema.Address{
+								schema.StaticStep{Name: "blk"},
+							},
+							BodyAsData: true,
+							InferBody:  true,
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"attr": {
+									Constraint: schema.List{
+										Elem: schema.LiteralType{Type: cty.Bool},
+									},
+									IsOptional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			`{"blk": {}}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "blk"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						End:      hcl.Pos{Line: 1, Column: 11, Byte: 10},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+					},
+					Type: cty.Object(map[string]cty.Type{
+						"attr": cty.List(cty.Bool),
+					}),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "blk"},
+								lang.AttrStep{Name: "attr"},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+								End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+							},
+							Type: cty.List(cty.Bool),
+						},
+					},
+				},
+			},
+		},
+		{
+			"undeclared as reference",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"blk": {
+						Address: &schema.BlockAddrSchema{
+							Steps: schema.Address{
+								schema.StaticStep{Name: "blk"},
+							},
+							AsReference: true,
+							ScopeId:     lang.ScopeId("foo"),
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"attr": {
+									Constraint: schema.List{
+										Elem: schema.LiteralType{Type: cty.Bool},
+									},
+									IsOptional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			`{"blk": {}}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "blk"},
+					},
+					ScopeId: lang.ScopeId("foo"),
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						End:      hcl.Pos{Line: 1, Column: 11, Byte: 10},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+					},
+				},
+			},
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := tc.bodySchema
 
 			f, diags := json.ParseWithStartPos([]byte(tc.cfg), "test.hcl.json", hcl.InitialPos)
 			if len(diags) > 0 {

--- a/decoder/expr_literal_type_ref_targets_test.go
+++ b/decoder/expr_literal_type_ref_targets_test.go
@@ -644,8 +644,21 @@ func TestCollectRefTargets_exprLiteralType_hcl(t *testing.T) {
 						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
 						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
 					},
-					Type:          cty.Tuple([]cty.Type{cty.String}),
-					NestedTargets: reference.Targets{},
+					Type: cty.Tuple([]cty.Type{cty.String}),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.NumberIntVal(0)},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+								End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							},
+							Type: cty.String,
+						},
+					},
 				},
 			},
 		},
@@ -2535,8 +2548,21 @@ func TestCollectRefTargets_exprLiteralType_json(t *testing.T) {
 						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
 						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
 					},
-					Type:          cty.Tuple([]cty.Type{cty.String}),
-					NestedTargets: reference.Targets{},
+					Type: cty.Tuple([]cty.Type{cty.String}),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.NumberIntVal(0)},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+								End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+							},
+							Type: cty.String,
+						},
+					},
 				},
 			},
 		},

--- a/decoder/expr_map_ref_targets_test.go
+++ b/decoder/expr_map_ref_targets_test.go
@@ -549,6 +549,147 @@ func TestCollectRefTargets_exprMap_hcl(t *testing.T) {
 	}
 }
 
+func TestCollectRefTargets_exprMap_implied_hcl(t *testing.T) {
+	testCases := []struct {
+		testName           string
+		bodySchema         *schema.BodySchema
+		cfg                string
+		expectedRefTargets reference.Targets
+	}{
+		{
+			"undeclared implied as type",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"blk": {
+						Address: &schema.BlockAddrSchema{
+							Steps: schema.Address{
+								schema.StaticStep{Name: "blk"},
+							},
+							BodyAsData: true,
+							InferBody:  true,
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"attr": {
+									Constraint: schema.Map{
+										Elem: schema.LiteralType{Type: cty.Bool},
+									},
+									IsOptional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			`blk {}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "blk"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 7, Byte: 6},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 4, Byte: 3},
+					},
+					Type: cty.Object(map[string]cty.Type{
+						"attr": cty.Map(cty.Bool),
+					}),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "blk"},
+								lang.AttrStep{Name: "attr"},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 1, Column: 5, Byte: 4},
+								End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+							},
+							Type: cty.Map(cty.Bool),
+						},
+					},
+				},
+			},
+		},
+		{
+			"undeclared as reference",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"blk": {
+						Address: &schema.BlockAddrSchema{
+							Steps: schema.Address{
+								schema.StaticStep{Name: "blk"},
+							},
+							AsReference: true,
+							ScopeId:     lang.ScopeId("foo"),
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"attr": {
+									Constraint: schema.List{
+										Elem: schema.LiteralType{Type: cty.Bool},
+									},
+									IsOptional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			`blk {}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "blk"},
+					},
+					ScopeId: lang.ScopeId("foo"),
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 7, Byte: 6},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 4, Byte: 3},
+					},
+				},
+			},
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := tc.bodySchema
+
+			f, diags := hclsyntax.ParseConfig([]byte(tc.cfg), "test.hcl", hcl.InitialPos)
+			if len(diags) > 0 {
+				t.Log(diags)
+			}
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.hcl": f,
+				},
+			})
+
+			targets, err := d.CollectReferenceTargets()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedRefTargets, targets, ctydebug.CmpOptions); diff != "" {
+				t.Fatalf("unexpected targets: %s", diff)
+			}
+		})
+	}
+}
+
 func TestCollectRefTargets_exprMap_json(t *testing.T) {
 	testCases := []struct {
 		testName           string
@@ -1051,6 +1192,147 @@ func TestCollectRefTargets_exprMap_json(t *testing.T) {
 			bodySchema := &schema.BodySchema{
 				Attributes: tc.attrSchema,
 			}
+
+			f, diags := json.ParseWithStartPos([]byte(tc.cfg), "test.hcl.json", hcl.InitialPos)
+			if len(diags) > 0 {
+				t.Error(diags)
+			}
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.hcl.json": f,
+				},
+			})
+
+			targets, err := d.CollectReferenceTargets()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedRefTargets, targets, ctydebug.CmpOptions); diff != "" {
+				t.Fatalf("unexpected targets: %s", diff)
+			}
+		})
+	}
+}
+
+func TestCollectRefTargets_exprMap_implied_json(t *testing.T) {
+	testCases := []struct {
+		testName           string
+		bodySchema         *schema.BodySchema
+		cfg                string
+		expectedRefTargets reference.Targets
+	}{
+		{
+			"undeclared implied as type",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"blk": {
+						Address: &schema.BlockAddrSchema{
+							Steps: schema.Address{
+								schema.StaticStep{Name: "blk"},
+							},
+							BodyAsData: true,
+							InferBody:  true,
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"attr": {
+									Constraint: schema.Map{
+										Elem: schema.LiteralType{Type: cty.Bool},
+									},
+									IsOptional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			`{"blk": {}}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "blk"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						End:      hcl.Pos{Line: 1, Column: 11, Byte: 10},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+					},
+					Type: cty.Object(map[string]cty.Type{
+						"attr": cty.Map(cty.Bool),
+					}),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "blk"},
+								lang.AttrStep{Name: "attr"},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+								End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+							},
+							Type: cty.Map(cty.Bool),
+						},
+					},
+				},
+			},
+		},
+		{
+			"undeclared as reference",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"blk": {
+						Address: &schema.BlockAddrSchema{
+							Steps: schema.Address{
+								schema.StaticStep{Name: "blk"},
+							},
+							AsReference: true,
+							ScopeId:     lang.ScopeId("foo"),
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"attr": {
+									Constraint: schema.List{
+										Elem: schema.LiteralType{Type: cty.Bool},
+									},
+									IsOptional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			`{"blk": {}}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "blk"},
+					},
+					ScopeId: lang.ScopeId("foo"),
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						End:      hcl.Pos{Line: 1, Column: 11, Byte: 10},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+					},
+				},
+			},
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := tc.bodySchema
 
 			f, diags := json.ParseWithStartPos([]byte(tc.cfg), "test.hcl.json", hcl.InitialPos)
 			if len(diags) > 0 {

--- a/decoder/expr_object_ref_targets_test.go
+++ b/decoder/expr_object_ref_targets_test.go
@@ -685,6 +685,174 @@ func TestCollectRefTargets_exprObject_hcl(t *testing.T) {
 	}
 }
 
+func TestCollectRefTargets_exprObject_implied_hcl(t *testing.T) {
+	testCases := []struct {
+		testName           string
+		bodySchema         *schema.BodySchema
+		cfg                string
+		expectedRefTargets reference.Targets
+	}{
+		{
+			"undeclared implied as type",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"blk": {
+						Address: &schema.BlockAddrSchema{
+							Steps: schema.Address{
+								schema.StaticStep{Name: "blk"},
+							},
+							BodyAsData: true,
+							InferBody:  true,
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"attr": {
+									Constraint: schema.Object{
+										Attributes: map[string]*schema.AttributeSchema{
+											"foo": {
+												Constraint: schema.LiteralType{Type: cty.Bool},
+											},
+										},
+									},
+									IsOptional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			`blk {}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "blk"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 7, Byte: 6},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 4, Byte: 3},
+					},
+					Type: cty.Object(map[string]cty.Type{
+						"attr": cty.Object(map[string]cty.Type{
+							"foo": cty.Bool,
+						}),
+					}),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "blk"},
+								lang.AttrStep{Name: "attr"},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 1, Column: 5, Byte: 4},
+								End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+							},
+							Type: cty.Object(map[string]cty.Type{
+								"foo": cty.Bool,
+							}),
+							NestedTargets: reference.Targets{
+								{
+									Addr: lang.Address{
+										lang.RootStep{Name: "blk"},
+										lang.AttrStep{Name: "attr"},
+										lang.AttrStep{Name: "foo"},
+									},
+									RangePtr: &hcl.Range{
+										Filename: "test.hcl",
+										Start:    hcl.Pos{Line: 1, Column: 5, Byte: 4},
+										End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+									},
+									Type: cty.Bool,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"undeclared as reference",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"blk": {
+						Address: &schema.BlockAddrSchema{
+							Steps: schema.Address{
+								schema.StaticStep{Name: "blk"},
+							},
+							AsReference: true,
+							ScopeId:     lang.ScopeId("foo"),
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"attr": {
+									Constraint: schema.Object{
+										Attributes: map[string]*schema.AttributeSchema{
+											"foo": {
+												Constraint: schema.LiteralType{Type: cty.Bool},
+											},
+										},
+									},
+									IsOptional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			`blk {}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "blk"},
+					},
+					ScopeId: lang.ScopeId("foo"),
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 7, Byte: 6},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 4, Byte: 3},
+					},
+				},
+			},
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := tc.bodySchema
+
+			f, diags := hclsyntax.ParseConfig([]byte(tc.cfg), "test.hcl", hcl.InitialPos)
+			if len(diags) > 0 {
+				t.Log(diags)
+			}
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.hcl": f,
+				},
+			})
+
+			targets, err := d.CollectReferenceTargets()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedRefTargets, targets, ctydebug.CmpOptions); diff != "" {
+				t.Fatalf("unexpected targets: %s", diff)
+			}
+		})
+	}
+}
+
 func TestCollectRefTargets_exprObject_json(t *testing.T) {
 	testCases := []struct {
 		testName           string
@@ -1323,6 +1491,174 @@ func TestCollectRefTargets_exprObject_json(t *testing.T) {
 			bodySchema := &schema.BodySchema{
 				Attributes: tc.attrSchema,
 			}
+
+			f, diags := json.ParseWithStartPos([]byte(tc.cfg), "test.hcl.json", hcl.InitialPos)
+			if len(diags) > 0 {
+				t.Error(diags)
+			}
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.hcl.json": f,
+				},
+			})
+
+			targets, err := d.CollectReferenceTargets()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedRefTargets, targets, ctydebug.CmpOptions); diff != "" {
+				t.Fatalf("unexpected targets: %s", diff)
+			}
+		})
+	}
+}
+
+func TestCollectRefTargets_exprObject_implied_json(t *testing.T) {
+	testCases := []struct {
+		testName           string
+		bodySchema         *schema.BodySchema
+		cfg                string
+		expectedRefTargets reference.Targets
+	}{
+		{
+			"undeclared implied as type",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"blk": {
+						Address: &schema.BlockAddrSchema{
+							Steps: schema.Address{
+								schema.StaticStep{Name: "blk"},
+							},
+							BodyAsData: true,
+							InferBody:  true,
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"attr": {
+									Constraint: schema.Object{
+										Attributes: map[string]*schema.AttributeSchema{
+											"foo": {
+												Constraint: schema.LiteralType{Type: cty.Bool},
+											},
+										},
+									},
+									IsOptional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			`{"blk": {}}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "blk"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						End:      hcl.Pos{Line: 1, Column: 11, Byte: 10},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+					},
+					Type: cty.Object(map[string]cty.Type{
+						"attr": cty.Object(map[string]cty.Type{
+							"foo": cty.Bool,
+						}),
+					}),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "blk"},
+								lang.AttrStep{Name: "attr"},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+								End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+							},
+							Type: cty.Object(map[string]cty.Type{
+								"foo": cty.Bool,
+							}),
+							NestedTargets: reference.Targets{
+								{
+									Addr: lang.Address{
+										lang.RootStep{Name: "blk"},
+										lang.AttrStep{Name: "attr"},
+										lang.AttrStep{Name: "foo"},
+									},
+									RangePtr: &hcl.Range{
+										Filename: "test.hcl.json",
+										Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+										End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+									},
+									Type: cty.Bool,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"undeclared as reference",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"blk": {
+						Address: &schema.BlockAddrSchema{
+							Steps: schema.Address{
+								schema.StaticStep{Name: "blk"},
+							},
+							AsReference: true,
+							ScopeId:     lang.ScopeId("foo"),
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"attr": {
+									Constraint: schema.Object{
+										Attributes: map[string]*schema.AttributeSchema{
+											"foo": {
+												Constraint: schema.LiteralType{Type: cty.Bool},
+											},
+										},
+									},
+									IsOptional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			`{"blk": {}}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "blk"},
+					},
+					ScopeId: lang.ScopeId("foo"),
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						End:      hcl.Pos{Line: 1, Column: 11, Byte: 10},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+					},
+				},
+			},
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := tc.bodySchema
 
 			f, diags := json.ParseWithStartPos([]byte(tc.cfg), "test.hcl.json", hcl.InitialPos)
 			if len(diags) > 0 {

--- a/decoder/expr_set_ref_targets.go
+++ b/decoder/expr_set_ref_targets.go
@@ -13,6 +13,10 @@ import (
 )
 
 func (set Set) ReferenceTargets(ctx context.Context, targetCtx *TargetContext) reference.Targets {
+	if isEmptyExpression(set.expr) && targetCtx != nil {
+		return set.wholeSetReferenceTargets(targetCtx, nil)
+	}
+
 	elems, diags := hcl.ExprList(set.expr)
 	if diags.HasErrors() {
 		return reference.Targets{}
@@ -36,55 +40,58 @@ func (set Set) ReferenceTargets(ctx context.Context, targetCtx *TargetContext) r
 		}
 	}
 
+	if targetCtx == nil {
+		// treat element targets as 1st class ones
+		// if the list itself isn't targetable
+		return elemTargets
+	}
+
+	return set.wholeSetReferenceTargets(targetCtx, elemTargets)
+}
+
+func (set Set) wholeSetReferenceTargets(targetCtx *TargetContext, nestedTargets reference.Targets) reference.Targets {
 	targets := make(reference.Targets, 0)
 
-	if targetCtx != nil {
-		// collect target for the whole set
+	// collect target for the whole set
 
-		var rangePtr *hcl.Range
-		if targetCtx.ParentRangePtr != nil {
-			rangePtr = targetCtx.ParentRangePtr
-		} else {
-			rangePtr = set.expr.Range().Ptr()
-		}
+	var rangePtr *hcl.Range
+	if targetCtx.ParentRangePtr != nil {
+		rangePtr = targetCtx.ParentRangePtr
+	} else {
+		rangePtr = set.expr.Range().Ptr()
+	}
 
-		// type-aware
-		elemCons, ok := set.cons.Elem.(schema.TypeAwareConstraint)
-		if targetCtx.AsExprType && ok {
-			elemType, ok := elemCons.ConstraintType()
-			if ok {
-				targets = append(targets, reference.Target{
-					Addr:                   targetCtx.ParentAddress,
-					Name:                   targetCtx.FriendlyName,
-					Type:                   cty.Set(elemType),
-					ScopeId:                targetCtx.ScopeId,
-					RangePtr:               rangePtr,
-					DefRangePtr:            targetCtx.ParentDefRangePtr,
-					NestedTargets:          elemTargets,
-					LocalAddr:              targetCtx.ParentLocalAddress,
-					TargetableFromRangePtr: targetCtx.TargetableFromRangePtr,
-				})
-			}
-		}
-
-		// type-unaware
-		if targetCtx.AsReference {
+	// type-aware
+	elemCons, ok := set.cons.Elem.(schema.TypeAwareConstraint)
+	if targetCtx.AsExprType && ok {
+		elemType, ok := elemCons.ConstraintType()
+		if ok {
 			targets = append(targets, reference.Target{
 				Addr:                   targetCtx.ParentAddress,
 				Name:                   targetCtx.FriendlyName,
+				Type:                   cty.Set(elemType),
 				ScopeId:                targetCtx.ScopeId,
 				RangePtr:               rangePtr,
 				DefRangePtr:            targetCtx.ParentDefRangePtr,
-				NestedTargets:          elemTargets,
+				NestedTargets:          nestedTargets,
 				LocalAddr:              targetCtx.ParentLocalAddress,
 				TargetableFromRangePtr: targetCtx.TargetableFromRangePtr,
 			})
 		}
-	} else {
-		// treat element targets as 1st class ones
-		// if the list itself isn't targetable
-		targets = elemTargets
 	}
 
+	// type-unaware
+	if targetCtx.AsReference {
+		targets = append(targets, reference.Target{
+			Addr:                   targetCtx.ParentAddress,
+			Name:                   targetCtx.FriendlyName,
+			ScopeId:                targetCtx.ScopeId,
+			RangePtr:               rangePtr,
+			DefRangePtr:            targetCtx.ParentDefRangePtr,
+			NestedTargets:          nestedTargets,
+			LocalAddr:              targetCtx.ParentLocalAddress,
+			TargetableFromRangePtr: targetCtx.TargetableFromRangePtr,
+		})
+	}
 	return targets
 }

--- a/decoder/expr_set_ref_targets_test.go
+++ b/decoder/expr_set_ref_targets_test.go
@@ -285,6 +285,147 @@ func TestCollectRefTargets_exprSet_hcl(t *testing.T) {
 	}
 }
 
+func TestCollectRefTargets_exprSet_implied_hcl(t *testing.T) {
+	testCases := []struct {
+		testName           string
+		bodySchema         *schema.BodySchema
+		cfg                string
+		expectedRefTargets reference.Targets
+	}{
+		{
+			"undeclared implied as type",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"blk": {
+						Address: &schema.BlockAddrSchema{
+							Steps: schema.Address{
+								schema.StaticStep{Name: "blk"},
+							},
+							BodyAsData: true,
+							InferBody:  true,
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"attr": {
+									Constraint: schema.Set{
+										Elem: schema.LiteralType{Type: cty.Bool},
+									},
+									IsOptional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			`blk {}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "blk"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 7, Byte: 6},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 4, Byte: 3},
+					},
+					Type: cty.Object(map[string]cty.Type{
+						"attr": cty.Set(cty.Bool),
+					}),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "blk"},
+								lang.AttrStep{Name: "attr"},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 1, Column: 5, Byte: 4},
+								End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+							},
+							Type: cty.Set(cty.Bool),
+						},
+					},
+				},
+			},
+		},
+		{
+			"undeclared as reference",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"blk": {
+						Address: &schema.BlockAddrSchema{
+							Steps: schema.Address{
+								schema.StaticStep{Name: "blk"},
+							},
+							AsReference: true,
+							ScopeId:     lang.ScopeId("foo"),
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"attr": {
+									Constraint: schema.Set{
+										Elem: schema.LiteralType{Type: cty.Bool},
+									},
+									IsOptional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			`blk {}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "blk"},
+					},
+					ScopeId: lang.ScopeId("foo"),
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 7, Byte: 6},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 4, Byte: 3},
+					},
+				},
+			},
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := tc.bodySchema
+
+			f, diags := hclsyntax.ParseConfig([]byte(tc.cfg), "test.hcl", hcl.InitialPos)
+			if len(diags) > 0 {
+				t.Log(diags)
+			}
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.hcl": f,
+				},
+			})
+
+			targets, err := d.CollectReferenceTargets()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedRefTargets, targets, ctydebug.CmpOptions); diff != "" {
+				t.Fatalf("unexpected targets: %s", diff)
+			}
+		})
+	}
+}
+
 func TestCollectRefTargets_exprSet_json(t *testing.T) {
 	testCases := []struct {
 		testName           string
@@ -532,6 +673,147 @@ func TestCollectRefTargets_exprSet_json(t *testing.T) {
 			bodySchema := &schema.BodySchema{
 				Attributes: tc.attrSchema,
 			}
+
+			f, diags := json.ParseWithStartPos([]byte(tc.cfg), "test.hcl.json", hcl.InitialPos)
+			if len(diags) > 0 {
+				t.Error(diags)
+			}
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.hcl.json": f,
+				},
+			})
+
+			targets, err := d.CollectReferenceTargets()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedRefTargets, targets, ctydebug.CmpOptions); diff != "" {
+				t.Fatalf("unexpected targets: %s", diff)
+			}
+		})
+	}
+}
+
+func TestCollectRefTargets_exprSet_implied_json(t *testing.T) {
+	testCases := []struct {
+		testName           string
+		bodySchema         *schema.BodySchema
+		cfg                string
+		expectedRefTargets reference.Targets
+	}{
+		{
+			"undeclared implied as type",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"blk": {
+						Address: &schema.BlockAddrSchema{
+							Steps: schema.Address{
+								schema.StaticStep{Name: "blk"},
+							},
+							BodyAsData: true,
+							InferBody:  true,
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"attr": {
+									Constraint: schema.Set{
+										Elem: schema.LiteralType{Type: cty.Bool},
+									},
+									IsOptional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			`{"blk": {}}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "blk"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						End:      hcl.Pos{Line: 1, Column: 11, Byte: 10},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+					},
+					Type: cty.Object(map[string]cty.Type{
+						"attr": cty.Set(cty.Bool),
+					}),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "blk"},
+								lang.AttrStep{Name: "attr"},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+								End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+							},
+							Type: cty.Set(cty.Bool),
+						},
+					},
+				},
+			},
+		},
+		{
+			"undeclared as reference",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"blk": {
+						Address: &schema.BlockAddrSchema{
+							Steps: schema.Address{
+								schema.StaticStep{Name: "blk"},
+							},
+							AsReference: true,
+							ScopeId:     lang.ScopeId("foo"),
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"attr": {
+									Constraint: schema.Set{
+										Elem: schema.LiteralType{Type: cty.Bool},
+									},
+									IsOptional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			`{"blk": {}}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "blk"},
+					},
+					ScopeId: lang.ScopeId("foo"),
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						End:      hcl.Pos{Line: 1, Column: 11, Byte: 10},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+					},
+				},
+			},
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := tc.bodySchema
 
 			f, diags := json.ParseWithStartPos([]byte(tc.cfg), "test.hcl.json", hcl.InitialPos)
 			if len(diags) > 0 {

--- a/decoder/expr_tuple_ref_targets.go
+++ b/decoder/expr_tuple_ref_targets.go
@@ -13,6 +13,10 @@ import (
 )
 
 func (tuple Tuple) ReferenceTargets(ctx context.Context, targetCtx *TargetContext) reference.Targets {
+	if isEmptyExpression(tuple.expr) && targetCtx != nil {
+		return tuple.wholeTupleReferenceTargets(targetCtx, tuple.collectTupleElemTargets(ctx, targetCtx, []hcl.Expression{}))
+	}
+
 	elems, diags := hcl.ExprList(tuple.expr)
 	if diags.HasErrors() {
 		return reference.Targets{}
@@ -22,14 +26,29 @@ func (tuple Tuple) ReferenceTargets(ctx context.Context, targetCtx *TargetContex
 		return reference.Targets{}
 	}
 
+	elemTargets := tuple.collectTupleElemTargets(ctx, targetCtx, elems)
+
+	if targetCtx == nil {
+		// treat element targets as 1st class ones
+		// if the tuple itself isn't targetable
+		return elemTargets
+	}
+
+	return tuple.wholeTupleReferenceTargets(targetCtx, elemTargets)
+}
+
+func (tuple Tuple) collectTupleElemTargets(ctx context.Context, targetCtx *TargetContext, declaredElems []hcl.Expression) reference.Targets {
 	elemTargets := make(reference.Targets, 0)
 
-	for i, elemExpr := range elems {
-		if i+1 > len(tuple.cons.Elems) {
-			break
+	for i, elemCons := range tuple.cons.Elems {
+		var elemExpr hcl.Expression
+		if len(declaredElems) >= i+1 {
+			elemExpr = declaredElems[i]
+		} else {
+			elemExpr = newEmptyExpressionAtPos(tuple.expr.Range().Filename, tuple.expr.Range().Start)
 		}
 
-		expr := newExpression(tuple.pathCtx, elemExpr, tuple.cons.Elems[i])
+		expr := newExpression(tuple.pathCtx, elemExpr, elemCons)
 		if e, ok := expr.(ReferenceTargetsExpression); ok {
 			if targetCtx == nil {
 				// collect any targets inside the expression
@@ -51,53 +70,51 @@ func (tuple Tuple) ReferenceTargets(ctx context.Context, targetCtx *TargetContex
 		}
 	}
 
+	return elemTargets
+}
+
+func (tuple Tuple) wholeTupleReferenceTargets(targetCtx *TargetContext, nestedTargets reference.Targets) reference.Targets {
 	targets := make(reference.Targets, 0)
 
-	if targetCtx != nil {
-		// collect target for the whole tuple
+	// collect target for the whole tuple
 
-		var rangePtr *hcl.Range
-		if targetCtx.ParentRangePtr != nil {
-			rangePtr = targetCtx.ParentRangePtr
-		} else {
-			rangePtr = tuple.expr.Range().Ptr()
-		}
+	var rangePtr *hcl.Range
+	if targetCtx.ParentRangePtr != nil {
+		rangePtr = targetCtx.ParentRangePtr
+	} else {
+		rangePtr = tuple.expr.Range().Ptr()
+	}
 
-		// type-aware
-		elemType, ok := tuple.cons.ConstraintType()
-		if targetCtx.AsExprType && ok {
-			if ok {
-				targets = append(targets, reference.Target{
-					Addr:                   targetCtx.ParentAddress,
-					Name:                   targetCtx.FriendlyName,
-					Type:                   elemType,
-					ScopeId:                targetCtx.ScopeId,
-					RangePtr:               rangePtr,
-					DefRangePtr:            targetCtx.ParentDefRangePtr,
-					NestedTargets:          elemTargets,
-					LocalAddr:              targetCtx.ParentLocalAddress,
-					TargetableFromRangePtr: targetCtx.TargetableFromRangePtr,
-				})
-			}
-		}
-
-		// type-unaware
-		if targetCtx.AsReference {
+	// type-aware
+	elemType, ok := tuple.cons.ConstraintType()
+	if targetCtx.AsExprType && ok {
+		if ok {
 			targets = append(targets, reference.Target{
 				Addr:                   targetCtx.ParentAddress,
 				Name:                   targetCtx.FriendlyName,
+				Type:                   elemType,
 				ScopeId:                targetCtx.ScopeId,
 				RangePtr:               rangePtr,
 				DefRangePtr:            targetCtx.ParentDefRangePtr,
-				NestedTargets:          elemTargets,
+				NestedTargets:          nestedTargets,
 				LocalAddr:              targetCtx.ParentLocalAddress,
 				TargetableFromRangePtr: targetCtx.TargetableFromRangePtr,
 			})
 		}
-	} else {
-		// treat element targets as 1st class ones
-		// if the tuple itself isn't targetable
-		targets = elemTargets
+	}
+
+	// type-unaware
+	if targetCtx.AsReference {
+		targets = append(targets, reference.Target{
+			Addr:                   targetCtx.ParentAddress,
+			Name:                   targetCtx.FriendlyName,
+			ScopeId:                targetCtx.ScopeId,
+			RangePtr:               rangePtr,
+			DefRangePtr:            targetCtx.ParentDefRangePtr,
+			NestedTargets:          nestedTargets,
+			LocalAddr:              targetCtx.ParentLocalAddress,
+			TargetableFromRangePtr: targetCtx.TargetableFromRangePtr,
+		})
 	}
 
 	return targets

--- a/decoder/expr_tuple_ref_targets_test.go
+++ b/decoder/expr_tuple_ref_targets_test.go
@@ -134,8 +134,21 @@ func TestCollectRefTargets_exprTuple_hcl(t *testing.T) {
 						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
 						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
 					},
-					Type:          cty.Tuple([]cty.Type{cty.String}),
-					NestedTargets: reference.Targets{},
+					Type: cty.Tuple([]cty.Type{cty.String}),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.NumberIntVal(0)},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+								End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							},
+							Type: cty.String,
+						},
+					},
 				},
 			},
 		},
@@ -615,8 +628,21 @@ func TestCollectRefTargets_exprTuple_json(t *testing.T) {
 						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
 						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
 					},
-					Type:          cty.Tuple([]cty.Type{cty.String}),
-					NestedTargets: reference.Targets{},
+					Type: cty.Tuple([]cty.Type{cty.String}),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.NumberIntVal(0)},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+								End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+							},
+							Type: cty.String,
+						},
+					},
 				},
 			},
 		},

--- a/decoder/expr_tuple_ref_targets_test.go
+++ b/decoder/expr_tuple_ref_targets_test.go
@@ -507,6 +507,166 @@ func TestCollectRefTargets_exprTuple_hcl(t *testing.T) {
 	}
 }
 
+func TestCollectRefTargets_exprTuple_implied_hcl(t *testing.T) {
+	testCases := []struct {
+		testName           string
+		bodySchema         *schema.BodySchema
+		cfg                string
+		expectedRefTargets reference.Targets
+	}{
+		{
+			"undeclared implied as type",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"blk": {
+						Address: &schema.BlockAddrSchema{
+							Steps: schema.Address{
+								schema.StaticStep{Name: "blk"},
+							},
+							BodyAsData: true,
+							InferBody:  true,
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"attr": {
+									Constraint: schema.Tuple{
+										Elems: []schema.Constraint{
+											schema.LiteralType{Type: cty.Bool},
+										},
+									},
+									IsOptional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			`blk {}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "blk"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 7, Byte: 6},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 4, Byte: 3},
+					},
+					Type: cty.Object(map[string]cty.Type{
+						"attr": cty.Tuple([]cty.Type{cty.Bool}),
+					}),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "blk"},
+								lang.AttrStep{Name: "attr"},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 1, Column: 5, Byte: 4},
+								End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+							},
+							Type: cty.Tuple([]cty.Type{cty.Bool}),
+							NestedTargets: reference.Targets{
+								{
+									Addr: lang.Address{
+										lang.RootStep{Name: "blk"},
+										lang.AttrStep{Name: "attr"},
+										lang.IndexStep{Key: cty.NumberIntVal(0)},
+									},
+									RangePtr: &hcl.Range{
+										Filename: "test.hcl",
+										Start:    hcl.Pos{Line: 1, Column: 5, Byte: 4},
+										End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+									},
+									Type: cty.Bool,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"undeclared as reference",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"blk": {
+						Address: &schema.BlockAddrSchema{
+							Steps: schema.Address{
+								schema.StaticStep{Name: "blk"},
+							},
+							AsReference: true,
+							ScopeId:     lang.ScopeId("foo"),
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"attr": {
+									Constraint: schema.Tuple{
+										Elems: []schema.Constraint{
+											schema.LiteralType{Type: cty.Bool},
+										},
+									},
+									IsOptional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			`blk {}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "blk"},
+					},
+					ScopeId: lang.ScopeId("foo"),
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 7, Byte: 6},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 4, Byte: 3},
+					},
+				},
+			},
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := tc.bodySchema
+
+			f, diags := hclsyntax.ParseConfig([]byte(tc.cfg), "test.hcl", hcl.InitialPos)
+			if len(diags) > 0 {
+				t.Log(diags)
+			}
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.hcl": f,
+				},
+			})
+
+			targets, err := d.CollectReferenceTargets()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedRefTargets, targets, ctydebug.CmpOptions); diff != "" {
+				t.Fatalf("unexpected targets: %s", diff)
+			}
+		})
+	}
+}
+
 func TestCollectRefTargets_exprTuple_json(t *testing.T) {
 	testCases := []struct {
 		testName           string
@@ -907,6 +1067,166 @@ func TestCollectRefTargets_exprTuple_json(t *testing.T) {
 			bodySchema := &schema.BodySchema{
 				Attributes: tc.attrSchema,
 			}
+
+			f, diags := json.ParseWithStartPos([]byte(tc.cfg), "test.hcl.json", hcl.InitialPos)
+			if len(diags) > 0 {
+				t.Error(diags)
+			}
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.hcl.json": f,
+				},
+			})
+
+			targets, err := d.CollectReferenceTargets()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedRefTargets, targets, ctydebug.CmpOptions); diff != "" {
+				t.Fatalf("unexpected targets: %s", diff)
+			}
+		})
+	}
+}
+
+func TestCollectRefTargets_exprTuple_implied_json(t *testing.T) {
+	testCases := []struct {
+		testName           string
+		bodySchema         *schema.BodySchema
+		cfg                string
+		expectedRefTargets reference.Targets
+	}{
+		{
+			"undeclared implied as type",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"blk": {
+						Address: &schema.BlockAddrSchema{
+							Steps: schema.Address{
+								schema.StaticStep{Name: "blk"},
+							},
+							BodyAsData: true,
+							InferBody:  true,
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"attr": {
+									Constraint: schema.Tuple{
+										Elems: []schema.Constraint{
+											schema.LiteralType{Type: cty.Bool},
+										},
+									},
+									IsOptional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			`{"blk": {}}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "blk"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						End:      hcl.Pos{Line: 1, Column: 11, Byte: 10},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+					},
+					Type: cty.Object(map[string]cty.Type{
+						"attr": cty.Tuple([]cty.Type{cty.Bool}),
+					}),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "blk"},
+								lang.AttrStep{Name: "attr"},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+								End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+							},
+							Type: cty.Tuple([]cty.Type{cty.Bool}),
+							NestedTargets: reference.Targets{
+								{
+									Addr: lang.Address{
+										lang.RootStep{Name: "blk"},
+										lang.AttrStep{Name: "attr"},
+										lang.IndexStep{Key: cty.NumberIntVal(0)},
+									},
+									RangePtr: &hcl.Range{
+										Filename: "test.hcl.json",
+										Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+										End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+									},
+									Type: cty.Bool,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"undeclared as reference",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"blk": {
+						Address: &schema.BlockAddrSchema{
+							Steps: schema.Address{
+								schema.StaticStep{Name: "blk"},
+							},
+							AsReference: true,
+							ScopeId:     lang.ScopeId("foo"),
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"attr": {
+									Constraint: schema.Tuple{
+										Elems: []schema.Constraint{
+											schema.LiteralType{Type: cty.Bool},
+										},
+									},
+									IsOptional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			`{"blk": {}}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "blk"},
+					},
+					ScopeId: lang.ScopeId("foo"),
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						End:      hcl.Pos{Line: 1, Column: 11, Byte: 10},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+					},
+				},
+			},
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := tc.bodySchema
 
 			f, diags := json.ParseWithStartPos([]byte(tc.cfg), "test.hcl.json", hcl.InitialPos)
 			if len(diags) > 0 {

--- a/decoder/reference_targets.go
+++ b/decoder/reference_targets.go
@@ -791,7 +791,7 @@ func (d *PathDecoder) collectInferredReferenceTargetsForBody(addr lang.Address, 
 
 		if aSchema.Constraint != nil {
 			if attrExpr == nil {
-				attrExpr = newEmptyExpressionAtPos(content.RangePtr.Filename, body.MissingItemRange().Start)
+				attrExpr = newEmptyExpressionAtPos(body.MissingItemRange().Filename, body.MissingItemRange().Start)
 			}
 			expr, ok := newExpression(d.pathCtx, attrExpr, aSchema.Constraint).(ReferenceTargetsExpression)
 			if ok {


### PR DESCRIPTION
## Context

Previously, as part of https://github.com/hashicorp/hcl-lang/pull/239 we forgot about the fact that complex expression types, such as `List`, `Set`, `Tuple`, `Map` or `Object` may end up being collected as reference targets in a context where there is no corresponding config/expression.

This is currently surfaced in the UX by references to any complex types missing unless explicitly declared:

![2023-04-05 21 52 52](https://user-images.githubusercontent.com/287584/230209046-d32a75b6-e7de-4640-afa1-d6d3a53329bd.gif)

## Proposal (fix)

- [x] Collect `List` targets for empty expression
  - [x] Cover with tests (AsExprType + AsReference)
- [x] Collect `Set` targets for empty expression
  - [x] Cover with tests (AsExprType + AsReference)
- [x] Collect `Map` targets for empty expression
  - [x] Cover with tests (AsExprType + AsReference)
- [x] Collect `Tuple` targets for empty expression (including nested expressions for each element in `Elems`)
  - [x] Cover with tests (AsExprType + AsReference)
- [x] Collect `Object` targets for empty expression (including nested expressions for each attribute in `Attributes`)
  - [x] Cover with tests (AsExprType + AsReference)