### PR TITLE
schemahelper: Make `dynamic` `content` block required

### DIFF
--- a/decoder/body_extensions_test.go
+++ b/decoder/body_extensions_test.go
@@ -1900,7 +1900,7 @@ resource "aws_elastic_beanstalk_environment" "example" {
 						Value: "The body of each generated block",
 						Kind:  lang.PlainTextKind,
 					},
-					Detail: "Block, max: 1",
+					Detail: "Block, min: 1, max: 1",
 					Kind:   lang.BlockCandidateKind,
 					TextEdit: lang.TextEdit{
 						Range: hcl.Range{

--- a/decoder/hover_test.go
+++ b/decoder/hover_test.go
@@ -1500,7 +1500,7 @@ func TestDecoder_HoverAtPos_extensions_dynamic(t *testing.T) {
 			hcl.Pos{Line: 5, Column: 13, Byte: 102},
 			&lang.HoverData{
 				Content: lang.MarkupContent{
-					Value: "**content** _Block, max: 1_\n\n" +
+					Value: "**content** _Block, min: 1, max: 1_\n\n" +
 						"The body of each generated block",
 					Kind: lang.MarkdownKind,
 				},

--- a/decoder/internal/schemahelper/dynamic_block.go
+++ b/decoder/internal/schemahelper/dynamic_block.go
@@ -20,6 +20,7 @@ func buildDynamicBlockSchema(inputSchema *schema.BodySchema) *schema.BlockSchema
 			Blocks: map[string]*schema.BlockSchema{
 				"content": {
 					Description: lang.PlainText("The body of each generated block"),
+					MinItems:    1,
 					MaxItems:    1,
 					Body:        block.Body.Copy(),
 				},


### PR DESCRIPTION
This is _mostly_ no-op for existing users but making the schema more accurate here will help us produce more helpful diagnostics as part of the ongoing validation project.

## UX Before

<img width="478" alt="Screenshot 2023-09-05 at 14 16 51" src="https://github.com/hashicorp/hcl-lang/assets/287584/ebd8cc9e-4834-4ddd-8dcc-650caa5449fe">

## UX After

<img width="776" alt="Screenshot 2023-09-05 at 14 17 48" src="https://github.com/hashicorp/hcl-lang/assets/287584/72075bc8-756a-4ea6-b782-b7625a441a0b">
