### PR TITLE
Remove execution of validation funcs

### DIFF
--- a/decoder/code_lens.go
+++ b/decoder/code_lens.go
@@ -21,7 +21,7 @@ func (d *Decoder) CodeLensesForFile(ctx context.Context, path lang.Path, file st
 
 	pathCtx, err := d.pathReader.PathContext(path)
 	if err == nil {
-		ctx = WithPathContext(ctx, pathCtx)
+		ctx = withPathContext(ctx, pathCtx)
 	}
 
 	ctx = withPathReader(ctx, d.pathReader)

--- a/decoder/context.go
+++ b/decoder/context.go
@@ -39,10 +39,6 @@ type DecoderContext struct {
 	// a resolve hook, ResolveCandidate will execute the hook and return
 	// additional (resolved) data for the completion item.
 	CompletionResolveHooks CompletionResolveFuncMap
-
-	// Validations represent a slice of executable functions
-	// which will validate each file in a path
-	Validations []lang.ValidationFunc
 }
 
 func NewDecoderContext() DecoderContext {

--- a/decoder/path_context.go
+++ b/decoder/path_context.go
@@ -24,7 +24,7 @@ type PathContext struct {
 
 type pathCtxKey struct{}
 
-func WithPathContext(ctx context.Context, pathCtx *PathContext) context.Context {
+func withPathContext(ctx context.Context, pathCtx *PathContext) context.Context {
 	return context.WithValue(ctx, pathCtxKey{}, pathCtx)
 }
 

--- a/decoder/validate.go
+++ b/decoder/validate.go
@@ -45,13 +45,6 @@ func (d *PathDecoder) Validate(ctx context.Context) (lang.DiagnosticsMap, error)
 		})
 	}
 
-	ctx = WithPathContext(ctx, d.pathCtx)
-
-	// Run validation functions
-	for _, vFunc := range d.decoderCtx.Validations {
-		diags = diags.Extend(vFunc(ctx))
-	}
-
 	return diags, nil
 }
 

--- a/lang/validate.go
+++ b/lang/validate.go
@@ -4,12 +4,8 @@
 package lang
 
 import (
-	"context"
-
 	"github.com/hashicorp/hcl/v2"
 )
-
-type ValidationFunc func(ctx context.Context) DiagnosticsMap
 
 type DiagnosticsMap map[string]hcl.Diagnostics
 


### PR DESCRIPTION
We move this to the language server in https://github.com/hashicorp/terraform-ls/pull/1361 to decouple it from schema validation and have more fine-grained control over when it runs.