### PR TITLE
schemahelper: Allow list(any) to be passed into `dynamic` block's `for_each`

### DIFF
--- a/decoder/body_extensions_test.go
+++ b/decoder/body_extensions_test.go
@@ -1915,10 +1915,10 @@ resource "aws_elastic_beanstalk_environment" "example" {
 				{
 					Label: "for_each",
 					Description: lang.MarkupContent{
-						Value: "A meta-argument that accepts a map or a set of strings, and creates an instance for each item in that map or set.",
+						Value: "A meta-argument that accepts a list, map or a set of strings, and creates an instance for each item in that list, map or set.",
 						Kind:  lang.MarkdownKind,
 					},
-					Detail:         "required, map of any single type or set of string",
+					Detail:         "required, map of any single type or list of any single type or set of string",
 					Kind:           lang.AttributeCandidateKind,
 					TriggerSuggest: true,
 					TextEdit: lang.TextEdit{

--- a/decoder/internal/schemahelper/dynamic_block.go
+++ b/decoder/internal/schemahelper/dynamic_block.go
@@ -41,10 +41,11 @@ func buildDynamicBlockSchema(inputSchema *schema.BodySchema) *schema.BlockSchema
 				"for_each": {
 					Constraint: schema.OneOf{
 						schema.AnyExpression{OfType: cty.Map(cty.DynamicPseudoType)},
+						schema.AnyExpression{OfType: cty.List(cty.DynamicPseudoType)},
 						schema.AnyExpression{OfType: cty.Set(cty.String)},
 					},
 					IsRequired:  true,
-					Description: lang.Markdown("A meta-argument that accepts a map or a set of strings, and creates an instance for each item in that map or set."),
+					Description: lang.Markdown("A meta-argument that accepts a list, map or a set of strings, and creates an instance for each item in that list, map or set."),
 				},
 				"iterator": {
 					Constraint: schema.LiteralType{Type: cty.String},


### PR DESCRIPTION
When `for_each` was initially introduced as a "schema extension" we thought it has the same constraints as the "top level" `for_each` in that it doesn't allow lists. However, since `dynamic` does _not_ have `count` inside, the `for_each` there _does_ allow iterating over lists.

So the updated schema reflects the reality more accurately.

This impacts all functionality driven by schema, i.e.

 - completion
 - hover
 - go-to-definition
 - go-to-references
 - semantic highlighting
 - validation

## Example

```hcl
terraform {
  required_providers {
    cloudinit = {
      source  = "hashicorp/cloudinit"
      version = "~> 2.3"
    }
  }
}

variable "parts" {
  type = list(object({
    filename     = string
    content_type = string
    content      = string
  }))
  default = [
    {
      filename     = "hello-script.sh"
      content_type = "text/x-shellscript"
      content      = "echo 'foo'"
    },
    {
      filename     = "cloud-config.yaml"
      content_type = "text/cloud-config"
      content      = "moot = 42"
    }
  ]
}

data "cloudinit_config" "foobar" {
  gzip          = false
  base64_encode = false

  dynamic "part" {
    for_each = var.parts
    content {
      filename     = part.value.filename
      content_type = part.value.content_type
      content      = part.value.content
    }
  }
}
```

## UX Before

<img width="532" alt="Screenshot 2023-09-05 at 13 26 10" src="https://github.com/hashicorp/hcl-lang/assets/287584/0ffaae1d-75ec-4d96-9a52-0be8bda2c65c">

## UX After

<img width="348" alt="Screenshot 2023-09-05 at 13 25 37" src="https://github.com/hashicorp/hcl-lang/assets/287584/9e59b435-70b3-4710-90b5-29cdf2b9b251">
