### PR TITLE
fix(schema): crash when completing `LiteralType{Type: cty.Tuple}`

### DIFF
--- a/schema/constraint_literal_type.go
+++ b/schema/constraint_literal_type.go
@@ -106,7 +106,9 @@ func (lt LiteralType) EmptyCompletionData(ctx context.Context, nextPlaceholder i
 	}
 	if lt.Type.IsTupleType() {
 		types := lt.Type.TupleElementTypes()
-		tupleCons := Tuple{}
+		tupleCons := Tuple{
+			Elems: make([]Constraint, len(types)),
+		}
 		for i, typ := range types {
 			tupleCons.Elems[i] = LiteralType{
 				Type: typ,

--- a/schema/constraint_literal_type_test.go
+++ b/schema/constraint_literal_type_test.go
@@ -1,0 +1,121 @@
+package schema
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestLiteralType_EmptyCompletionData(t *testing.T) {
+	testCases := []struct {
+		typ                   cty.Type
+		prefillRequiredFields bool
+		expectedData          CompletionData
+	}{
+		{
+			cty.Bool,
+			false,
+			CompletionData{
+				NewText:         "false",
+				Snippet:         "${1:false}",
+				NextPlaceholder: 2,
+			},
+		},
+		{
+			cty.List(cty.String),
+			false,
+			CompletionData{
+				NewText:         `[ "value" ]`,
+				Snippet:         `[ "${1:value}" ]`,
+				NextPlaceholder: 2,
+			},
+		},
+		{
+			cty.Set(cty.String),
+			false,
+			CompletionData{
+				NewText:         `[ "value" ]`,
+				Snippet:         `[ "${1:value}" ]`,
+				NextPlaceholder: 2,
+			},
+		},
+		{
+			cty.Tuple([]cty.Type{}),
+			false,
+			CompletionData{
+				NewText:         "[ ]",
+				Snippet:         "[ ${1} ]",
+				NextPlaceholder: 2,
+			},
+		},
+		{
+			cty.Tuple([]cty.Type{cty.String, cty.Number}),
+			false,
+			CompletionData{
+				NewText:         `[ "value", 0 ]`,
+				Snippet:         `[ "${1:value}", ${2:0} ]`,
+				NextPlaceholder: 3,
+			},
+		},
+		{
+			cty.Map(cty.String),
+			false,
+			CompletionData{
+				NewText:         "{\n  \"name\" = \"value\"\n}",
+				Snippet:         "{\n  \"${1:name}\" = \"${2:value}\"\n}",
+				NextPlaceholder: 3,
+			},
+		},
+		{
+			cty.Object(map[string]cty.Type{}),
+			false,
+			CompletionData{
+				NewText:         "{\n  \n}",
+				Snippet:         "{\n  ${1}\n}",
+				NextPlaceholder: 2,
+			},
+		},
+		{
+			cty.Object(map[string]cty.Type{
+				"foo": cty.String,
+				"bar": cty.Number,
+			}),
+			false,
+			CompletionData{
+				NewText:         "{\n  \n}",
+				Snippet:         "{\n  ${1}\n}",
+				TriggerSuggest:  true,
+				NextPlaceholder: 2,
+			},
+		},
+		{
+			cty.Object(map[string]cty.Type{
+				"foo": cty.String,
+				"bar": cty.Number,
+			}),
+			true,
+			CompletionData{
+				NewText:         "{\n  bar = 0\n  foo = \"value\"\n}",
+				Snippet:         "{\n  bar = ${1:0}\n  foo = \"${2:value}\"\n}",
+				NextPlaceholder: 3,
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%2d-%s", i, tc.typ.FriendlyNameForConstraint()), func(t *testing.T) {
+			lt := LiteralType{
+				Type: tc.typ,
+			}
+			ctx := WithPrefillRequiredFields(context.Background(), tc.prefillRequiredFields)
+			cData := lt.EmptyCompletionData(ctx, 1, 0)
+
+			if diff := cmp.Diff(tc.expectedData, cData); diff != "" {
+				t.Fatalf("unexpected data: %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
As discovered in manual testing and in #251 

Completion of an attribute of `cty.Tuple` type would previously cause a crash.

I also decided to add some more tests to cover the (clearly non-trivial enough to hide a bug) `EmptyCompletionData()` method on `LiteralType`.

## UX Before

![2023-04-13 15 16 26](https://user-images.githubusercontent.com/287584/231787460-0b35f9ac-5f6d-469b-b70e-9202485e2880.gif)

## UX After

![2023-04-13 15 17 13](https://user-images.githubusercontent.com/287584/231787682-92bca530-2d7e-40b4-bab4-df2bed606591.gif)
