### PR TITLE
decoder: Fix collection of implied declared targets of complex types

### DIFF
--- a/decoder/expr_list_ref_targets_test.go
+++ b/decoder/expr_list_ref_targets_test.go
@@ -459,6 +459,73 @@ func TestCollectRefTargets_exprList_implied_hcl(t *testing.T) {
 			},
 		},
 		{
+			"declared as type",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"blk": {
+						Address: &schema.BlockAddrSchema{
+							Steps: schema.Address{
+								schema.StaticStep{Name: "blk"},
+							},
+							BodyAsData: true,
+							InferBody:  true,
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"attr": {
+									Constraint: schema.List{
+										Elem: schema.LiteralType{Type: cty.Bool},
+									},
+									IsOptional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			`blk { attr = [] }`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "blk"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 18, Byte: 17},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 4, Byte: 3},
+					},
+					Type: cty.Object(map[string]cty.Type{
+						"attr": cty.List(cty.Bool),
+					}),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "blk"},
+								lang.AttrStep{Name: "attr"},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 1, Column: 7, Byte: 6},
+								End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 1, Column: 7, Byte: 6},
+								End:      hcl.Pos{Line: 1, Column: 11, Byte: 10},
+							},
+							Type:          cty.List(cty.Bool),
+							NestedTargets: reference.Targets{},
+						},
+					},
+				},
+			},
+		},
+		{
 			"undeclared as reference",
 			&schema.BodySchema{
 				Blocks: map[string]*schema.BlockSchema{
@@ -1008,6 +1075,73 @@ func TestCollectRefTargets_exprList_implied_json(t *testing.T) {
 								End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
 							},
 							Type: cty.List(cty.Bool),
+						},
+					},
+				},
+			},
+		},
+		{
+			"declared as type",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"blk": {
+						Address: &schema.BlockAddrSchema{
+							Steps: schema.Address{
+								schema.StaticStep{Name: "blk"},
+							},
+							BodyAsData: true,
+							InferBody:  true,
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"attr": {
+									Constraint: schema.List{
+										Elem: schema.LiteralType{Type: cty.Bool},
+									},
+									IsOptional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			`{"blk": {"attr": []}}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "blk"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						End:      hcl.Pos{Line: 1, Column: 21, Byte: 20},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+					},
+					Type: cty.Object(map[string]cty.Type{
+						"attr": cty.List(cty.Bool),
+					}),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "blk"},
+								lang.AttrStep{Name: "attr"},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+								End:      hcl.Pos{Line: 1, Column: 20, Byte: 19},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+								End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+							},
+							Type:          cty.List(cty.Bool),
+							NestedTargets: reference.Targets{},
 						},
 					},
 				},

--- a/decoder/expr_map_ref_targets_test.go
+++ b/decoder/expr_map_ref_targets_test.go
@@ -618,6 +618,73 @@ func TestCollectRefTargets_exprMap_implied_hcl(t *testing.T) {
 			},
 		},
 		{
+			"declared as type",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"blk": {
+						Address: &schema.BlockAddrSchema{
+							Steps: schema.Address{
+								schema.StaticStep{Name: "blk"},
+							},
+							BodyAsData: true,
+							InferBody:  true,
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"attr": {
+									Constraint: schema.Map{
+										Elem: schema.LiteralType{Type: cty.Bool},
+									},
+									IsOptional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			`blk { attr = {} }`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "blk"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 18, Byte: 17},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 4, Byte: 3},
+					},
+					Type: cty.Object(map[string]cty.Type{
+						"attr": cty.Map(cty.Bool),
+					}),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "blk"},
+								lang.AttrStep{Name: "attr"},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 1, Column: 7, Byte: 6},
+								End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 1, Column: 7, Byte: 6},
+								End:      hcl.Pos{Line: 1, Column: 11, Byte: 10},
+							},
+							Type:          cty.Map(cty.Bool),
+							NestedTargets: reference.Targets{},
+						},
+					},
+				},
+			},
+		},
+		{
 			"undeclared as reference",
 			&schema.BodySchema{
 				Blocks: map[string]*schema.BlockSchema{
@@ -1279,6 +1346,73 @@ func TestCollectRefTargets_exprMap_implied_json(t *testing.T) {
 								End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
 							},
 							Type: cty.Map(cty.Bool),
+						},
+					},
+				},
+			},
+		},
+		{
+			"declared as type",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"blk": {
+						Address: &schema.BlockAddrSchema{
+							Steps: schema.Address{
+								schema.StaticStep{Name: "blk"},
+							},
+							BodyAsData: true,
+							InferBody:  true,
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"attr": {
+									Constraint: schema.Map{
+										Elem: schema.LiteralType{Type: cty.Bool},
+									},
+									IsOptional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			`{"blk": {"attr": {}}}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "blk"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						End:      hcl.Pos{Line: 1, Column: 21, Byte: 20},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+					},
+					Type: cty.Object(map[string]cty.Type{
+						"attr": cty.Map(cty.Bool),
+					}),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "blk"},
+								lang.AttrStep{Name: "attr"},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+								End:      hcl.Pos{Line: 1, Column: 20, Byte: 19},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+								End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+							},
+							Type:          cty.Map(cty.Bool),
+							NestedTargets: reference.Targets{},
 						},
 					},
 				},

--- a/decoder/expr_object_ref_targets_test.go
+++ b/decoder/expr_object_ref_targets_test.go
@@ -777,6 +777,93 @@ func TestCollectRefTargets_exprObject_implied_hcl(t *testing.T) {
 			},
 		},
 		{
+			"declared as type",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"blk": {
+						Address: &schema.BlockAddrSchema{
+							Steps: schema.Address{
+								schema.StaticStep{Name: "blk"},
+							},
+							BodyAsData: true,
+							InferBody:  true,
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"attr": {
+									Constraint: schema.Object{
+										Attributes: schema.ObjectAttributes{
+											"foo": {Constraint: schema.LiteralType{Type: cty.Bool}},
+										},
+									},
+									IsOptional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			`blk { attr = {} }`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "blk"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 18, Byte: 17},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 4, Byte: 3},
+					},
+					Type: cty.Object(map[string]cty.Type{
+						"attr": cty.Object(map[string]cty.Type{
+							"foo": cty.Bool,
+						}),
+					}),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "blk"},
+								lang.AttrStep{Name: "attr"},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 1, Column: 7, Byte: 6},
+								End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 1, Column: 7, Byte: 6},
+								End:      hcl.Pos{Line: 1, Column: 11, Byte: 10},
+							},
+							Type: cty.Object(map[string]cty.Type{
+								"foo": cty.Bool,
+							}),
+							NestedTargets: reference.Targets{
+								{
+									Addr: lang.Address{
+										lang.RootStep{Name: "blk"},
+										lang.AttrStep{Name: "attr"},
+										lang.AttrStep{Name: "foo"},
+									},
+									RangePtr: &hcl.Range{
+										Filename: "test.hcl",
+										Start:    hcl.Pos{Line: 1, Column: 14, Byte: 13},
+										End:      hcl.Pos{Line: 1, Column: 14, Byte: 13},
+									},
+									Type: cty.Bool,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			"undeclared as reference",
 			&schema.BodySchema{
 				Blocks: map[string]*schema.BlockSchema{
@@ -1597,6 +1684,95 @@ func TestCollectRefTargets_exprObject_implied_json(t *testing.T) {
 										Filename: "test.hcl.json",
 										Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
 										End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+									},
+									Type: cty.Bool,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"declared as type",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"blk": {
+						Address: &schema.BlockAddrSchema{
+							Steps: schema.Address{
+								schema.StaticStep{Name: "blk"},
+							},
+							BodyAsData: true,
+							InferBody:  true,
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"attr": {
+									Constraint: schema.Object{
+										Attributes: map[string]*schema.AttributeSchema{
+											"foo": {
+												Constraint: schema.LiteralType{Type: cty.Bool},
+											},
+										},
+									},
+									IsOptional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			`{"blk": {"attr": {}}}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "blk"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						End:      hcl.Pos{Line: 1, Column: 21, Byte: 20},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+					},
+					Type: cty.Object(map[string]cty.Type{
+						"attr": cty.Object(map[string]cty.Type{
+							"foo": cty.Bool,
+						}),
+					}),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "blk"},
+								lang.AttrStep{Name: "attr"},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+								End:      hcl.Pos{Line: 1, Column: 20, Byte: 19},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+								End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+							},
+							Type: cty.Object(map[string]cty.Type{
+								"foo": cty.Bool,
+							}),
+							NestedTargets: reference.Targets{
+								{
+									Addr: lang.Address{
+										lang.RootStep{Name: "blk"},
+										lang.AttrStep{Name: "attr"},
+										lang.AttrStep{Name: "foo"},
+									},
+									RangePtr: &hcl.Range{
+										Filename: "test.hcl.json",
+										Start:    hcl.Pos{Line: 1, Column: 18, Byte: 17},
+										End:      hcl.Pos{Line: 1, Column: 18, Byte: 17},
 									},
 									Type: cty.Bool,
 								},

--- a/decoder/expr_set_ref_targets_test.go
+++ b/decoder/expr_set_ref_targets_test.go
@@ -354,6 +354,73 @@ func TestCollectRefTargets_exprSet_implied_hcl(t *testing.T) {
 			},
 		},
 		{
+			"declared as type",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"blk": {
+						Address: &schema.BlockAddrSchema{
+							Steps: schema.Address{
+								schema.StaticStep{Name: "blk"},
+							},
+							BodyAsData: true,
+							InferBody:  true,
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"attr": {
+									Constraint: schema.Set{
+										Elem: schema.LiteralType{Type: cty.Bool},
+									},
+									IsOptional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			`blk { attr = [] }`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "blk"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 18, Byte: 17},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 4, Byte: 3},
+					},
+					Type: cty.Object(map[string]cty.Type{
+						"attr": cty.Set(cty.Bool),
+					}),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "blk"},
+								lang.AttrStep{Name: "attr"},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 1, Column: 7, Byte: 6},
+								End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 1, Column: 7, Byte: 6},
+								End:      hcl.Pos{Line: 1, Column: 11, Byte: 10},
+							},
+							Type:          cty.Set(cty.Bool),
+							NestedTargets: reference.Targets{},
+						},
+					},
+				},
+			},
+		},
+		{
 			"undeclared as reference",
 			&schema.BodySchema{
 				Blocks: map[string]*schema.BlockSchema{
@@ -760,6 +827,73 @@ func TestCollectRefTargets_exprSet_implied_json(t *testing.T) {
 								End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
 							},
 							Type: cty.Set(cty.Bool),
+						},
+					},
+				},
+			},
+		},
+		{
+			"declared as type",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"blk": {
+						Address: &schema.BlockAddrSchema{
+							Steps: schema.Address{
+								schema.StaticStep{Name: "blk"},
+							},
+							BodyAsData: true,
+							InferBody:  true,
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"attr": {
+									Constraint: schema.Set{
+										Elem: schema.LiteralType{Type: cty.Bool},
+									},
+									IsOptional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			`{"blk": {"attr": []}}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "blk"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						End:      hcl.Pos{Line: 1, Column: 21, Byte: 20},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+					},
+					Type: cty.Object(map[string]cty.Type{
+						"attr": cty.Set(cty.Bool),
+					}),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "blk"},
+								lang.AttrStep{Name: "attr"},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+								End:      hcl.Pos{Line: 1, Column: 20, Byte: 19},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+								End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+							},
+							Type:          cty.Set(cty.Bool),
+							NestedTargets: reference.Targets{},
 						},
 					},
 				},

--- a/decoder/expr_tuple_ref_targets_test.go
+++ b/decoder/expr_tuple_ref_targets_test.go
@@ -593,6 +593,89 @@ func TestCollectRefTargets_exprTuple_implied_hcl(t *testing.T) {
 			},
 		},
 		{
+			"declared as type",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"blk": {
+						Address: &schema.BlockAddrSchema{
+							Steps: schema.Address{
+								schema.StaticStep{Name: "blk"},
+							},
+							BodyAsData: true,
+							InferBody:  true,
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"attr": {
+									Constraint: schema.Tuple{
+										Elems: []schema.Constraint{
+											schema.LiteralType{Type: cty.Bool},
+										},
+									},
+									IsOptional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			`blk { attr = [] }`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "blk"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 18, Byte: 17},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 4, Byte: 3},
+					},
+					Type: cty.Object(map[string]cty.Type{
+						"attr": cty.Tuple([]cty.Type{cty.Bool}),
+					}),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "blk"},
+								lang.AttrStep{Name: "attr"},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 1, Column: 7, Byte: 6},
+								End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.hcl",
+								Start:    hcl.Pos{Line: 1, Column: 7, Byte: 6},
+								End:      hcl.Pos{Line: 1, Column: 11, Byte: 10},
+							},
+							Type: cty.Tuple([]cty.Type{cty.Bool}),
+							NestedTargets: reference.Targets{
+								{
+									Addr: lang.Address{
+										lang.RootStep{Name: "blk"},
+										lang.AttrStep{Name: "attr"},
+										lang.IndexStep{Key: cty.NumberIntVal(0)},
+									},
+									RangePtr: &hcl.Range{
+										Filename: "test.hcl",
+										Start:    hcl.Pos{Line: 1, Column: 14, Byte: 13},
+										End:      hcl.Pos{Line: 1, Column: 14, Byte: 13},
+									},
+									Type: cty.Bool,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			"undeclared as reference",
 			&schema.BodySchema{
 				Blocks: map[string]*schema.BlockSchema{
@@ -1167,6 +1250,89 @@ func TestCollectRefTargets_exprTuple_implied_json(t *testing.T) {
 										Filename: "test.hcl.json",
 										Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
 										End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+									},
+									Type: cty.Bool,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"declared as type",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"blk": {
+						Address: &schema.BlockAddrSchema{
+							Steps: schema.Address{
+								schema.StaticStep{Name: "blk"},
+							},
+							BodyAsData: true,
+							InferBody:  true,
+						},
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"attr": {
+									Constraint: schema.Tuple{
+										Elems: []schema.Constraint{
+											schema.LiteralType{Type: cty.Bool},
+										},
+									},
+									IsOptional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			`{"blk": {"attr": []}}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "blk"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						End:      hcl.Pos{Line: 1, Column: 21, Byte: 20},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+					},
+					Type: cty.Object(map[string]cty.Type{
+						"attr": cty.Tuple([]cty.Type{cty.Bool}),
+					}),
+					NestedTargets: reference.Targets{
+						{
+							Addr: lang.Address{
+								lang.RootStep{Name: "blk"},
+								lang.AttrStep{Name: "attr"},
+							},
+							RangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+								End:      hcl.Pos{Line: 1, Column: 20, Byte: 19},
+							},
+							DefRangePtr: &hcl.Range{
+								Filename: "test.hcl.json",
+								Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+								End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
+							},
+							Type: cty.Tuple([]cty.Type{cty.Bool}),
+							NestedTargets: reference.Targets{
+								{
+									Addr: lang.Address{
+										lang.RootStep{Name: "blk"},
+										lang.AttrStep{Name: "attr"},
+										lang.IndexStep{Key: cty.NumberIntVal(0)},
+									},
+									RangePtr: &hcl.Range{
+										Filename: "test.hcl.json",
+										Start:    hcl.Pos{Line: 1, Column: 18, Byte: 17},
+										End:      hcl.Pos{Line: 1, Column: 18, Byte: 17},
 									},
 									Type: cty.Bool,
 								},


### PR DESCRIPTION
As discovered in https://github.com/hashicorp/hcl-lang/pull/251

## UX Impact

There currently aren't any constraints in the Terraform schema involving _targetable_ `List`/`Set`/`Tuple`/`Map`/`Object` - most occurrences are either not targetable or are implied through `LiteralType` or `AnyExpression`, or part of `OneOf` where `AnyExpression` takes precedence when collecting targets.

TL;DR there's no expected UX impact on Terraform LS users.

This was only discovered because some existing tests being updated in #251

## Implementation Notes

There are situations where the schema may be vague and the user may benefit from seeing the fully inferred type, rather than just `any` in certain contexts. We already do that for the most obvious case of `LiteralType{Type: cty.DynamicPseudoType}` and `AnyExpression{}` equivalent.

https://github.com/hashicorp/hcl-lang/blob/d2c7ba3e0033b84af71dcb98d86f73fa3c110e7b/decoder/expr_literal_type_ref_targets.go#L18-L23

We could potentially implement `InferType()` for all the impacted types, but there's no immediate benefit given the above + this would require some more changes to take advantage of such type inference. We'd e.g. have to introduce `TypeHint` to `TargetContext` and get all the expression types to actually use the inferred type when collecting the targets.

The edge cases this could handle involve either explicit `List`, `Set`, `Tuple`, `Map` or `Object` constraints with `cty.DynamicPseudoType` element type, or `LiteralType{Type: cty.List(cty.DynamicPseudoType)}` and similar.