### PR TITLE
Implement reference validation

### DIFF
--- a/decoder/code_lens.go
+++ b/decoder/code_lens.go
@@ -21,7 +21,7 @@ func (d *Decoder) CodeLensesForFile(ctx context.Context, path lang.Path, file st
 
 	pathCtx, err := d.pathReader.PathContext(path)
 	if err == nil {
-		ctx = withPathContext(ctx, pathCtx)
+		ctx = WithPathContext(ctx, pathCtx)
 	}
 
 	ctx = withPathReader(ctx, d.pathReader)

--- a/decoder/path_context.go
+++ b/decoder/path_context.go
@@ -24,7 +24,7 @@ type PathContext struct {
 
 type pathCtxKey struct{}
 
-func withPathContext(ctx context.Context, pathCtx *PathContext) context.Context {
+func WithPathContext(ctx context.Context, pathCtx *PathContext) context.Context {
 	return context.WithValue(ctx, pathCtxKey{}, pathCtx)
 }
 

--- a/decoder/validate.go
+++ b/decoder/validate.go
@@ -45,7 +45,7 @@ func (d *PathDecoder) Validate(ctx context.Context) (lang.DiagnosticsMap, error)
 		})
 	}
 
-	ctx = withPathContext(ctx, d.pathCtx)
+	ctx = WithPathContext(ctx, d.pathCtx)
 
 	// Run validation functions
 	for _, vFunc := range d.decoderCtx.Validations {

--- a/decoder/validate.go
+++ b/decoder/validate.go
@@ -8,14 +8,15 @@ import (
 
 	"github.com/hashicorp/hcl-lang/decoder/internal/validator"
 	"github.com/hashicorp/hcl-lang/decoder/internal/walker"
+	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 )
 
 // Validate returns a set of Diagnostics for all known files
-func (d *PathDecoder) Validate(ctx context.Context) (map[string]hcl.Diagnostics, error) {
-	diags := make(map[string]hcl.Diagnostics)
+func (d *PathDecoder) Validate(ctx context.Context) (lang.DiagnosticsMap, error) {
+	diags := make(lang.DiagnosticsMap)
 	if d.pathCtx.Schema == nil {
 		return diags, &NoSchemaError{}
 	}
@@ -44,10 +45,12 @@ func (d *PathDecoder) Validate(ctx context.Context) (map[string]hcl.Diagnostics,
 		})
 	}
 
+	ctx = withPathContext(ctx, d.pathCtx)
+
 	// Run validation functions
-	// for _, vFunc := range d.decoderCtx.Validations {
-	// 	diags = diags.Extend(vFunc(ctx))
-	// }
+	for _, vFunc := range d.decoderCtx.Validations {
+		diags = diags.Extend(vFunc(ctx))
+	}
 
 	return diags, nil
 }

--- a/lang/validate.go
+++ b/lang/validate.go
@@ -20,9 +20,7 @@ func (dm DiagnosticsMap) Extend(diagMap DiagnosticsMap) DiagnosticsMap {
 			dm[fileName] = make(hcl.Diagnostics, 0)
 		}
 
-		// TODO: this seems to wipe instead of extend
-		// dm[fileName].Extend(diags)
-		dm[fileName] = append(dm[fileName], diags...)
+		dm[fileName].Extend(diags)
 	}
 
 	return dm

--- a/lang/validate.go
+++ b/lang/validate.go
@@ -19,7 +19,10 @@ func (dm DiagnosticsMap) Extend(diagMap DiagnosticsMap) DiagnosticsMap {
 		if !ok {
 			dm[fileName] = make(hcl.Diagnostics, 0)
 		}
-		dm[fileName].Extend(diags)
+
+		// TODO: this seems to wipe instead of extend
+		// dm[fileName].Extend(diags)
+		dm[fileName] = append(dm[fileName], diags...)
 	}
 
 	return dm

--- a/lang/validate.go
+++ b/lang/validate.go
@@ -9,4 +9,18 @@ import (
 	"github.com/hashicorp/hcl/v2"
 )
 
-type ValidationFunc func(ctx context.Context) hcl.Diagnostics
+type ValidationFunc func(ctx context.Context) DiagnosticsMap
+
+type DiagnosticsMap map[string]hcl.Diagnostics
+
+func (dm DiagnosticsMap) Extend(diagMap DiagnosticsMap) DiagnosticsMap {
+	for fileName, diags := range diagMap {
+		_, ok := dm[fileName]
+		if !ok {
+			dm[fileName] = make(hcl.Diagnostics, 0)
+		}
+		dm[fileName].Extend(diags)
+	}
+
+	return dm
+}


### PR DESCRIPTION
Add the ability to use the collected origin and target references in early validation.

Validation funcs will be provided by terraform-ls for now.
