### PR TITLE
decoder: Display `Tuple` hover data on invalid element

### DIFF
--- a/decoder/expr_tuple_hover.go
+++ b/decoder/expr_tuple_hover.go
@@ -20,7 +20,9 @@ func (tuple Tuple) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData 
 
 	for i, elemExpr := range eType.Exprs {
 		if i+1 > len(tuple.cons.Elems) {
-			return nil
+			// fall back to details about whole tuple
+			// for invalid (unknown) elements
+			break
 		}
 
 		if elemExpr.Range().ContainsPos(pos) {

--- a/decoder/expr_tuple_hover_test.go
+++ b/decoder/expr_tuple_hover_test.go
@@ -328,6 +328,30 @@ func TestHoverAtPos_exprTuple(t *testing.T) {
 				},
 			},
 		},
+		{
+			"trailing unknown element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Tuple{
+						Elems: []schema.Constraint{
+							schema.Keyword{
+								Keyword: "keyword",
+							},
+						},
+					},
+				},
+			},
+			`attr = [ keyword, foobar ]`,
+			hcl.Pos{Line: 1, Column: 21, Byte: 20},
+			&lang.HoverData{
+				Content: lang.Markdown("_tuple_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 27, Byte: 26},
+				},
+			},
+		},
 	}
 
 	for i, tc := range testCases {


### PR DESCRIPTION
As discovered in #251 

I am not sure if this is the right/best UX, but it is the behaviour we had before, as per the test in #251 

## UX Before

![2023-04-13 15 13 57](https://user-images.githubusercontent.com/287584/231786769-ac063c56-0569-408c-8b35-fe43da548c8f.gif)

## UX After

![2023-04-13 14 25 04](https://user-images.githubusercontent.com/287584/231784756-f9371220-0eca-47bb-b539-e3923695d1e6.gif)
