### PR TITLE
decoder: Implement `InferType` for complex expressions

### DIFF
--- a/decoder/expr_list.go
+++ b/decoder/expr_list.go
@@ -6,10 +6,59 @@ package decoder
 import (
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
 )
 
 type List struct {
 	expr    hcl.Expression
 	cons    schema.List
 	pathCtx *PathContext
+}
+
+func (list List) InferType() (cty.Type, bool) {
+	if isEmptyExpression(list.expr) {
+		return list.cons.ConstraintType()
+	}
+
+	elems, diags := hcl.ExprList(list.expr)
+	if diags.HasErrors() {
+		return list.cons.ConstraintType()
+	}
+
+	if len(elems) == 0 {
+		return list.cons.ConstraintType()
+	}
+
+	elemType, ok := list.inferExprListElemType(elems)
+	if !ok {
+		return list.cons.ConstraintType()
+	}
+
+	return cty.List(elemType), true
+}
+
+func (list List) inferExprListElemType(elems []hcl.Expression) (cty.Type, bool) {
+	var firstElemType cty.Type
+
+	// Try to infer element type from declared element expressions
+	for _, elemExpr := range elems {
+		elem, ok := newExpression(list.pathCtx, elemExpr, list.cons.Elem).(CanInferTypeExpression)
+		if !ok {
+			return cty.NilType, false
+		}
+		elemType, ok := elem.InferType()
+		if !ok {
+			return cty.NilType, false
+		}
+		if firstElemType == cty.NilType {
+			firstElemType = elemType
+			continue
+		}
+		if !firstElemType.Equals(elemType) {
+			// elements of mismatching type
+			return cty.NilType, false
+		}
+	}
+
+	return firstElemType, true
 }

--- a/decoder/expr_literal_value.go
+++ b/decoder/expr_literal_value.go
@@ -18,6 +18,8 @@ type LiteralValue struct {
 	pathCtx *PathContext
 }
 
+// TODO: InferType()
+
 func formatNumberVal(val cty.Value) string {
 	bf := val.AsBigFloat()
 

--- a/decoder/expr_map.go
+++ b/decoder/expr_map.go
@@ -6,10 +6,57 @@ package decoder
 import (
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
 )
 
 type Map struct {
 	expr    hcl.Expression
 	cons    schema.Map
 	pathCtx *PathContext
+}
+
+func (m Map) InferType() (cty.Type, bool) {
+	if isEmptyExpression(m.expr) {
+		return m.cons.ConstraintType()
+	}
+
+	elems, diags := hcl.ExprMap(m.expr)
+	if diags.HasErrors() {
+		return m.cons.ConstraintType()
+	}
+
+	if len(elems) == 0 {
+		return m.cons.ConstraintType()
+	}
+
+	elemType, ok := m.inferExprMapElemType(elems)
+	if !ok {
+		return m.cons.ConstraintType()
+	}
+
+	return cty.Map(elemType), true
+}
+
+func (m Map) inferExprMapElemType(kvPairs []hcl.KeyValuePair) (cty.Type, bool) {
+	var firstElemType cty.Type
+	for _, kvPair := range kvPairs {
+		elemExpr, ok := newExpression(m.pathCtx, kvPair.Value, m.cons.Elem).(CanInferTypeExpression)
+		if !ok {
+			return cty.NilType, false
+		}
+		elemType, ok := elemExpr.InferType()
+		if !ok {
+			return cty.NilType, false
+		}
+		if firstElemType == cty.NilType {
+			firstElemType = elemType
+			continue
+		}
+		if !firstElemType.Equals(elemType) {
+			// elements of mismatching type
+			return cty.NilType, false
+		}
+	}
+
+	return firstElemType, true
 }

--- a/decoder/expr_object.go
+++ b/decoder/expr_object.go
@@ -6,10 +6,71 @@ package decoder
 import (
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
 )
 
 type Object struct {
 	expr    hcl.Expression
 	cons    schema.Object
 	pathCtx *PathContext
+}
+
+func (obj Object) InferType() (cty.Type, bool) {
+	if isEmptyExpression(obj.expr) {
+		return obj.cons.ConstraintType()
+	}
+
+	elems, diags := hcl.ExprMap(obj.expr)
+	if diags.HasErrors() {
+		return obj.cons.ConstraintType()
+	}
+
+	if len(elems) == 0 {
+		return obj.cons.ConstraintType()
+	}
+
+	attrTypes, ok := obj.inferExprObjectAttrTypes(elems)
+	if !ok {
+		return obj.cons.ConstraintType()
+	}
+
+	return cty.Object(attrTypes), true
+}
+
+func (obj Object) inferExprObjectAttrTypes(kvPairs []hcl.KeyValuePair) (map[string]cty.Type, bool) {
+	declaredAttributes := make(map[string]hcl.Expression)
+	for _, kvPair := range kvPairs {
+		keyName, _, ok := rawObjectKey(kvPair.Key)
+		if !ok {
+			// avoid collecting pair w/ invalid key
+			continue
+		}
+
+		_, ok = obj.cons.Attributes[keyName]
+		if !ok {
+			// avoid collecting for unknown attribute
+			continue
+		}
+
+		declaredAttributes[keyName] = kvPair.Value
+	}
+
+	attrTypes := make(map[string]cty.Type)
+	for name, aSchema := range obj.cons.Attributes {
+		valueExpr, ok := declaredAttributes[name]
+		if !ok {
+			valueExpr = newEmptyExpressionAtPos(obj.expr.Range().Filename, obj.expr.Range().Start)
+		}
+
+		expr, ok := newExpression(obj.pathCtx, valueExpr, aSchema.Constraint).(CanInferTypeExpression)
+		if !ok {
+			return map[string]cty.Type{}, false
+		}
+		attrType, ok := expr.InferType()
+		if !ok {
+			return map[string]cty.Type{}, false
+		}
+		attrTypes[name] = attrType
+	}
+	return attrTypes, true
 }

--- a/decoder/expr_set.go
+++ b/decoder/expr_set.go
@@ -6,10 +6,59 @@ package decoder
 import (
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
 )
 
 type Set struct {
 	expr    hcl.Expression
 	cons    schema.Set
 	pathCtx *PathContext
+}
+
+func (set Set) InferType() (cty.Type, bool) {
+	if isEmptyExpression(set.expr) {
+		return set.cons.ConstraintType()
+	}
+
+	elems, diags := hcl.ExprList(set.expr)
+	if diags.HasErrors() {
+		return set.cons.ConstraintType()
+	}
+
+	if len(elems) == 0 {
+		return set.cons.ConstraintType()
+	}
+
+	elemType, ok := set.inferExprSetElemType(elems)
+	if !ok {
+		return set.cons.ConstraintType()
+	}
+
+	return cty.Set(elemType), true
+}
+
+func (set Set) inferExprSetElemType(elems []hcl.Expression) (cty.Type, bool) {
+	var firstElemType cty.Type
+
+	// Try to infer element type from declared element expressions
+	for _, elemExpr := range elems {
+		elem, ok := newExpression(set.pathCtx, elemExpr, set.cons.Elem).(CanInferTypeExpression)
+		if !ok {
+			return cty.NilType, false
+		}
+		elemType, ok := elem.InferType()
+		if !ok {
+			return cty.NilType, false
+		}
+		if firstElemType == cty.NilType {
+			firstElemType = elemType
+			continue
+		}
+		if !firstElemType.Equals(elemType) {
+			// elements of mismatching type
+			return cty.NilType, false
+		}
+	}
+
+	return firstElemType, true
 }

--- a/decoder/expr_tuple.go
+++ b/decoder/expr_tuple.go
@@ -6,10 +6,57 @@ package decoder
 import (
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
 )
 
 type Tuple struct {
 	expr    hcl.Expression
 	cons    schema.Tuple
 	pathCtx *PathContext
+}
+
+func (tuple Tuple) InferType() (cty.Type, bool) {
+	if isEmptyExpression(tuple.expr) {
+		return tuple.cons.ConstraintType()
+	}
+
+	elems, diags := hcl.ExprList(tuple.expr)
+	if diags.HasErrors() {
+		return tuple.cons.ConstraintType()
+	}
+
+	if len(elems) == 0 {
+		return tuple.cons.ConstraintType()
+	}
+
+	elemTypes, ok := tuple.inferExprTupleElemTypes(elems)
+	if !ok {
+		return tuple.cons.ConstraintType()
+	}
+
+	return cty.Tuple(elemTypes), true
+}
+
+func (tuple Tuple) inferExprTupleElemTypes(elems []hcl.Expression) ([]cty.Type, bool) {
+	elemTypes := make([]cty.Type, len(tuple.cons.Elems))
+
+	for i, elemCons := range tuple.cons.Elems {
+		if len(elems) < i+1 {
+			return []cty.Type{}, false
+		}
+
+		elemExpr := elems[i]
+		elem, ok := newExpression(tuple.pathCtx, elemExpr, elemCons).(CanInferTypeExpression)
+		if !ok {
+			return []cty.Type{}, false
+		}
+
+		elemType, ok := elem.InferType()
+		if !ok {
+			return []cty.Type{}, false
+		}
+		elemTypes[i] = elemType
+	}
+
+	return elemTypes, true
 }


### PR DESCRIPTION
As discovered in #251 

Related to https://github.com/hashicorp/hcl-lang/pull/247

One alternative (possibly simpler) solution here would be falling back to `ConstraintType()` of the corresponding constraint (List, Set, Tuple, Map, Object). I do see some benefits in the ability to _infer_ types though in the long run.

## UX Impact

There currently aren't any constraints in the Terraform schema involving "partially known" types as explained above, so there's no expected UX impact on Terraform LS users.

This was only discovered because some existing tests in #251 use the mentioned constraints.