### PR TITLE
Improve `MinItems` validation for `dynamic` blocks

### DIFF
--- a/decoder/internal/schemahelper/context.go
+++ b/decoder/internal/schemahelper/context.go
@@ -7,6 +7,7 @@ import "context"
 
 type unknownSchemaCtxKey struct{}
 type foundBlocksCtxKey struct{}
+type dynamicBlocksCtxKey struct{}
 
 // WithUnknownSchema attaches a flag indicating that the schema being passed
 // is not wholly known.
@@ -32,4 +33,12 @@ func WithFoundBlocks(ctx context.Context, foundBlocks map[string]uint64) context
 
 func FoundBlocks(ctx context.Context) map[string]uint64 {
 	return ctx.Value(foundBlocksCtxKey{}).(map[string]uint64)
+}
+
+func WithDynamicBlocks(ctx context.Context, dynamicBlocks map[string]uint64) context.Context {
+	return context.WithValue(ctx, dynamicBlocksCtxKey{}, dynamicBlocks)
+}
+
+func DynamicBlocks(ctx context.Context) map[string]uint64 {
+	return ctx.Value(dynamicBlocksCtxKey{}).(map[string]uint64)
 }

--- a/decoder/internal/schemahelper/context.go
+++ b/decoder/internal/schemahelper/context.go
@@ -6,6 +6,7 @@ package schemahelper
 import "context"
 
 type unknownSchemaCtxKey struct{}
+type foundBlocksCtxKey struct{}
 
 // WithUnknownSchema attaches a flag indicating that the schema being passed
 // is not wholly known.
@@ -23,4 +24,12 @@ func HasUnknownSchema(ctx context.Context) bool {
 		return false
 	}
 	return uSchema
+}
+
+func WithFoundBlocks(ctx context.Context, foundBlocks map[string]uint64) context.Context {
+	return context.WithValue(ctx, foundBlocksCtxKey{}, foundBlocks)
+}
+
+func FoundBlocks(ctx context.Context) map[string]uint64 {
+	return ctx.Value(foundBlocksCtxKey{}).(map[string]uint64)
 }

--- a/decoder/internal/validator/block_max_items.go
+++ b/decoder/internal/validator/block_max_items.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/hcl-lang/decoder/internal/schemahelper"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -15,7 +16,7 @@ import (
 type MaxBlocks struct{}
 
 func (v MaxBlocks) Visit(ctx context.Context, node hclsyntax.Node, nodeSchema schema.Schema) (diags hcl.Diagnostics) {
-	body, ok := node.(*hclsyntax.Body)
+	_, ok := node.(*hclsyntax.Body)
 	if !ok {
 		return
 	}
@@ -24,14 +25,7 @@ func (v MaxBlocks) Visit(ctx context.Context, node hclsyntax.Node, nodeSchema sc
 		return
 	}
 
-	foundBlocks := make(map[string]uint64)
-	for _, block := range body.Blocks {
-		if _, ok := foundBlocks[block.Type]; !ok {
-			foundBlocks[block.Type] = 0
-		}
-
-		foundBlocks[block.Type]++
-	}
+	foundBlocks := schemahelper.FoundBlocks(ctx)
 
 	bodySchema := nodeSchema.(*schema.BodySchema)
 	for name, blockSchema := range bodySchema.Blocks {

--- a/decoder/internal/validator/block_min_items.go
+++ b/decoder/internal/validator/block_min_items.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/hcl-lang/decoder/internal/schemahelper"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -15,7 +16,7 @@ import (
 type MinBlocks struct{}
 
 func (v MinBlocks) Visit(ctx context.Context, node hclsyntax.Node, nodeSchema schema.Schema) (diags hcl.Diagnostics) {
-	body, ok := node.(*hclsyntax.Body)
+	_, ok := node.(*hclsyntax.Body)
 	if !ok {
 		return
 	}
@@ -24,14 +25,7 @@ func (v MinBlocks) Visit(ctx context.Context, node hclsyntax.Node, nodeSchema sc
 		return
 	}
 
-	foundBlocks := make(map[string]uint64)
-	for _, block := range body.Blocks {
-		if _, ok := foundBlocks[block.Type]; !ok {
-			foundBlocks[block.Type] = 0
-		}
-
-		foundBlocks[block.Type]++
-	}
+	foundBlocks := schemahelper.FoundBlocks(ctx)
 
 	bodySchema := nodeSchema.(*schema.BodySchema)
 	for name, blockSchema := range bodySchema.Blocks {

--- a/decoder/validate_test.go
+++ b/decoder/validate_test.go
@@ -597,6 +597,47 @@ wakka = 2
 			map[string]hcl.Diagnostics{},
 		},
 		{
+			"minitems with dynamic block",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"foo": {
+						Labels: []*schema.LabelSchema{
+							{
+								Name:     "type",
+								IsDepKey: true,
+							},
+						},
+						Body: &schema.BodySchema{
+							Extensions: &schema.BodyExtensions{
+								DynamicBlocks: true,
+							},
+						},
+						DependentBody: map[schema.SchemaKey]*schema.BodySchema{
+							schema.NewSchemaKey(schema.DependencyKeys{
+								Labels: []schema.LabelDependent{
+									{Index: 0, Value: "type"},
+								},
+							}): {
+								Blocks: map[string]*schema.BlockSchema{
+									"one": {
+										MinItems: 2,
+										Body:     schema.NewBodySchema(),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			`foo "type" {
+				dynamic "one" {
+					for_each = []
+					content {}
+				}
+			}`,
+			map[string]hcl.Diagnostics{},
+		},
+		{
 			"any attribute",
 			&schema.BodySchema{
 				Blocks: map[string]*schema.BlockSchema{


### PR DESCRIPTION
This PR improves the validation of blocks that have the `MinItems` property set. We now account for dynamic blocks for the specific block type.

While we can't evaluate the exact amount of block the dynamic block will generate, we stop raising false negatives.

## UX

**Before**
<img width="767" alt="CleanShot 2023-09-07 at 14 30 16@2x" src="https://github.com/hashicorp/hcl-lang/assets/45985/50b7136b-b08f-413a-9eb5-ea86abbc380d">


**After**
<img width="761" alt="CleanShot 2023-09-07 at 14 29 24@2x" src="https://github.com/hashicorp/hcl-lang/assets/45985/9ad0e8b3-99f6-4637-b8f0-19c2795a2a1d">
