### PR TITLE
decoder: Collect targets w/ interpolation for `Any` correctly

### DIFF
--- a/decoder/expr_any_ref_targets.go
+++ b/decoder/expr_any_ref_targets.go
@@ -8,17 +8,118 @@ import (
 
 	"github.com/hashicorp/hcl-lang/reference"
 	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
 )
 
 func (a Any) ReferenceTargets(ctx context.Context, targetCtx *TargetContext) reference.Targets {
-	expr := OneOf{
-		pathCtx: a.pathCtx,
-		expr:    a.expr,
-		cons: schema.OneOf{
-			schema.Reference{OfType: a.cons.OfType},
-			schema.LiteralType{Type: a.cons.OfType},
-		},
+	typ := a.cons.OfType
+
+	if typ == cty.DynamicPseudoType {
+		val, diags := a.expr.Value(&hcl.EvalContext{})
+		if !diags.HasErrors() {
+			typ = val.Type()
+		}
 	}
 
-	return expr.ReferenceTargets(ctx, targetCtx)
+	if targetCtx == nil || len(targetCtx.ParentAddress) == 0 {
+		return reference.Targets{}
+	}
+
+	if typ.IsPrimitiveType() || typ == cty.DynamicPseudoType {
+		var rangePtr *hcl.Range
+		if targetCtx.ParentRangePtr != nil {
+			rangePtr = targetCtx.ParentRangePtr
+		} else {
+			rangePtr = a.expr.Range().Ptr()
+		}
+
+		var refType cty.Type
+		if targetCtx.AsExprType {
+			refType = typ
+		}
+
+		return reference.Targets{
+			{
+				Addr:                   targetCtx.ParentAddress,
+				LocalAddr:              targetCtx.ParentLocalAddress,
+				TargetableFromRangePtr: targetCtx.TargetableFromRangePtr,
+				ScopeId:                targetCtx.ScopeId,
+				RangePtr:               rangePtr,
+				DefRangePtr:            targetCtx.ParentDefRangePtr,
+				Type:                   refType,
+			},
+		}
+	}
+
+	if typ.IsListType() {
+		list := List{
+			cons: schema.List{
+				Elem: schema.LiteralType{
+					Type: typ.ElementType(),
+				},
+			},
+			expr:    a.expr,
+			pathCtx: a.pathCtx,
+		}
+		return list.ReferenceTargets(ctx, targetCtx)
+	}
+
+	if typ.IsSetType() {
+		set := Set{
+			cons: schema.Set{
+				Elem: schema.LiteralType{
+					Type: typ.ElementType(),
+				},
+			},
+			expr:    a.expr,
+			pathCtx: a.pathCtx,
+		}
+		return set.ReferenceTargets(ctx, targetCtx)
+	}
+
+	if typ.IsTupleType() {
+		elemTypes := typ.TupleElementTypes()
+		cons := schema.Tuple{
+			Elems: make([]schema.Constraint, len(elemTypes)),
+		}
+		for i, elemType := range elemTypes {
+			cons.Elems[i] = schema.LiteralType{
+				Type: elemType,
+			}
+		}
+		tuple := Tuple{
+			cons:    cons,
+			expr:    a.expr,
+			pathCtx: a.pathCtx,
+		}
+
+		return tuple.ReferenceTargets(ctx, targetCtx)
+	}
+
+	if typ.IsMapType() {
+		m := Map{
+			cons: schema.Map{
+				Elem: schema.LiteralType{
+					Type: typ.ElementType(),
+				},
+			},
+			expr:    a.expr,
+			pathCtx: a.pathCtx,
+		}
+		return m.ReferenceTargets(ctx, targetCtx)
+	}
+
+	if typ.IsObjectType() {
+		obj := Object{
+			cons: schema.Object{
+				Attributes: ctyObjectToObjectAttributes(typ),
+			},
+			expr:    a.expr,
+			pathCtx: a.pathCtx,
+		}
+		return obj.ReferenceTargets(ctx, targetCtx)
+	}
+
+	return reference.Targets{}
 }

--- a/decoder/expr_any_ref_targets_test.go
+++ b/decoder/expr_any_ref_targets_test.go
@@ -26,6 +26,74 @@ func TestCollectRefTargets_exprAny_hcl(t *testing.T) {
 		expectedRefTargets reference.Targets
 	}{
 		{
+			"constraint mismatch",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{OfType: cty.String},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`attr = keyword`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					Type: cty.String,
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 15, Byte: 14},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+			},
+		},
+		{
+			"bool",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{OfType: cty.Bool},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`attr = true`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					Type: cty.Bool,
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 12, Byte: 11},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+			},
+		},
+		{
 			"string",
 			map[string]*schema.AttributeSchema{
 				"attr": {
@@ -55,6 +123,1790 @@ func TestCollectRefTargets_exprAny_hcl(t *testing.T) {
 						Filename: "test.hcl",
 						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
 						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+			},
+		},
+		{
+			"number",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{OfType: cty.Number},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`attr = 42`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					Type: cty.Number,
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+			},
+		},
+		{
+			"list constraint mismatch",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.List(cty.Bool),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`attr = true`,
+			reference.Targets{},
+		},
+		{
+			"list empty type-aware",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.List(cty.String),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`attr = []`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+					Type:          cty.List(cty.String),
+					NestedTargets: reference.Targets{},
+				},
+			},
+		},
+		{
+			"list type-aware with invalid element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.List(cty.String),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`attr = ["one", foo, "two"]`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 27, Byte: 26},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+					Type: cty.List(cty.String),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.NumberIntVal(0)},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+								End:      hcl.Pos{Line: 1, Column: 14, Byte: 13},
+							},
+							Type: cty.String,
+						},
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.NumberIntVal(2)},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 1, Column: 21, Byte: 20},
+								End:      hcl.Pos{Line: 1, Column: 26, Byte: 25},
+							},
+							Type: cty.String,
+						},
+					},
+				},
+			},
+		},
+		{
+			"list type-unaware",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.List(cty.String),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						ScopeId:     lang.ScopeId("test"),
+						AsReference: true,
+					},
+				},
+			},
+			`attr = ["one", "two"]`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 22, Byte: 21},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+					ScopeId: lang.ScopeId("test"),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.NumberIntVal(0)},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+								End:      hcl.Pos{Line: 1, Column: 14, Byte: 13},
+							},
+							ScopeId: lang.ScopeId("test"),
+						},
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.NumberIntVal(1)},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 1, Column: 16, Byte: 15},
+								End:      hcl.Pos{Line: 1, Column: 21, Byte: 20},
+							},
+							ScopeId: lang.ScopeId("test"),
+						},
+					},
+				},
+			},
+		},
+		{
+			"list type-aware nested",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.List(cty.List(cty.String)),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`attr = [
+  ["one"],
+  ["two"],
+]
+`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 4, Column: 2, Byte: 32},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+					Type: cty.List(cty.List(cty.String)),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.NumberIntVal(0)},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+								End:      hcl.Pos{Line: 2, Column: 10, Byte: 18},
+							},
+							Type: cty.List(cty.String),
+							NestedTargets: reference.Targets{
+								{
+									Addr: lang.Address{
+										lang.RootStep{Name: "attr"},
+										lang.IndexStep{Key: cty.NumberIntVal(0)},
+										lang.IndexStep{Key: cty.NumberIntVal(0)},
+									},
+									Type: cty.String,
+									RangePtr: &hcl.Range{
+										Filename: "test.hcl",
+										Start:    hcl.Pos{Line: 2, Column: 4, Byte: 12},
+										End:      hcl.Pos{Line: 2, Column: 9, Byte: 17},
+									},
+								},
+							},
+						},
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.NumberIntVal(1)},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 22},
+								End:      hcl.Pos{Line: 3, Column: 10, Byte: 29},
+							},
+							Type: cty.List(cty.String),
+							NestedTargets: reference.Targets{
+								{
+									Addr: lang.Address{
+										lang.RootStep{Name: "attr"},
+										lang.IndexStep{Key: cty.NumberIntVal(1)},
+										lang.IndexStep{Key: cty.NumberIntVal(0)},
+									},
+									Type: cty.String,
+									RangePtr: &hcl.Range{
+										Filename: "test.hcl",
+										Start:    hcl.Pos{Line: 3, Column: 4, Byte: 23},
+										End:      hcl.Pos{Line: 3, Column: 9, Byte: 28},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"set constraint mismatch",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Set(cty.Bool),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`attr = true`,
+			reference.Targets{},
+		},
+		{
+			"set empty type-aware",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Set(cty.String),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`attr = []`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+					Type:          cty.Set(cty.String),
+					NestedTargets: reference.Targets{},
+				},
+			},
+		},
+		{
+			"set type-aware with invalid element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Set(cty.String),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`attr = ["one", foo, "two"]`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 27, Byte: 26},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+					Type:          cty.Set(cty.String),
+					NestedTargets: reference.Targets{},
+				},
+			},
+		},
+		{
+			"set type-unaware",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Set(cty.String),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						ScopeId:     lang.ScopeId("test"),
+						AsReference: true,
+					},
+				},
+			},
+			`attr = ["one", "two"]`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 22, Byte: 21},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+					ScopeId:       lang.ScopeId("test"),
+					NestedTargets: reference.Targets{},
+				},
+			},
+		},
+		{
+			"set type-aware nested",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Set(cty.Set(cty.String)),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`attr = [
+  ["one"],
+  ["two"],
+]
+`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 4, Column: 2, Byte: 32},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+					Type:          cty.Set(cty.Set(cty.String)),
+					NestedTargets: reference.Targets{},
+				},
+			},
+		},
+		{
+			"tuple constraint mismatch",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Tuple([]cty.Type{cty.Bool}),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`attr = true`,
+			reference.Targets{},
+		},
+		{
+			"tuple empty type-aware",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Tuple([]cty.Type{cty.String}),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`attr = []`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+					Type: cty.Tuple([]cty.Type{cty.String}),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.NumberIntVal(0)},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+								End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							},
+							Type: cty.String,
+						},
+					},
+				},
+			},
+		},
+		{
+			"tuple type-aware with invalid element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Tuple([]cty.Type{cty.String, cty.String, cty.Number}),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`attr = ["one", foo, 42224]`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 27, Byte: 26},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+					Type: cty.Tuple([]cty.Type{cty.String, cty.String, cty.Number}),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.NumberIntVal(0)},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+								End:      hcl.Pos{Line: 1, Column: 14, Byte: 13},
+							},
+							Type: cty.String,
+						},
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.NumberIntVal(2)},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 1, Column: 21, Byte: 20},
+								End:      hcl.Pos{Line: 1, Column: 26, Byte: 25},
+							},
+							Type: cty.Number,
+						},
+					},
+				},
+			},
+		},
+		{
+			"tuple type-aware with extra element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Tuple([]cty.Type{cty.String, cty.Number}),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`attr = ["one", 422, "two"]`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 27, Byte: 26},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+					Type: cty.Tuple([]cty.Type{cty.String, cty.Number}),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.NumberIntVal(0)},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+								End:      hcl.Pos{Line: 1, Column: 14, Byte: 13},
+							},
+							Type: cty.String,
+						},
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.NumberIntVal(1)},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 1, Column: 16, Byte: 15},
+								End:      hcl.Pos{Line: 1, Column: 19, Byte: 18},
+							},
+							Type: cty.Number,
+						},
+					},
+				},
+			},
+		},
+		{
+			"tuple type-unaware",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Tuple([]cty.Type{cty.String, cty.String}),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						ScopeId:     lang.ScopeId("test"),
+						AsReference: true,
+					},
+				},
+			},
+			`attr = ["one", "two"]`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 22, Byte: 21},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+					ScopeId: lang.ScopeId("test"),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.NumberIntVal(0)},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+								End:      hcl.Pos{Line: 1, Column: 14, Byte: 13},
+							},
+							ScopeId: lang.ScopeId("test"),
+						},
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.NumberIntVal(1)},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 1, Column: 16, Byte: 15},
+								End:      hcl.Pos{Line: 1, Column: 21, Byte: 20},
+							},
+							ScopeId: lang.ScopeId("test"),
+						},
+					},
+				},
+			},
+		},
+		{
+			"tuple type-aware nested",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Tuple([]cty.Type{
+							cty.Tuple([]cty.Type{
+								cty.String,
+							}),
+							cty.Tuple([]cty.Type{
+								cty.String,
+							}),
+						}),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`attr = [
+  ["one"],
+  ["two"],
+]
+`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 4, Column: 2, Byte: 32},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+					Type: cty.Tuple([]cty.Type{
+						cty.Tuple([]cty.Type{cty.String}),
+						cty.Tuple([]cty.Type{cty.String}),
+					}),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.NumberIntVal(0)},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+								End:      hcl.Pos{Line: 2, Column: 10, Byte: 18},
+							},
+							Type: cty.Tuple([]cty.Type{cty.String}),
+							NestedTargets: reference.Targets{
+								{
+									Addr: lang.Address{
+										lang.RootStep{Name: "attr"},
+										lang.IndexStep{Key: cty.NumberIntVal(0)},
+										lang.IndexStep{Key: cty.NumberIntVal(0)},
+									},
+									Type: cty.String,
+									RangePtr: &hcl.Range{
+										Filename: "test.hcl",
+										Start:    hcl.Pos{Line: 2, Column: 4, Byte: 12},
+										End:      hcl.Pos{Line: 2, Column: 9, Byte: 17},
+									},
+								},
+							},
+						},
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.NumberIntVal(1)},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 22},
+								End:      hcl.Pos{Line: 3, Column: 10, Byte: 29},
+							},
+							Type: cty.Tuple([]cty.Type{cty.String}),
+							NestedTargets: reference.Targets{
+								{
+									Addr: lang.Address{
+										lang.RootStep{Name: "attr"},
+										lang.IndexStep{Key: cty.NumberIntVal(1)},
+										lang.IndexStep{Key: cty.NumberIntVal(0)},
+									},
+									Type: cty.String,
+									RangePtr: &hcl.Range{
+										Filename: "test.hcl",
+										Start:    hcl.Pos{Line: 3, Column: 4, Byte: 23},
+										End:      hcl.Pos{Line: 3, Column: 9, Byte: 28},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"object constraint mismatch",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+							"foo": cty.String,
+						}, []string{"foo"}),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`attr = keyword`,
+			reference.Targets{},
+		},
+		{
+			"object empty type-aware",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.Number,
+						}, []string{"foo"}),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`attr = {}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					Type: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+						"foo": cty.String,
+						"bar": cty.Number,
+					}, []string{"foo"}),
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.AttrStep{Name: "bar"},
+							},
+							Type: cty.Number,
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+								End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							},
+						},
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.AttrStep{Name: "foo"},
+							},
+							Type: cty.String,
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+								End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"object type-aware with invalid key type",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.Number,
+						}, []string{"foo"}),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`attr = {
+  422 = "foo"
+  bar = 42
+}
+`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					Type: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+						"foo": cty.String,
+						"bar": cty.Number,
+					}, []string{"foo"}),
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 4, Column: 2, Byte: 35},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.AttrStep{Name: "bar"},
+							},
+							Type: cty.Number,
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 25},
+								End:      hcl.Pos{Line: 3, Column: 11, Byte: 33},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 25},
+								End:      hcl.Pos{Line: 3, Column: 6, Byte: 28},
+							},
+						},
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.AttrStep{Name: "foo"},
+							},
+							Type: cty.String,
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+								End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"object type-aware with invalid attribute name",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.Number,
+						}, []string{"foo"}),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`attr = {
+  fox = "foo"
+  bar = 42
+}
+`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					Type: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+						"foo": cty.String,
+						"bar": cty.Number,
+					}, []string{"foo"}),
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 4, Column: 2, Byte: 35},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.AttrStep{Name: "bar"},
+							},
+							Type: cty.Number,
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 25},
+								End:      hcl.Pos{Line: 3, Column: 11, Byte: 33},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 25},
+								End:      hcl.Pos{Line: 3, Column: 6, Byte: 28},
+							},
+						},
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.AttrStep{Name: "foo"},
+							},
+							Type: cty.String,
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+								End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"object type-aware with invalid value type",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.Number,
+						}, []string{"foo"}),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`attr = {
+  foo = 12345
+  bar = 42
+}
+`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					Type: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+						"foo": cty.String,
+						"bar": cty.Number,
+					}, []string{"foo"}),
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 4, Column: 2, Byte: 35},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.AttrStep{Name: "bar"},
+							},
+							Type: cty.Number,
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 25},
+								End:      hcl.Pos{Line: 3, Column: 11, Byte: 33},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 25},
+								End:      hcl.Pos{Line: 3, Column: 6, Byte: 28},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"object type-unaware",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.Number,
+						}, []string{"foo"}),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						ScopeId:     lang.ScopeId("test"),
+						AsReference: true,
+					},
+				},
+			},
+			`attr = {
+  foo = "foo"
+  bar = 42
+}
+`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					ScopeId: lang.ScopeId("test"),
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 4, Column: 2, Byte: 35},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.AttrStep{Name: "bar"},
+							},
+							ScopeId: lang.ScopeId("test"),
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 25},
+								End:      hcl.Pos{Line: 3, Column: 11, Byte: 33},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 25},
+								End:      hcl.Pos{Line: 3, Column: 6, Byte: 28},
+							},
+						},
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.AttrStep{Name: "foo"},
+							},
+							ScopeId: lang.ScopeId("test"),
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+								End:      hcl.Pos{Line: 2, Column: 14, Byte: 22},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+								End:      hcl.Pos{Line: 2, Column: 6, Byte: 14},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"object nested type-unaware",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Object{
+						Attributes: schema.ObjectAttributes{
+							"foo": {
+								Constraint: schema.AnyExpression{
+									OfType: cty.String,
+								},
+								IsOptional: true,
+							},
+							"bar": {
+								Constraint: schema.Object{
+									Attributes: schema.ObjectAttributes{
+										"baz": {
+											Constraint: schema.AnyExpression{
+												OfType: cty.String,
+											},
+											IsRequired: true,
+										},
+									},
+								},
+								IsRequired: true,
+							},
+						},
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`attr = {
+  foo = "foo"
+  bar = {
+    baz = "noot"
+  }
+}
+`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					Type: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+						"foo": cty.String,
+						"bar": cty.Object(map[string]cty.Type{
+							"baz": cty.String,
+						}),
+					}, []string{"foo"}),
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 6, Column: 2, Byte: 55},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.AttrStep{Name: "bar"},
+							},
+							Type: cty.Object(map[string]cty.Type{
+								"baz": cty.String,
+							}),
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 25},
+								End:      hcl.Pos{Line: 5, Column: 4, Byte: 53},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 25},
+								End:      hcl.Pos{Line: 3, Column: 6, Byte: 28},
+							},
+							NestedTargets: reference.Targets{
+								{
+									Addr: lang.Address{
+										lang.RootStep{Name: "attr"},
+										lang.AttrStep{Name: "bar"},
+										lang.AttrStep{Name: "baz"},
+									},
+									Type: cty.String,
+									RangePtr: &hcl.Range{
+										Filename: "test.hcl",
+										Start:    hcl.Pos{Line: 4, Column: 5, Byte: 37},
+										End:      hcl.Pos{Line: 4, Column: 17, Byte: 49},
+									},
+									DefRangePtr: &hcl.Range{
+										Filename: "test.hcl",
+										Start:    hcl.Pos{Line: 4, Column: 5, Byte: 37},
+										End:      hcl.Pos{Line: 4, Column: 8, Byte: 40},
+									},
+								},
+							},
+						},
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.AttrStep{Name: "foo"},
+							},
+							Type: cty.String,
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+								End:      hcl.Pos{Line: 2, Column: 14, Byte: 22},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+								End:      hcl.Pos{Line: 2, Column: 6, Byte: 14},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"map constraint mismatch",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Map(cty.String),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`attr = keyword`,
+			reference.Targets{},
+		},
+		{
+			"map empty type-aware",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Map(cty.String),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`attr = {}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					Type: cty.Map(cty.String),
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+					NestedTargets: reference.Targets{},
+				},
+			},
+		},
+		{
+			"map type-aware with invalid key type",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Map(cty.Number),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`attr = {
+  422 = "foo"
+  bar = 42
+}
+`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					Type: cty.Map(cty.Number),
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 4, Column: 2, Byte: 35},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.StringVal("bar")},
+							},
+							Type: cty.Number,
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 25},
+								End:      hcl.Pos{Line: 3, Column: 11, Byte: 33},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 25},
+								End:      hcl.Pos{Line: 3, Column: 6, Byte: 28},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"map type-aware with multiple items",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Map(cty.Number),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`attr = {
+  fox = 12345
+  bar = 42
+}
+`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					Type: cty.Map(cty.Number),
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 4, Column: 2, Byte: 35},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.StringVal("bar")},
+							},
+							Type: cty.Number,
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 25},
+								End:      hcl.Pos{Line: 3, Column: 11, Byte: 33},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 25},
+								End:      hcl.Pos{Line: 3, Column: 6, Byte: 28},
+							},
+						},
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.StringVal("fox")},
+							},
+							Type: cty.Number,
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+								End:      hcl.Pos{Line: 2, Column: 14, Byte: 22},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+								End:      hcl.Pos{Line: 2, Column: 6, Byte: 14},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"map type-aware with invalid value type",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Map(cty.Number),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`attr = {
+  foo = "foo"
+  bar = 42
+}
+`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					Type: cty.Map(cty.Number),
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 4, Column: 2, Byte: 35},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.StringVal("bar")},
+							},
+							Type: cty.Number,
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 25},
+								End:      hcl.Pos{Line: 3, Column: 11, Byte: 33},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 25},
+								End:      hcl.Pos{Line: 3, Column: 6, Byte: 28},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"map type-unaware",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Map(cty.Number),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						ScopeId:     lang.ScopeId("test"),
+						AsReference: true,
+					},
+				},
+			},
+			`attr = {
+  foo = 12345
+  bar = 42
+}
+`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					ScopeId: lang.ScopeId("test"),
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 4, Column: 2, Byte: 35},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.StringVal("bar")},
+							},
+							ScopeId: lang.ScopeId("test"),
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 25},
+								End:      hcl.Pos{Line: 3, Column: 11, Byte: 33},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 25},
+								End:      hcl.Pos{Line: 3, Column: 6, Byte: 28},
+							},
+						},
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.StringVal("foo")},
+							},
+							ScopeId: lang.ScopeId("test"),
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+								End:      hcl.Pos{Line: 2, Column: 14, Byte: 22},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+								End:      hcl.Pos{Line: 2, Column: 6, Byte: 14},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"map nested type-unaware",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Map(cty.Map(cty.String)),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`attr = {
+  foo = {   }
+  bar = {
+    baz = "noot"
+  }
+}
+`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					Type: cty.Map(cty.Map(cty.String)),
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 6, Column: 2, Byte: 55},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.StringVal("bar")},
+							},
+							Type: cty.Map(cty.String),
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 25},
+								End:      hcl.Pos{Line: 5, Column: 4, Byte: 53},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 25},
+								End:      hcl.Pos{Line: 3, Column: 6, Byte: 28},
+							},
+							NestedTargets: reference.Targets{
+								{
+									Addr: lang.Address{
+										lang.RootStep{Name: "attr"},
+										lang.IndexStep{Key: cty.StringVal("bar")},
+										lang.IndexStep{Key: cty.StringVal("baz")},
+									},
+									Type: cty.String,
+									RangePtr: &hcl.Range{
+										Filename: "test.hcl",
+										Start:    hcl.Pos{Line: 4, Column: 5, Byte: 37},
+										End:      hcl.Pos{Line: 4, Column: 17, Byte: 49},
+									},
+									DefRangePtr: &hcl.Range{
+										Filename: "test.hcl",
+										Start:    hcl.Pos{Line: 4, Column: 5, Byte: 37},
+										End:      hcl.Pos{Line: 4, Column: 8, Byte: 40},
+									},
+								},
+							},
+						},
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.StringVal("foo")},
+							},
+							Type: cty.Map(cty.String),
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+								End:      hcl.Pos{Line: 2, Column: 14, Byte: 22},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
+								End:      hcl.Pos{Line: 2, Column: 6, Byte: 14},
+							},
+							NestedTargets: reference.Targets{},
+						},
 					},
 				},
 			},
@@ -98,6 +1950,74 @@ func TestCollectRefTargets_exprAny_json(t *testing.T) {
 		expectedRefTargets reference.Targets
 	}{
 		{
+			"constraint mismatch",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{OfType: cty.String},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`{"attr": true}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					Type: cty.String,
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 14, Byte: 13},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					},
+				},
+			},
+		},
+		{
+			"bool",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{OfType: cty.Bool},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`{"attr": true}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					Type: cty.Bool,
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 14, Byte: 13},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					},
+				},
+			},
+		},
+		{
 			"string",
 			map[string]*schema.AttributeSchema{
 				"attr": {
@@ -127,6 +2047,1696 @@ func TestCollectRefTargets_exprAny_json(t *testing.T) {
 						Filename: "test.hcl.json",
 						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
 						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					},
+				},
+			},
+		},
+		{
+			"number",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{OfType: cty.Number},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`{"attr": 42}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					Type: cty.Number,
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 12, Byte: 11},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					},
+				},
+			},
+		},
+		{
+			"list constraint mismatch",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.List(cty.Bool),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`{"attr": true}`,
+			reference.Targets{},
+		},
+		{
+			"list empty type-aware",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.List(cty.String),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`{"attr": []}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 12, Byte: 11},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					},
+					Type:          cty.List(cty.String),
+					NestedTargets: reference.Targets{},
+				},
+			},
+		},
+		{
+			"list type-aware with invalid element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.List(cty.String),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`{"attr": ["one", 422, "two"]}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 29, Byte: 28},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					},
+					Type: cty.List(cty.String),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.NumberIntVal(0)},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 1, Column: 11, Byte: 10},
+								End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+							},
+							Type: cty.String,
+						},
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.NumberIntVal(2)},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 1, Column: 23, Byte: 22},
+								End:      hcl.Pos{Line: 1, Column: 28, Byte: 27},
+							},
+							Type: cty.String,
+						},
+					},
+				},
+			},
+		},
+		{
+			"list type-unaware",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.List(cty.String),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						ScopeId:     lang.ScopeId("test"),
+						AsReference: true,
+					},
+				},
+			},
+			`{"attr": ["one", "two"]}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 24, Byte: 23},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					},
+					ScopeId: lang.ScopeId("test"),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.NumberIntVal(0)},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 1, Column: 11, Byte: 10},
+								End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+							},
+							ScopeId: lang.ScopeId("test"),
+						},
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.NumberIntVal(1)},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 1, Column: 18, Byte: 17},
+								End:      hcl.Pos{Line: 1, Column: 23, Byte: 22},
+							},
+							ScopeId: lang.ScopeId("test"),
+						},
+					},
+				},
+			},
+		},
+		{
+			"list type-aware nested",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.List(cty.List(cty.String)),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`{"attr": [
+  ["one"],
+  ["two"]
+]}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 4, Column: 2, Byte: 33},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					},
+					Type: cty.List(cty.List(cty.String)),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.NumberIntVal(0)},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 13},
+								End:      hcl.Pos{Line: 2, Column: 10, Byte: 20},
+							},
+							Type: cty.List(cty.String),
+							NestedTargets: reference.Targets{
+								{
+									Addr: lang.Address{
+										lang.RootStep{Name: "attr"},
+										lang.IndexStep{Key: cty.NumberIntVal(0)},
+										lang.IndexStep{Key: cty.NumberIntVal(0)},
+									},
+									Type: cty.String,
+									RangePtr: &hcl.Range{
+										Filename: "test.hcl.json",
+										Start:    hcl.Pos{Line: 2, Column: 4, Byte: 14},
+										End:      hcl.Pos{Line: 2, Column: 9, Byte: 19},
+									},
+								},
+							},
+						},
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.NumberIntVal(1)},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 24},
+								End:      hcl.Pos{Line: 3, Column: 10, Byte: 31},
+							},
+							Type: cty.List(cty.String),
+							NestedTargets: reference.Targets{
+								{
+									Addr: lang.Address{
+										lang.RootStep{Name: "attr"},
+										lang.IndexStep{Key: cty.NumberIntVal(1)},
+										lang.IndexStep{Key: cty.NumberIntVal(0)},
+									},
+									Type: cty.String,
+									RangePtr: &hcl.Range{
+										Filename: "test.hcl.json",
+										Start:    hcl.Pos{Line: 3, Column: 4, Byte: 25},
+										End:      hcl.Pos{Line: 3, Column: 9, Byte: 30},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"set constraint mismatch",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Set(cty.Bool),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`{"attr": true}`,
+			reference.Targets{},
+		},
+		{
+			"set empty type-aware",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Set(cty.String),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`{"attr": []}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 12, Byte: 11},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					},
+					Type:          cty.Set(cty.String),
+					NestedTargets: reference.Targets{},
+				},
+			},
+		},
+		{
+			"set type-aware with invalid element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Set(cty.String),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`{"attr": ["one", 422, "two"]}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 29, Byte: 28},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					},
+					Type:          cty.Set(cty.String),
+					NestedTargets: reference.Targets{},
+				},
+			},
+		},
+		{
+			"set type-unaware",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Set(cty.String),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						ScopeId:     lang.ScopeId("test"),
+						AsReference: true,
+					},
+				},
+			},
+			`{"attr": ["one", "two"]}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 24, Byte: 23},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					},
+					ScopeId:       lang.ScopeId("test"),
+					NestedTargets: reference.Targets{},
+				},
+			},
+		},
+		{
+			"set type-aware nested",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Set(cty.Set(cty.String)),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`{"attr": [
+  ["one"],
+  ["two"]
+]}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 4, Column: 2, Byte: 33},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					},
+					Type:          cty.Set(cty.Set(cty.String)),
+					NestedTargets: reference.Targets{},
+				},
+			},
+		},
+		{
+			"tuple constraint mismatch",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Tuple([]cty.Type{cty.Bool}),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`{"attr": true}`,
+			reference.Targets{},
+		},
+		{
+			"tuple empty type-aware",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Tuple([]cty.Type{cty.String}),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`{"attr": []}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 12, Byte: 11},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					},
+					Type: cty.Tuple([]cty.Type{cty.String}),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.NumberIntVal(0)},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+								End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+							},
+							Type: cty.String,
+						},
+					},
+				},
+			},
+		},
+		{
+			"tuple type-aware with invalid element",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Tuple([]cty.Type{cty.String, cty.String, cty.Number}),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`{"attr": ["one", 422, 42223]}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 29, Byte: 28},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					},
+					Type: cty.Tuple([]cty.Type{cty.String, cty.String, cty.Number}),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.NumberIntVal(0)},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 1, Column: 11, Byte: 10},
+								End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+							},
+							Type: cty.String,
+						},
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.NumberIntVal(2)},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 1, Column: 23, Byte: 22},
+								End:      hcl.Pos{Line: 1, Column: 28, Byte: 27},
+							},
+							Type: cty.Number,
+						},
+					},
+				},
+			},
+		},
+		{
+			"tuple type-unaware",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Tuple([]cty.Type{cty.String, cty.String}),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						ScopeId:     lang.ScopeId("test"),
+						AsReference: true,
+					},
+				},
+			},
+			`{"attr": ["one", "two"]}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 24, Byte: 23},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					},
+					ScopeId: lang.ScopeId("test"),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.NumberIntVal(0)},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 1, Column: 11, Byte: 10},
+								End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+							},
+							ScopeId: lang.ScopeId("test"),
+						},
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.NumberIntVal(1)},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 1, Column: 18, Byte: 17},
+								End:      hcl.Pos{Line: 1, Column: 23, Byte: 22},
+							},
+							ScopeId: lang.ScopeId("test"),
+						},
+					},
+				},
+			},
+		},
+		{
+			"tuple type-aware nested",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Tuple([]cty.Type{
+							cty.Tuple([]cty.Type{cty.String}),
+							cty.Tuple([]cty.Type{cty.String}),
+						}),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`{"attr": [
+  ["one"],
+  ["two"]
+]}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 4, Column: 2, Byte: 33},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					},
+					Type: cty.Tuple([]cty.Type{
+						cty.Tuple([]cty.Type{cty.String}),
+						cty.Tuple([]cty.Type{cty.String}),
+					}),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.NumberIntVal(0)},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 13},
+								End:      hcl.Pos{Line: 2, Column: 10, Byte: 20},
+							},
+							Type: cty.Tuple([]cty.Type{cty.String}),
+							NestedTargets: reference.Targets{
+								{
+									Addr: lang.Address{
+										lang.RootStep{Name: "attr"},
+										lang.IndexStep{Key: cty.NumberIntVal(0)},
+										lang.IndexStep{Key: cty.NumberIntVal(0)},
+									},
+									Type: cty.String,
+									RangePtr: &hcl.Range{
+										Filename: "test.hcl.json",
+										Start:    hcl.Pos{Line: 2, Column: 4, Byte: 14},
+										End:      hcl.Pos{Line: 2, Column: 9, Byte: 19},
+									},
+								},
+							},
+						},
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.NumberIntVal(1)},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 24},
+								End:      hcl.Pos{Line: 3, Column: 10, Byte: 31},
+							},
+							Type: cty.Tuple([]cty.Type{cty.String}),
+							NestedTargets: reference.Targets{
+								{
+									Addr: lang.Address{
+										lang.RootStep{Name: "attr"},
+										lang.IndexStep{Key: cty.NumberIntVal(1)},
+										lang.IndexStep{Key: cty.NumberIntVal(0)},
+									},
+									Type: cty.String,
+									RangePtr: &hcl.Range{
+										Filename: "test.hcl.json",
+										Start:    hcl.Pos{Line: 3, Column: 4, Byte: 25},
+										End:      hcl.Pos{Line: 3, Column: 9, Byte: 30},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"object constraint mismatch",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+							"foo": cty.String,
+						}, []string{"foo"}),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`{"attr": true}`,
+			reference.Targets{},
+		},
+		{
+			"object empty type-aware",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.Number,
+						}, []string{"foo"}),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`{"attr": {}}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					Type: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+						"foo": cty.String,
+						"bar": cty.Number,
+					}, []string{"foo"}),
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 12, Byte: 11},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					},
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.AttrStep{Name: "bar"},
+							},
+							Type: cty.Number,
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+								End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+							},
+						},
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.AttrStep{Name: "foo"},
+							},
+							Type: cty.String,
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+								End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"object type-aware with invalid key type",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.Number,
+						}, []string{"foo"}),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`{"attr": {
+  "422": "foo",
+  "bar": 42
+}}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					Type: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+						"foo": cty.String,
+						"bar": cty.Number,
+					}, []string{"foo"}),
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 4, Column: 2, Byte: 40},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					},
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.AttrStep{Name: "bar"},
+							},
+							Type: cty.Number,
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 29},
+								End:      hcl.Pos{Line: 3, Column: 12, Byte: 38},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 29},
+								End:      hcl.Pos{Line: 3, Column: 8, Byte: 34},
+							},
+						},
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.AttrStep{Name: "foo"},
+							},
+							Type: cty.String,
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+								End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"object type-aware with invalid attribute name",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.Number,
+						}, []string{"foo"}),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`{"attr": {
+  "fox": "foo",
+  "bar": 42
+}}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					Type: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+						"foo": cty.String,
+						"bar": cty.Number,
+					}, []string{"foo"}),
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 4, Column: 2, Byte: 40},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					},
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.AttrStep{Name: "bar"},
+							},
+							Type: cty.Number,
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 29},
+								End:      hcl.Pos{Line: 3, Column: 12, Byte: 38},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 29},
+								End:      hcl.Pos{Line: 3, Column: 8, Byte: 34},
+							},
+						},
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.AttrStep{Name: "foo"},
+							},
+							Type: cty.String,
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+								End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"object type-aware with invalid value type",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.Number,
+						}, []string{"foo"}),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`{"attr": {
+  "foo": 12345,
+  "bar": 42
+}}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					Type: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+						"foo": cty.String,
+						"bar": cty.Number,
+					}, []string{"foo"}),
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 4, Column: 2, Byte: 40},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					},
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.AttrStep{Name: "bar"},
+							},
+							Type: cty.Number,
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 29},
+								End:      hcl.Pos{Line: 3, Column: 12, Byte: 38},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 29},
+								End:      hcl.Pos{Line: 3, Column: 8, Byte: 34},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"object type-unaware",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.Number,
+						}, []string{"foo"}),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						ScopeId:     lang.ScopeId("test"),
+						AsReference: true,
+					},
+				},
+			},
+			`{"attr": {
+  "foo": "foo",
+  "bar": 42
+}}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					ScopeId: lang.ScopeId("test"),
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 4, Column: 2, Byte: 40},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					},
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.AttrStep{Name: "bar"},
+							},
+							ScopeId: lang.ScopeId("test"),
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 29},
+								End:      hcl.Pos{Line: 3, Column: 12, Byte: 38},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 29},
+								End:      hcl.Pos{Line: 3, Column: 8, Byte: 34},
+							},
+						},
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.AttrStep{Name: "foo"},
+							},
+							ScopeId: lang.ScopeId("test"),
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 13},
+								End:      hcl.Pos{Line: 2, Column: 15, Byte: 25},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 13},
+								End:      hcl.Pos{Line: 2, Column: 8, Byte: 18},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"object nested type-unaware",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.Object(map[string]cty.Type{
+								"baz": cty.String,
+							}),
+						}, []string{"foo"}),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`{"attr": {
+  "foo": "foo",
+  "bar": {
+    "baz": "noot"
+  }
+}}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					Type: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+						"foo": cty.String,
+						"bar": cty.Object(map[string]cty.Type{
+							"baz": cty.String,
+						}),
+					}, []string{"foo"}),
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 6, Column: 2, Byte: 61},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					},
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.AttrStep{Name: "bar"},
+							},
+							Type: cty.Object(map[string]cty.Type{
+								"baz": cty.String,
+							}),
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 29},
+								End:      hcl.Pos{Line: 5, Column: 4, Byte: 59},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 29},
+								End:      hcl.Pos{Line: 3, Column: 8, Byte: 34},
+							},
+							NestedTargets: reference.Targets{
+								{
+									Addr: lang.Address{
+										lang.RootStep{Name: "attr"},
+										lang.AttrStep{Name: "bar"},
+										lang.AttrStep{Name: "baz"},
+									},
+									Type: cty.String,
+									RangePtr: &hcl.Range{
+										Filename: "test.hcl.json",
+										Start:    hcl.Pos{Line: 4, Column: 5, Byte: 42},
+										End:      hcl.Pos{Line: 4, Column: 18, Byte: 55},
+									},
+									DefRangePtr: &hcl.Range{
+										Filename: "test.hcl.json",
+										Start:    hcl.Pos{Line: 4, Column: 5, Byte: 42},
+										End:      hcl.Pos{Line: 4, Column: 10, Byte: 47},
+									},
+								},
+							},
+						},
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.AttrStep{Name: "foo"},
+							},
+							Type: cty.String,
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 13},
+								End:      hcl.Pos{Line: 2, Column: 15, Byte: 25},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 13},
+								End:      hcl.Pos{Line: 2, Column: 8, Byte: 18},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"map constraint mismatch",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Map(cty.String),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`{"attr": true}`,
+			reference.Targets{},
+		},
+		{
+			"map empty type-aware",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Map(cty.String),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`{"attr": {}}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					Type: cty.Map(cty.String),
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 12, Byte: 11},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					},
+					NestedTargets: reference.Targets{},
+				},
+			},
+		},
+		{
+			"map type-aware with invalid key type",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Map(cty.Number),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`{"attr": {
+  "422": "foo",
+  "bar": 42
+}}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					Type: cty.Map(cty.Number),
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 4, Column: 2, Byte: 40},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					},
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.StringVal("bar")},
+							},
+							Type: cty.Number,
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 29},
+								End:      hcl.Pos{Line: 3, Column: 12, Byte: 38},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 29},
+								End:      hcl.Pos{Line: 3, Column: 8, Byte: 34},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"map type-aware with multiple items",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Map(cty.Number),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`{"attr": {
+  "fox": 12345,
+  "bar": 42
+}}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					Type: cty.Map(cty.Number),
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 4, Column: 2, Byte: 40},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					},
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.StringVal("bar")},
+							},
+							Type: cty.Number,
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 29},
+								End:      hcl.Pos{Line: 3, Column: 12, Byte: 38},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 29},
+								End:      hcl.Pos{Line: 3, Column: 8, Byte: 34},
+							},
+						},
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.StringVal("fox")},
+							},
+							Type: cty.Number,
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 13},
+								End:      hcl.Pos{Line: 2, Column: 15, Byte: 25},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 13},
+								End:      hcl.Pos{Line: 2, Column: 8, Byte: 18},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"map type-aware with invalid value type",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Map(cty.Number),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`{"attr": {
+  "foo": "foo",
+  "bar": 42
+}}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					Type: cty.Map(cty.Number),
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 4, Column: 2, Byte: 40},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					},
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.StringVal("bar")},
+							},
+							Type: cty.Number,
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 29},
+								End:      hcl.Pos{Line: 3, Column: 12, Byte: 38},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 29},
+								End:      hcl.Pos{Line: 3, Column: 8, Byte: 34},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"map type-unaware",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Map(cty.Number),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						ScopeId:     lang.ScopeId("test"),
+						AsReference: true,
+					},
+				},
+			},
+			`{"attr": {
+  "foo": 12345,
+  "bar": 42
+}}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					ScopeId: lang.ScopeId("test"),
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 4, Column: 2, Byte: 40},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					},
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.StringVal("bar")},
+							},
+							ScopeId: lang.ScopeId("test"),
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 29},
+								End:      hcl.Pos{Line: 3, Column: 12, Byte: 38},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 29},
+								End:      hcl.Pos{Line: 3, Column: 8, Byte: 34},
+							},
+						},
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.StringVal("foo")},
+							},
+							ScopeId: lang.ScopeId("test"),
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 13},
+								End:      hcl.Pos{Line: 2, Column: 15, Byte: 25},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 13},
+								End:      hcl.Pos{Line: 2, Column: 8, Byte: 18},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"map nested type-unaware",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Map(cty.Map(cty.String)),
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`{"attr": {
+  "foo": {   },
+  "bar": {
+    "baz": "noot"
+  }
+}}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					Type: cty.Map(cty.Map(cty.String)),
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 6, Column: 2, Byte: 61},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					},
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.StringVal("bar")},
+							},
+							Type: cty.Map(cty.String),
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 29},
+								End:      hcl.Pos{Line: 5, Column: 4, Byte: 59},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 29},
+								End:      hcl.Pos{Line: 3, Column: 8, Byte: 34},
+							},
+							NestedTargets: reference.Targets{
+								{
+									Addr: lang.Address{
+										lang.RootStep{Name: "attr"},
+										lang.IndexStep{Key: cty.StringVal("bar")},
+										lang.IndexStep{Key: cty.StringVal("baz")},
+									},
+									Type: cty.String,
+									RangePtr: &hcl.Range{
+										Filename: "test.hcl.json",
+										Start:    hcl.Pos{Line: 4, Column: 5, Byte: 42},
+										End:      hcl.Pos{Line: 4, Column: 18, Byte: 55},
+									},
+									DefRangePtr: &hcl.Range{
+										Filename: "test.hcl.json",
+										Start:    hcl.Pos{Line: 4, Column: 5, Byte: 42},
+										End:      hcl.Pos{Line: 4, Column: 10, Byte: 47},
+									},
+								},
+							},
+						},
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "attr"},
+								lang.IndexStep{Key: cty.StringVal("foo")},
+							},
+							Type: cty.Map(cty.String),
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 13},
+								End:      hcl.Pos{Line: 2, Column: 15, Byte: 25},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 13},
+								End:      hcl.Pos{Line: 2, Column: 8, Byte: 18},
+							},
+							NestedTargets: reference.Targets{},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
As discovered in #251

In a hypothetical perfect/ideal scenario we could collect just targets which match the type but in reality we cannot always establish the expression type, because:

 - we don't recognise all expression types (yet)
 - we'd have to re-implement DAG in some way to ensure we collect and interpolate in the right order
 - not all variables may be known at editing time (some may be provided only at runtime)

Also it's questionable whether it's beneficial to suppress mismatching targets.
We _mostly_ only do it as a hack to aid `LiteralType` and `Reference` in `OneOf`.

The LOC in the diff may seem high, but 95% of that is a result of copying over all tests for reference target collection from `LiteralType` & replacing `LiteralType{Type}` with `AnyExpression{OfType}` + updating that one test for "mismatching" constraint which becomes a positive test.

## UX Before

![Screenshot 2023-04-13 at 15 33 27](https://user-images.githubusercontent.com/287584/231793267-7b494877-c550-4b70-b64b-782fe6f2df3d.png)

## UX After

![Screenshot 2023-04-13 at 20 58 09](https://user-images.githubusercontent.com/287584/231869552-0c3e9edb-ede6-4a3b-8016-3c8d3a5fe981.png)
