### PR TITLE
Support schema extensions in early validation

### DIFF
--- a/decoder/body_candidates.go
+++ b/decoder/body_candidates.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/hashicorp/hcl-lang/decoder/internal/schemahelper"
 	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
@@ -27,7 +28,7 @@ func (d *PathDecoder) bodySchemaCandidates(ctx context.Context, body *hclsyntax.
 			// check if count attribute is already declared, so we don't
 			// suggest a duplicate
 			if _, ok := body.Attributes["count"]; !ok {
-				candidates.List = append(candidates.List, attributeSchemaToCandidate(ctx, "count", countAttributeSchema(), editRng))
+				candidates.List = append(candidates.List, attributeSchemaToCandidate(ctx, "count", schemahelper.CountAttributeSchema(), editRng))
 			}
 		}
 
@@ -35,7 +36,7 @@ func (d *PathDecoder) bodySchemaCandidates(ctx context.Context, body *hclsyntax.
 			// check if for_each attribute is already declared, so we don't
 			// suggest a duplicate
 			if _, present := body.Attributes["for_each"]; !present {
-				candidates.List = append(candidates.List, attributeSchemaToCandidate(ctx, "for_each", forEachAttributeSchema(), editRng))
+				candidates.List = append(candidates.List, attributeSchemaToCandidate(ctx, "for_each", schemahelper.ForEachAttributeSchema(), editRng))
 			}
 		}
 	}

--- a/decoder/candidates.go
+++ b/decoder/candidates.go
@@ -60,10 +60,10 @@ func (d *PathDecoder) candidatesAtPos(ctx context.Context, body *hclsyntax.Body,
 				ctx = schema.WithActiveSelfRefs(ctx)
 			}
 			if bodySchema.Extensions != nil && bodySchema.Extensions.Count && attr.Name == "count" {
-				return d.attrValueCandidatesAtPos(ctx, attr, countAttributeSchema(), outerBodyRng, pos)
+				return d.attrValueCandidatesAtPos(ctx, attr, schemahelper.CountAttributeSchema(), outerBodyRng, pos)
 			}
 			if bodySchema.Extensions != nil && bodySchema.Extensions.ForEach && attr.Name == "for_each" {
-				return d.attrValueCandidatesAtPos(ctx, attr, forEachAttributeSchema(), outerBodyRng, pos)
+				return d.attrValueCandidatesAtPos(ctx, attr, schemahelper.ForEachAttributeSchema(), outerBodyRng, pos)
 			}
 			if aSchema, ok := bodySchema.Attributes[attr.Name]; ok {
 				return d.attrValueCandidatesAtPos(ctx, attr, aSchema, outerBodyRng, pos)

--- a/decoder/extension_schemas.go
+++ b/decoder/extension_schemas.go
@@ -6,31 +6,9 @@ package decoder
 import (
 	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/reference"
-	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
 )
-
-func countAttributeSchema() *schema.AttributeSchema {
-	return &schema.AttributeSchema{
-		IsOptional: true,
-		Constraint: schema.AnyExpression{OfType: cty.Number},
-		Description: lang.Markdown("Total number of instances of this block.\n\n" +
-			"**Note**: A given block cannot use both `count` and `for_each`."),
-	}
-}
-
-func forEachAttributeSchema() *schema.AttributeSchema {
-	return &schema.AttributeSchema{
-		IsOptional: true,
-		Constraint: schema.OneOf{
-			schema.AnyExpression{OfType: cty.Map(cty.DynamicPseudoType)},
-			schema.AnyExpression{OfType: cty.Set(cty.String)},
-		},
-		Description: lang.Markdown("A meta-argument that accepts a map or a set of strings, and creates an instance for each item in that map or set.\n\n" +
-			"**Note**: A given block cannot use both `count` and `for_each`."),
-	}
-}
 
 func countIndexReferenceTarget(attr *hcl.Attribute, bodyRange hcl.Range) reference.Target {
 	return reference.Target{

--- a/decoder/hover.go
+++ b/decoder/hover.go
@@ -56,9 +56,9 @@ func (d *PathDecoder) hoverAtPos(ctx context.Context, body *hclsyntax.Body, body
 			}
 
 			if bodySchema.Extensions != nil && bodySchema.Extensions.Count && name == "count" {
-				aSchema = countAttributeSchema()
+				aSchema = schemahelper.CountAttributeSchema()
 			} else if bodySchema.Extensions != nil && bodySchema.Extensions.ForEach && name == "for_each" {
-				aSchema = forEachAttributeSchema()
+				aSchema = schemahelper.ForEachAttributeSchema()
 			} else {
 				var ok bool
 				aSchema, ok = bodySchema.Attributes[attr.Name]

--- a/decoder/internal/schemahelper/attribute_extensions.go
+++ b/decoder/internal/schemahelper/attribute_extensions.go
@@ -1,0 +1,31 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schemahelper
+
+import (
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func CountAttributeSchema() *schema.AttributeSchema {
+	return &schema.AttributeSchema{
+		IsOptional: true,
+		Constraint: schema.AnyExpression{OfType: cty.Number},
+		Description: lang.Markdown("Total number of instances of this block.\n\n" +
+			"**Note**: A given block cannot use both `count` and `for_each`."),
+	}
+}
+
+func ForEachAttributeSchema() *schema.AttributeSchema {
+	return &schema.AttributeSchema{
+		IsOptional: true,
+		Constraint: schema.OneOf{
+			schema.AnyExpression{OfType: cty.Map(cty.DynamicPseudoType)},
+			schema.AnyExpression{OfType: cty.Set(cty.String)},
+		},
+		Description: lang.Markdown("A meta-argument that accepts a map or a set of strings, and creates an instance for each item in that map or set.\n\n" +
+			"**Note**: A given block cannot use both `count` and `for_each`."),
+	}
+}

--- a/decoder/internal/walker/walker.go
+++ b/decoder/internal/walker/walker.go
@@ -38,6 +38,14 @@ func Walk(ctx context.Context, node hclsyntax.Node, nodeSchema schema.Schema, w 
 					attrSchema = bodySchema.AnyAttribute
 				}
 
+				if bodySchema.Extensions != nil && bodySchema.Extensions.Count && attr.Name == "count" {
+					attrSchema = schemahelper.CountAttributeSchema()
+				}
+
+				if bodySchema.Extensions != nil && bodySchema.Extensions.ForEach && attr.Name == "for_each" {
+					attrSchema = schemahelper.ForEachAttributeSchema()
+				}
+
 				diags = diags.Extend(Walk(ctx, attr, attrSchema, w))
 			}
 

--- a/decoder/reference_origins.go
+++ b/decoder/reference_origins.go
@@ -131,9 +131,9 @@ func (d *PathDecoder) referenceOriginsInBody(body hcl.Body, bodySchema *schema.B
 	for _, attr := range content.Attributes {
 		var aSchema *schema.AttributeSchema
 		if bodySchema.Extensions != nil && bodySchema.Extensions.Count && attr.Name == "count" {
-			aSchema = countAttributeSchema()
+			aSchema = schemahelper.CountAttributeSchema()
 		} else if bodySchema.Extensions != nil && bodySchema.Extensions.ForEach && attr.Name == "for_each" {
-			aSchema = forEachAttributeSchema()
+			aSchema = schemahelper.ForEachAttributeSchema()
 		} else {
 			var ok bool
 			aSchema, ok = bodySchema.Attributes[attr.Name]

--- a/decoder/semantic_tokens.go
+++ b/decoder/semantic_tokens.go
@@ -59,9 +59,9 @@ func (d *PathDecoder) tokensForBody(ctx context.Context, body *hclsyntax.Body, b
 		attrSchema, ok := bodySchema.Attributes[name]
 		if !ok {
 			if bodySchema.Extensions != nil && name == "count" && bodySchema.Extensions.Count {
-				attrSchema = countAttributeSchema()
+				attrSchema = schemahelper.CountAttributeSchema()
 			} else if bodySchema.Extensions != nil && name == "for_each" && bodySchema.Extensions.ForEach {
-				attrSchema = forEachAttributeSchema()
+				attrSchema = schemahelper.ForEachAttributeSchema()
 			} else {
 				if bodySchema.AnyAttribute == nil {
 					// unknown attribute

--- a/decoder/validate_test.go
+++ b/decoder/validate_test.go
@@ -684,6 +684,111 @@ wakka = 2
 			}`,
 			map[string]hcl.Diagnostics{},
 		},
+		{
+			"dynamic block disabled and present",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"foo": {
+						Body: &schema.BodySchema{
+							Extensions: &schema.BodyExtensions{
+								DynamicBlocks: false,
+							},
+						},
+						Labels: []*schema.LabelSchema{
+							{
+								Name:     "key",
+								IsDepKey: true,
+							},
+						},
+						DependentBody: map[schema.SchemaKey]*schema.BodySchema{
+							schema.NewSchemaKey(schema.DependencyKeys{
+								Labels: []schema.LabelDependent{
+									{Index: 0, Value: "toot"},
+								},
+							}): {
+								Blocks: map[string]*schema.BlockSchema{
+									"noot": {
+										Body: &schema.BodySchema{
+											Attributes: map[string]*schema.AttributeSchema{
+												"test": {
+													IsOptional: true,
+													Constraint: schema.LiteralType{Type: cty.String},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			`foo "toot" {
+				dynamic "test" {
+					for_each = {}
+				}
+			}`,
+			map[string]hcl.Diagnostics{
+				"test.tf": {
+					&hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Unexpected block",
+						Detail:   `Blocks of type "dynamic" are not expected here`,
+						Subject: &hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 5, Byte: 17},
+							End:      hcl.Pos{Line: 2, Column: 12, Byte: 24},
+						},
+					},
+				},
+			},
+		},
+		{
+			"dynamic block enabled and present",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"foo": {
+						Body: &schema.BodySchema{
+							Extensions: &schema.BodyExtensions{
+								DynamicBlocks: true,
+							},
+						},
+						Labels: []*schema.LabelSchema{
+							{
+								Name:     "key",
+								IsDepKey: true,
+							},
+						},
+						DependentBody: map[schema.SchemaKey]*schema.BodySchema{
+							schema.NewSchemaKey(schema.DependencyKeys{
+								Labels: []schema.LabelDependent{
+									{Index: 0, Value: "toot"},
+								},
+							}): {
+								Blocks: map[string]*schema.BlockSchema{
+									"noot": {
+										Body: &schema.BodySchema{
+											Attributes: map[string]*schema.AttributeSchema{
+												"test": {
+													IsOptional: true,
+													Constraint: schema.LiteralType{Type: cty.String},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			`foo "toot" {
+				dynamic "test" {
+					for_each = {}
+				}
+			}`,
+			map[string]hcl.Diagnostics{},
+		},
 	}
 
 	for i, tc := range testCases {

--- a/decoder/validate_test.go
+++ b/decoder/validate_test.go
@@ -648,6 +648,42 @@ wakka = 2
 				},
 			},
 		},
+		{
+			"count attribute present no diags",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"foo": {
+						Body: &schema.BodySchema{
+							Extensions: &schema.BodyExtensions{
+								Count: true,
+							},
+						},
+					},
+				},
+			},
+			`foo {
+				count = 1
+			}`,
+			map[string]hcl.Diagnostics{},
+		},
+		{
+			"for_each attribute present no diags",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"foo": {
+						Body: &schema.BodySchema{
+							Extensions: &schema.BodyExtensions{
+								ForEach: true,
+							},
+						},
+					},
+				},
+			},
+			`foo {
+				for_each = []
+			}`,
+			map[string]hcl.Diagnostics{},
+		},
 	}
 
 	for i, tc := range testCases {


### PR DESCRIPTION
This does not raise diagnostics if schema extensions are enabled and Count or ForEach is enabled.

In the work on functions & expressions we introduced the concept of extensions for handling count and for_each. Both aren't part of the regular attributes for a block, but are introduced by enabling the specific extensions for a block.

This adds count and for_each at runtime like completion, hover, and other parts do. Since these are optional attributes, there is are no diagnostics necessary if they are not present.
