### PR TITLE
decoder: Support `AnyAttribute` in `Validate`

### DIFF
--- a/decoder/validate.go
+++ b/decoder/validate.go
@@ -62,15 +62,18 @@ func (d *PathDecoder) validateBody(ctx context.Context, body *hclsyntax.Body, bo
 	for name, attribute := range body.Attributes {
 		attributeSchema, ok := bodySchema.Attributes[name]
 		if !ok {
-			// ---------- diag ERR unknown attribute
-			diags = append(diags, &hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Unexpected attribute",
-				Detail:   fmt.Sprintf("An attribute named %q is not expected here", name),
-				Subject:  attribute.SrcRange.Ptr(),
-			})
-			// don't check futher because this isn't a valid attribute
-			continue
+			if bodySchema.AnyAttribute == nil {
+				// ---------- diag ERR unknown attribute
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Unexpected attribute",
+					Detail:   fmt.Sprintf("An attribute named %q is not expected here", name),
+					Subject:  attribute.SrcRange.Ptr(),
+				})
+				// don't check futher because this isn't a valid attribute
+				continue
+			}
+			attributeSchema = bodySchema.AnyAttribute
 		}
 
 		// ---------- diag WARN deprecated attribute

--- a/decoder/validate_test.go
+++ b/decoder/validate_test.go
@@ -606,6 +606,60 @@ wakka = 2
 				"test.tf": {},
 			},
 		},
+		{
+			"any attribute",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"foo": {
+						Body: &schema.BodySchema{
+							AnyAttribute: &schema.AttributeSchema{
+								Constraint: schema.LiteralType{Type: cty.Number},
+								IsOptional: true,
+							},
+						},
+					},
+				},
+			},
+			`foo {
+				test = 1
+			}`,
+			map[string]hcl.Diagnostics{
+				"test.tf": {},
+			},
+		},
+		{
+			"deprecated any attribute",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"foo": {
+						Body: &schema.BodySchema{
+							AnyAttribute: &schema.AttributeSchema{
+								Constraint:   schema.LiteralType{Type: cty.Number},
+								IsOptional:   true,
+								IsDeprecated: true,
+							},
+						},
+					},
+				},
+			},
+			`foo {
+				test = 1
+			}`,
+			map[string]hcl.Diagnostics{
+				"test.tf": {
+					{
+						Severity: hcl.DiagWarning,
+						Summary:  `"test" is deprecated`,
+						Detail:   `Reason: ""`,
+						Subject: &hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 5, Byte: 10},
+							End:      hcl.Pos{Line: 2, Column: 13, Byte: 18},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for i, tc := range testCases {


### PR DESCRIPTION
Closes https://github.com/hashicorp/hcl-lang/issues/289

---

## UX Before

![Screenshot 2023-08-08 at 12 00 23](https://github.com/hashicorp/hcl-lang/assets/287584/f3e4a0be-90c1-4107-a100-bde31190635c)

## UX After

![Screenshot 2023-08-08 at 12 01 58](https://github.com/hashicorp/hcl-lang/assets/287584/e132cf11-e448-48a5-ae88-3992c1d7a9b4)
