### PR TITLE
decoder: Reflect `LiteralValue` `Description` & `IsDeprecated` in completion/hover

### DIFF
--- a/decoder/expr_any_completion_test.go
+++ b/decoder/expr_any_completion_test.go
@@ -1324,7 +1324,7 @@ func TestCompletionAtPos_exprAny_literalTypes(t *testing.T) {
 			`attr = [  ]
 `,
 			hcl.Pos{Line: 1, Column: 10, Byte: 9},
-			lang.CompleteCandidates(boolLiteralCandidates("", hcl.Range{
+			lang.CompleteCandidates(boolLiteralTypeCandidates("", hcl.Range{
 				Filename: "test.tf",
 				Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
 				End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
@@ -1344,7 +1344,7 @@ func TestCompletionAtPos_exprAny_literalTypes(t *testing.T) {
 ]
 `,
 			hcl.Pos{Line: 2, Column: 3, Byte: 11},
-			lang.CompleteCandidates(boolLiteralCandidates("", hcl.Range{
+			lang.CompleteCandidates(boolLiteralTypeCandidates("", hcl.Range{
 				Filename: "test.tf",
 				Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
 				End:      hcl.Pos{Line: 2, Column: 3, Byte: 11},
@@ -1362,7 +1362,7 @@ func TestCompletionAtPos_exprAny_literalTypes(t *testing.T) {
 			`attr = [ false,  ]
 `,
 			hcl.Pos{Line: 1, Column: 17, Byte: 16},
-			lang.CompleteCandidates(boolLiteralCandidates("", hcl.Range{
+			lang.CompleteCandidates(boolLiteralTypeCandidates("", hcl.Range{
 				Filename: "test.tf",
 				Start:    hcl.Pos{Line: 1, Column: 17, Byte: 16},
 				End:      hcl.Pos{Line: 1, Column: 17, Byte: 16},
@@ -1383,7 +1383,7 @@ func TestCompletionAtPos_exprAny_literalTypes(t *testing.T) {
 ]
 `,
 			hcl.Pos{Line: 3, Column: 3, Byte: 20},
-			lang.CompleteCandidates(boolLiteralCandidates("", hcl.Range{
+			lang.CompleteCandidates(boolLiteralTypeCandidates("", hcl.Range{
 				Filename: "test.tf",
 				Start:    hcl.Pos{Line: 3, Column: 3, Byte: 20},
 				End:      hcl.Pos{Line: 3, Column: 3, Byte: 20},
@@ -1401,7 +1401,7 @@ func TestCompletionAtPos_exprAny_literalTypes(t *testing.T) {
 			`attr = [ false, ]
 `,
 			hcl.Pos{Line: 1, Column: 16, Byte: 15},
-			lang.CompleteCandidates(boolLiteralCandidates("", hcl.Range{
+			lang.CompleteCandidates(boolLiteralTypeCandidates("", hcl.Range{
 				Filename: "test.tf",
 				Start:    hcl.Pos{Line: 1, Column: 16, Byte: 15},
 				End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
@@ -1419,7 +1419,7 @@ func TestCompletionAtPos_exprAny_literalTypes(t *testing.T) {
 			`attr = [ false, ]
 `,
 			hcl.Pos{Line: 1, Column: 17, Byte: 16},
-			lang.CompleteCandidates(boolLiteralCandidates("", hcl.Range{
+			lang.CompleteCandidates(boolLiteralTypeCandidates("", hcl.Range{
 				Filename: "test.tf",
 				Start:    hcl.Pos{Line: 1, Column: 17, Byte: 16},
 				End:      hcl.Pos{Line: 1, Column: 17, Byte: 16},

--- a/decoder/expr_literal_type_completion.go
+++ b/decoder/expr_literal_type_completion.go
@@ -26,7 +26,7 @@ func (lt LiteralType) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.C
 
 		if typ.IsPrimitiveType() {
 			if typ == cty.Bool {
-				return boolLiteralCandidates("", editRange)
+				return boolLiteralTypeCandidates("", editRange)
 			}
 			return []lang.Candidate{}
 		}
@@ -141,7 +141,7 @@ func (lt LiteralType) completeBoolAtPos(ctx context.Context, pos hcl.Pos) []lang
 	case *hclsyntax.ScopeTraversalExpr:
 		prefixLen := pos.Byte - eType.Range().Start.Byte
 		prefix := eType.Traversal.RootName()[0:prefixLen]
-		return boolLiteralCandidates(prefix, eType.Range())
+		return boolLiteralTypeCandidates(prefix, eType.Range())
 
 	case *hclsyntax.LiteralValueExpr:
 		if eType.Val.Type() == cty.Bool {
@@ -151,14 +151,14 @@ func (lt LiteralType) completeBoolAtPos(ctx context.Context, pos hcl.Pos) []lang
 			}
 			prefixLen := pos.Byte - eType.Range().Start.Byte
 			prefix := value[0:prefixLen]
-			return boolLiteralCandidates(prefix, eType.Range())
+			return boolLiteralTypeCandidates(prefix, eType.Range())
 		}
 	}
 
 	return []lang.Candidate{}
 }
 
-func boolLiteralCandidates(prefix string, editRange hcl.Range) []lang.Candidate {
+func boolLiteralTypeCandidates(prefix string, editRange hcl.Range) []lang.Candidate {
 	candidates := make([]lang.Candidate, 0)
 
 	if strings.HasPrefix("false", prefix) {

--- a/decoder/expr_literal_type_completion_test.go
+++ b/decoder/expr_literal_type_completion_test.go
@@ -151,7 +151,7 @@ func TestCompletionAtPos_exprLiteralType(t *testing.T) {
 			`attr = [  ]
 `,
 			hcl.Pos{Line: 1, Column: 10, Byte: 9},
-			lang.CompleteCandidates(boolLiteralCandidates("", hcl.Range{
+			lang.CompleteCandidates(boolLiteralTypeCandidates("", hcl.Range{
 				Filename: "test.tf",
 				Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
 				End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
@@ -171,7 +171,7 @@ func TestCompletionAtPos_exprLiteralType(t *testing.T) {
 ]
 `,
 			hcl.Pos{Line: 2, Column: 3, Byte: 11},
-			lang.CompleteCandidates(boolLiteralCandidates("", hcl.Range{
+			lang.CompleteCandidates(boolLiteralTypeCandidates("", hcl.Range{
 				Filename: "test.tf",
 				Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
 				End:      hcl.Pos{Line: 2, Column: 3, Byte: 11},
@@ -189,7 +189,7 @@ func TestCompletionAtPos_exprLiteralType(t *testing.T) {
 			`attr = [ false,  ]
 `,
 			hcl.Pos{Line: 1, Column: 17, Byte: 16},
-			lang.CompleteCandidates(boolLiteralCandidates("", hcl.Range{
+			lang.CompleteCandidates(boolLiteralTypeCandidates("", hcl.Range{
 				Filename: "test.tf",
 				Start:    hcl.Pos{Line: 1, Column: 17, Byte: 16},
 				End:      hcl.Pos{Line: 1, Column: 17, Byte: 16},
@@ -210,7 +210,7 @@ func TestCompletionAtPos_exprLiteralType(t *testing.T) {
 ]
 `,
 			hcl.Pos{Line: 3, Column: 3, Byte: 20},
-			lang.CompleteCandidates(boolLiteralCandidates("", hcl.Range{
+			lang.CompleteCandidates(boolLiteralTypeCandidates("", hcl.Range{
 				Filename: "test.tf",
 				Start:    hcl.Pos{Line: 3, Column: 3, Byte: 20},
 				End:      hcl.Pos{Line: 3, Column: 3, Byte: 20},
@@ -228,7 +228,7 @@ func TestCompletionAtPos_exprLiteralType(t *testing.T) {
 			`attr = [ false, ]
 `,
 			hcl.Pos{Line: 1, Column: 16, Byte: 15},
-			lang.CompleteCandidates(boolLiteralCandidates("", hcl.Range{
+			lang.CompleteCandidates(boolLiteralTypeCandidates("", hcl.Range{
 				Filename: "test.tf",
 				Start:    hcl.Pos{Line: 1, Column: 16, Byte: 15},
 				End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
@@ -246,7 +246,7 @@ func TestCompletionAtPos_exprLiteralType(t *testing.T) {
 			`attr = [ false, ]
 `,
 			hcl.Pos{Line: 1, Column: 17, Byte: 16},
-			lang.CompleteCandidates(boolLiteralCandidates("", hcl.Range{
+			lang.CompleteCandidates(boolLiteralTypeCandidates("", hcl.Range{
 				Filename: "test.tf",
 				Start:    hcl.Pos{Line: 1, Column: 17, Byte: 16},
 				End:      hcl.Pos{Line: 1, Column: 17, Byte: 16},

--- a/decoder/expr_literal_value_completion_test.go
+++ b/decoder/expr_literal_value_completion_test.go
@@ -24,6 +24,40 @@ func TestCompletionAtPos_exprLiteralValue(t *testing.T) {
 		pos                hcl.Pos
 		expectedCandidates lang.Candidates
 	}{
+		// extra metadata
+		{
+			"bool",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralValue{
+						Value:        cty.StringVal("foo"),
+						IsDeprecated: true,
+						Description:  lang.Markdown("foobar"),
+					},
+				},
+			},
+			`attr = 
+`,
+			hcl.Pos{Line: 1, Column: 8, Byte: 7},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:        "foo",
+					Detail:       "string",
+					Kind:         lang.StringCandidateKind,
+					IsDeprecated: true,
+					Description:  lang.Markdown("foobar"),
+					TextEdit: lang.TextEdit{
+						NewText: `"foo"`,
+						Snippet: `"foo"`,
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+					},
+				},
+			}),
+		},
 		// primitive types
 		{
 			"bool",

--- a/decoder/expr_literal_value_hover.go
+++ b/decoder/expr_literal_value_hover.go
@@ -34,8 +34,13 @@ func (lv LiteralValue) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverD
 		}
 
 		if expr.IsStringLiteral() || isMultilineStringLiteral(expr) {
+			content := fmt.Sprintf(`_%s_`, typ.FriendlyName())
+			if lv.cons.Description.Value != "" {
+				content += "\n\n" + lv.cons.Description.Value
+			}
+
 			return &lang.HoverData{
-				Content: lang.Markdown(fmt.Sprintf(`_%s_`, typ.FriendlyName())),
+				Content: lang.Markdown(content),
 				Range:   expr.Range(),
 			}
 		}
@@ -57,8 +62,13 @@ func (lv LiteralValue) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverD
 			return nil
 		}
 
+		content := fmt.Sprintf(`_%s_`, typ.FriendlyName())
+		if lv.cons.Description.Value != "" {
+			content += "\n\n" + lv.cons.Description.Value
+		}
+
 		return &lang.HoverData{
-			Content: lang.Markdown(fmt.Sprintf(`_%s_`, typ.FriendlyName())),
+			Content: lang.Markdown(content),
 			Range:   expr.Range(),
 		}
 	}
@@ -97,6 +107,7 @@ func (lv LiteralValue) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverD
 			Elem: schema.LiteralType{
 				Type: typ.ElementType(),
 			},
+			Description: lv.cons.Description,
 		}
 
 		return newExpression(lv.pathCtx, expr, cons).HoverAtPos(ctx, pos)
@@ -141,6 +152,7 @@ func (lv LiteralValue) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverD
 			Elem: schema.LiteralType{
 				Type: typ.ElementType(),
 			},
+			Description: lv.cons.Description,
 		}
 
 		return newExpression(lv.pathCtx, expr, cons).HoverAtPos(ctx, pos)
@@ -154,7 +166,8 @@ func (lv LiteralValue) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverD
 
 		elemTypes := typ.TupleElementTypes()
 		cons := schema.Tuple{
-			Elems: make([]schema.Constraint, len(elemTypes)),
+			Elems:       make([]schema.Constraint, len(elemTypes)),
+			Description: lv.cons.Description,
 		}
 		for i, elemType := range elemTypes {
 			cons.Elems[i] = schema.LiteralType{
@@ -206,6 +219,7 @@ func (lv LiteralValue) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverD
 			Elem: schema.LiteralType{
 				Type: typ.ElementType(),
 			},
+			Description: lv.cons.Description,
 		}
 		return newExpression(lv.pathCtx, expr, cons).HoverAtPos(ctx, pos)
 	}
@@ -217,7 +231,8 @@ func (lv LiteralValue) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverD
 		}
 
 		cons := schema.Object{
-			Attributes: ctyObjectToObjectAttributes(typ),
+			Attributes:  ctyObjectToObjectAttributes(typ),
+			Description: lv.cons.Description,
 		}
 		return newExpression(lv.pathCtx, expr, cons).HoverAtPos(ctx, pos)
 	}

--- a/decoder/expr_literal_value_hover_test.go
+++ b/decoder/expr_literal_value_hover_test.go
@@ -24,6 +24,71 @@ func TestHoverAtPos_exprLiteralValue(t *testing.T) {
 		pos               hcl.Pos
 		expectedHoverData *lang.HoverData
 	}{
+		// extra metadata
+		{
+			"primitive with metadata",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralValue{
+						Value:       cty.BoolVal(false),
+						Description: lang.Markdown("foobar"),
+					},
+				},
+			},
+			`attr = false`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			&lang.HoverData{
+				Content: lang.Markdown("_bool_\n\nfoobar"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 13, Byte: 12},
+				},
+			},
+		},
+		{
+			"list with metadata",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralValue{
+						Value:       cty.ListValEmpty(cty.String),
+						Description: lang.Markdown("foobar"),
+					},
+				},
+			},
+			`attr = []`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			&lang.HoverData{
+				Content: lang.Markdown("_list of string_\n\nfoobar"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+				},
+			},
+		},
+		{
+			"map with metadata",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralValue{
+						Value:       cty.EmptyObjectVal,
+						Description: lang.Markdown("foobar"),
+					},
+				},
+			},
+			`attr = {}`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			&lang.HoverData{
+				Content: lang.Markdown("_object_\n\nfoobar"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+				},
+			},
+		},
+
 		// primitive types
 		{
 			"boolean",


### PR DESCRIPTION
As discovered in https://github.com/hashicorp/hcl-lang/pull/251

`LiteralValue` constraint (prior to this patch) ignores `Description` and `IsDeprecated` fields during completion and hover.

## Example UX Before

![2023-04-13 14 08 17](https://user-images.githubusercontent.com/287584/231768600-a245f6e8-12ba-4e71-8ed9-e62c73316207.gif)

## Example UX After

![2023-04-13 14 08 47](https://user-images.githubusercontent.com/287584/231768622-c9a9212d-c46f-4025-89d7-f3cdfe657ef3.gif)
