### PR TITLE
decoder: Enable validators to deal with unknown schema

### DIFF
--- a/decoder/candidates.go
+++ b/decoder/candidates.go
@@ -143,11 +143,7 @@ func (d *PathDecoder) candidatesAtPos(ctx context.Context, body *hclsyntax.Body,
 			}
 
 			if block.Body != nil && block.Body.Range().ContainsPos(pos) {
-				mergedSchema, err := schemahelper.MergeBlockBodySchemas(block.AsHCLBlock(), blockSchema)
-				if err != nil {
-					return lang.ZeroCandidates(), err
-				}
-
+				mergedSchema, _ := schemahelper.MergeBlockBodySchemas(block.AsHCLBlock(), blockSchema)
 				return d.candidatesAtPos(ctx, block.Body, outerBodyRng, mergedSchema, pos)
 			}
 		}

--- a/decoder/hover.go
+++ b/decoder/hover.go
@@ -144,11 +144,7 @@ func (d *PathDecoder) hoverAtPos(ctx context.Context, body *hclsyntax.Body, body
 			}
 
 			if block.Body != nil && block.Body.Range().ContainsPos(pos) {
-				mergedSchema, err := schemahelper.MergeBlockBodySchemas(block.AsHCLBlock(), blockSchema)
-				if err != nil {
-					return nil, err
-				}
-
+				mergedSchema, _ := schemahelper.MergeBlockBodySchemas(block.AsHCLBlock(), blockSchema)
 				return d.hoverAtPos(ctx, block.Body, mergedSchema, pos)
 			}
 		}

--- a/decoder/internal/schemahelper/context.go
+++ b/decoder/internal/schemahelper/context.go
@@ -1,0 +1,26 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schemahelper
+
+import "context"
+
+type unknownSchemaCtxKey struct{}
+
+// WithUnknownSchema attaches a flag indicating that the schema being passed
+// is not wholly known.
+func WithUnknownSchema(ctx context.Context) context.Context {
+	return context.WithValue(ctx, unknownSchemaCtxKey{}, true)
+}
+
+// HasUnknownSchema returns true if the schema being passed
+// is not wholly known. This allows each validator to decide
+// whether and how to validate the AST.
+func HasUnknownSchema(ctx context.Context) bool {
+	value := ctx.Value(unknownSchemaCtxKey{})
+	uSchema, ok := value.(bool)
+	if !ok {
+		return false
+	}
+	return uSchema
+}

--- a/decoder/internal/validator/attribute_unexpected.go
+++ b/decoder/internal/validator/attribute_unexpected.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/hcl-lang/decoder/internal/schemahelper"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -15,6 +16,12 @@ import (
 type UnexpectedAttribute struct{}
 
 func (v UnexpectedAttribute) Visit(ctx context.Context, node hclsyntax.Node, nodeSchema schema.Schema) (diags hcl.Diagnostics) {
+	if schemahelper.HasUnknownSchema(ctx) {
+		// Avoid checking for unexpected attributes
+		// if we cannot tell which ones are expected.
+		return
+	}
+
 	attr, ok := node.(*hclsyntax.Attribute)
 	if !ok {
 		return

--- a/decoder/internal/validator/block_unexpected.go
+++ b/decoder/internal/validator/block_unexpected.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/hcl-lang/decoder/internal/schemahelper"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -15,6 +16,12 @@ import (
 type UnexpectedBlock struct{}
 
 func (v UnexpectedBlock) Visit(ctx context.Context, node hclsyntax.Node, nodeSchema schema.Schema) (diags hcl.Diagnostics) {
+	if schemahelper.HasUnknownSchema(ctx) {
+		// Avoid checking for unexpected blocks
+		// if we cannot tell which ones are expected.
+		return
+	}
+
 	block, ok := node.(*hclsyntax.Block)
 	if !ok {
 		return

--- a/decoder/internal/walker/walker.go
+++ b/decoder/internal/walker/walker.go
@@ -70,7 +70,7 @@ func Walk(ctx context.Context, node hclsyntax.Node, nodeSchema schema.Schema, w 
 		if ok && bSchema.Body != nil {
 			mergedSchema, ok := schemahelper.MergeBlockBodySchemas(nodeType.AsHCLBlock(), bSchema)
 			if !ok {
-				// TODO
+				ctx = schemahelper.WithUnknownSchema(ctx)
 			}
 			blockBodySchema = mergedSchema
 		}

--- a/decoder/internal/walker/walker.go
+++ b/decoder/internal/walker/walker.go
@@ -68,9 +68,9 @@ func Walk(ctx context.Context, node hclsyntax.Node, nodeSchema schema.Schema, w 
 		var blockBodySchema schema.Schema = nil
 		bSchema, ok := nodeSchema.(*schema.BlockSchema)
 		if ok && bSchema.Body != nil {
-			mergedSchema, err := schemahelper.MergeBlockBodySchemas(nodeType.AsHCLBlock(), bSchema)
-			if err != nil {
-				// TODO! err
+			mergedSchema, ok := schemahelper.MergeBlockBodySchemas(nodeType.AsHCLBlock(), bSchema)
+			if !ok {
+				// TODO
 			}
 			blockBodySchema = mergedSchema
 		}

--- a/decoder/reference_origins.go
+++ b/decoder/reference_origins.go
@@ -192,10 +192,7 @@ func (d *PathDecoder) referenceOriginsInBody(body hcl.Body, bodySchema *schema.B
 				// skip unknown blocks
 				continue
 			}
-			mergedSchema, err := schemahelper.MergeBlockBodySchemas(block.Block, bSchema)
-			if err != nil {
-				continue
-			}
+			mergedSchema, _ := schemahelper.MergeBlockBodySchemas(block.Block, bSchema)
 
 			os, ios := d.referenceOriginsInBody(block.Body, mergedSchema)
 			origins = append(origins, os...)

--- a/decoder/reference_targets.go
+++ b/decoder/reference_targets.go
@@ -142,10 +142,7 @@ func (d *PathDecoder) decodeReferenceTargetsForBody(body hcl.Body, parentBlock *
 			continue
 		}
 
-		mergedSchema, err := schemahelper.MergeBlockBodySchemas(blk.Block, bSchema)
-		if err != nil {
-			mergedSchema = bSchema.Body
-		}
+		mergedSchema, _ := schemahelper.MergeBlockBodySchemas(blk.Block, bSchema)
 
 		iRefs := d.decodeReferenceTargetsForBody(blk.Body, blk, mergedSchema)
 		refs = append(refs, iRefs...)
@@ -209,10 +206,7 @@ func (d *PathDecoder) decodeReferenceTargetsForBody(body hcl.Body, parentBlock *
 			if ok {
 				fullSchema := depSchema
 				if bSchema.Address.BodyAsData {
-					mergedSchema, err := schemahelper.MergeBlockBodySchemas(blk.Block, bSchema)
-					if err != nil {
-						continue
-					}
+					mergedSchema, _ := schemahelper.MergeBlockBodySchemas(blk.Block, bSchema)
 					bodyRef.NestedTargets = make(reference.Targets, 0)
 					fullSchema = mergedSchema
 				}

--- a/decoder/semantic_tokens.go
+++ b/decoder/semantic_tokens.go
@@ -127,10 +127,7 @@ func (d *PathDecoder) tokensForBody(ctx context.Context, body *hclsyntax.Body, b
 		}
 
 		if block.Body != nil {
-			mergedSchema, err := schemahelper.MergeBlockBodySchemas(block.AsHCLBlock(), blockSchema)
-			if err != nil {
-				continue
-			}
+			mergedSchema, _ := schemahelper.MergeBlockBodySchemas(block.AsHCLBlock(), blockSchema)
 
 			tokens = append(tokens, d.tokensForBody(ctx, block.Body, mergedSchema, blockModifiers)...)
 		}

--- a/decoder/symbols.go
+++ b/decoder/symbols.go
@@ -116,10 +116,8 @@ func (d *PathDecoder) symbolsForBody(body hcl.Body, bodySchema *schema.BodySchem
 			bs, ok := bodySchema.Blocks[block.Type]
 			if ok {
 				bSchema = bs.Body
-				mergedSchema, err := schemahelper.MergeBlockBodySchemas(block.Block, bs)
-				if err == nil {
-					bSchema = mergedSchema
-				}
+				mergedSchema, _ := schemahelper.MergeBlockBodySchemas(block.Block, bs)
+				bSchema = mergedSchema
 			}
 		}
 


### PR DESCRIPTION
Depends on https://github.com/hashicorp/hcl-lang/pull/299

Closes https://github.com/hashicorp/hcl-lang/issues/291

--- 

Comments should be self-explanatory and the implementation works exactly as described/desired in https://github.com/hashicorp/hcl-lang/issues/291 - i.e.

> If merging is successful we can continue as normal
> If not, we have to skip some validations, like required attribute/block detection
> If we encounter a attribute/block that still exists in the schema (must be part of the core schema then), we can return to normal validation for that one

This is all driven by a flag which we provide through the context.