### PR TITLE
decoder: Implement completion for binary & unary operators

### DIFF
--- a/decoder/candidates.go
+++ b/decoder/candidates.go
@@ -172,9 +172,9 @@ func (d *PathDecoder) isPosInsideAttrExpr(attr *hclsyntax.Attribute, pos hcl.Pos
 		return true
 	}
 
-	// edge case: end of incomplete traversal with '.' (which parser ignores)
+	// edge case: end of incomplete expression with trailing '.' (which parser ignores)
 	endByte := attr.Expr.Range().End.Byte
-	if _, ok := attr.Expr.(*hclsyntax.ScopeTraversalExpr); ok && pos.Byte-endByte == 1 {
+	if pos.Byte-endByte == 1 {
 		suspectedDotRng := hcl.Range{
 			Filename: attr.Expr.Range().Filename,
 			Start:    attr.Expr.Range().End,

--- a/decoder/expr_any_completion.go
+++ b/decoder/expr_any_completion.go
@@ -10,6 +10,8 @@ import (
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
 )
 
 func (a Any) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate {
@@ -100,9 +102,14 @@ func (a Any) completeNonComplexExprAtPos(ctx context.Context, pos hcl.Pos) []lan
 	// TODO: Support splat expression https://github.com/hashicorp/terraform-ls/issues/526
 	// TODO: Support for-in-if expression https://github.com/hashicorp/terraform-ls/issues/527
 	// TODO: Support conditional expression https://github.com/hashicorp/terraform-ls/issues/528
-	// TODO: Support operator expresssions https://github.com/hashicorp/terraform-ls/issues/529
 	// TODO: Support complex index expressions https://github.com/hashicorp/terraform-ls/issues/531
 	// TODO: Support relative traversals https://github.com/hashicorp/terraform-ls/issues/532
+
+	opCandidates, ok := a.completeOperatorExprAtPos(ctx, pos)
+	if !ok {
+		return candidates
+	}
+	candidates = append(candidates, opCandidates...)
 
 	ref := Reference{
 		expr:    a.expr,
@@ -129,4 +136,81 @@ func (a Any) completeNonComplexExprAtPos(ctx context.Context, pos hcl.Pos) []lan
 	candidates = append(candidates, lt.CompletionAtPos(ctx, pos)...)
 
 	return candidates
+}
+
+func (a Any) completeOperatorExprAtPos(ctx context.Context, pos hcl.Pos) ([]lang.Candidate, bool) {
+	candidates := make([]lang.Candidate, 0)
+
+	switch eType := a.expr.(type) {
+	case *hclsyntax.BinaryOpExpr:
+		opReturnType := eType.Op.Type
+
+		// Check if such an operation is even allowed within the constraint
+		if _, err := convert.Convert(cty.UnknownVal(opReturnType), a.cons.OfType); err != nil {
+			// This could illustrate a situation such as `list_attr = 42 +`
+			// which is invalid syntax as add (+) op will never produce a list
+			return candidates, false
+		}
+
+		opFuncParams := eType.Op.Impl.Params()
+		if len(opFuncParams) != 2 {
+			// This should never happen if HCL implementation is correct
+			return candidates, false
+		}
+
+		if eType.LHS.Range().ContainsPos(pos) {
+			cons := schema.AnyExpression{
+				OfType: opFuncParams[0].Type,
+			}
+			return newExpression(a.pathCtx, eType.LHS, cons).CompletionAtPos(ctx, pos), true
+		}
+		if eType.RHS.Range().ContainsPos(pos) || eType.RHS.Range().End.Byte == pos.Byte {
+			cons := schema.AnyExpression{
+				OfType: opFuncParams[1].Type,
+			}
+			return newExpression(a.pathCtx, eType.RHS, cons).CompletionAtPos(ctx, pos), true
+		}
+
+		return candidates, false
+
+	case *hclsyntax.UnaryOpExpr:
+		opReturnType := eType.Op.Type
+
+		// Check if such an operation is even allowed within the constraint
+		if _, err := convert.Convert(cty.UnknownVal(opReturnType), a.cons.OfType); err != nil {
+			// This could illustrate a situation such as `list_attr = !`
+			// which is invalid syntax as negation (!) op will never produce a list
+			return candidates, false
+		}
+
+		opFuncParams := eType.Op.Impl.Params()
+		if len(opFuncParams) != 1 {
+			// This should never happen if HCL implementation is correct
+			return candidates, false
+		}
+
+		if eType.Val.Range().ContainsPos(pos) || eType.Val.Range().End.Byte == pos.Byte {
+			cons := schema.AnyExpression{
+				OfType: opFuncParams[0].Type,
+			}
+			return newExpression(a.pathCtx, eType.Val, cons).CompletionAtPos(ctx, pos), true
+		}
+
+		// Trailing dot may be ignored by the parser so we attempt to recover it
+		if pos.Byte-eType.Val.Range().End.Byte == 1 {
+			fileBytes := a.pathCtx.Files[eType.Range().Filename].Bytes
+			trailingRune := fileBytes[eType.Val.Range().End.Byte:pos.Byte][0]
+
+			if trailingRune == '.' {
+				cons := schema.AnyExpression{
+					OfType: opFuncParams[0].Type,
+				}
+				return newExpression(a.pathCtx, eType.Val, cons).CompletionAtPos(ctx, pos), true
+			}
+		}
+
+		return candidates, false
+	}
+
+	return candidates, true
 }

--- a/decoder/expr_any_completion_test.go
+++ b/decoder/expr_any_completion_test.go
@@ -3007,6 +3007,66 @@ func TestCompletionAtPos_exprAny_operators(t *testing.T) {
 			hcl.Pos{Line: 1, Column: 9, Byte: 8},
 			lang.CompleteCandidates([]lang.Candidate{
 				{
+					Label:       "element",
+					Detail:      "element(list dynamic, index number) dynamic",
+					Description: lang.Markdown("`element` retrieves a single element from a list."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "element()",
+						Snippet: "element(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+							End:      hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						},
+					},
+				},
+				{
+					Label:       "join",
+					Detail:      "join(separator string, …lists list of string) string",
+					Description: lang.Markdown("`join` produces a string by concatenating together all elements of a given list of strings with the given delimiter."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "join()",
+						Snippet: "join(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+							End:      hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						},
+					},
+				},
+				{
+					Label:       "keys",
+					Detail:      "keys(inputMap dynamic) dynamic",
+					Description: lang.Markdown("`keys` takes a map and returns a list containing the keys from that map."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "keys()",
+						Snippet: "keys(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+							End:      hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						},
+					},
+				},
+				{
+					Label:       "lower",
+					Detail:      "lower(str string) string",
+					Description: lang.Markdown("`lower` converts all cased letters in the given string to lowercase."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "lower()",
+						Snippet: "lower(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+							End:      hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						},
+					},
+				},
+				{
 					Label:  "false",
 					Detail: "bool",
 					Kind:   lang.BoolCandidateKind,
@@ -3187,6 +3247,154 @@ func TestCompletionAtPos_exprAny_operators(t *testing.T) {
 				// TODO: See https://github.com/hashicorp/hcl-lang/issues/321
 			}),
 		},
+		{
+			"unary expression with function",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Bool,
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "foo"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 17},
+						End:      hcl.Pos{Line: 2, Column: 3, Byte: 19},
+					},
+					Type: cty.String,
+				},
+			},
+			`attr = !lower()
+`,
+			hcl.Pos{Line: 1, Column: 15, Byte: 14},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "var.foo",
+					Detail: "string",
+					Kind:   lang.TraversalCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "var.foo",
+						Snippet: "var.foo",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 15, Byte: 14},
+							End:      hcl.Pos{Line: 1, Column: 15, Byte: 14},
+						},
+					},
+				},
+				{
+					Label:       "element",
+					Detail:      "element(list dynamic, index number) dynamic",
+					Description: lang.Markdown("`element` retrieves a single element from a list."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "element()",
+						Snippet: "element(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 15, Byte: 14},
+							End:      hcl.Pos{Line: 1, Column: 15, Byte: 14},
+						},
+					},
+				},
+				{
+					Label:       "join",
+					Detail:      "join(separator string, …lists list of string) string",
+					Description: lang.Markdown("`join` produces a string by concatenating together all elements of a given list of strings with the given delimiter."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "join()",
+						Snippet: "join(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 15, Byte: 14},
+							End:      hcl.Pos{Line: 1, Column: 15, Byte: 14},
+						},
+					},
+				},
+				{
+					Label:       "keys",
+					Detail:      "keys(inputMap dynamic) dynamic",
+					Description: lang.Markdown("`keys` takes a map and returns a list containing the keys from that map."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "keys()",
+						Snippet: "keys(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 15, Byte: 14},
+							End:      hcl.Pos{Line: 1, Column: 15, Byte: 14},
+						},
+					},
+				},
+				{
+					Label:       "log",
+					Detail:      "log(num number, base number) number",
+					Description: lang.Markdown("`log` returns the logarithm of a given number in a given base."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "log()",
+						Snippet: "log(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 15, Byte: 14},
+							End:      hcl.Pos{Line: 1, Column: 15, Byte: 14},
+						},
+					},
+				},
+				{
+					Label:       "lower",
+					Detail:      "lower(str string) string",
+					Description: lang.Markdown("`lower` converts all cased letters in the given string to lowercase."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "lower()",
+						Snippet: "lower(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 15, Byte: 14},
+							End:      hcl.Pos{Line: 1, Column: 15, Byte: 14},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"unary expression with unterminated function",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Bool,
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "foo"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 17},
+						End:      hcl.Pos{Line: 2, Column: 3, Byte: 19},
+					},
+					Type: cty.String,
+				},
+			},
+			`attr = !lower(
+`,
+			hcl.Pos{Line: 1, Column: 15, Byte: 14},
+			lang.CompleteCandidates([]lang.Candidate{
+				// TODO: See https://github.com/hashicorp/hcl-lang/issues/325
+			}),
+		},
 	}
 
 	for i, tc := range testCases {
@@ -3202,6 +3410,7 @@ func TestCompletionAtPos_exprAny_operators(t *testing.T) {
 					"test.tf": f,
 				},
 				ReferenceTargets: tc.refTargets,
+				Functions:        testFunctionSignatures(),
 			})
 
 			ctx := context.Background()

--- a/decoder/expr_any_completion_test.go
+++ b/decoder/expr_any_completion_test.go
@@ -2826,3 +2826,393 @@ func TestCompletionAtPos_exprAny_skipComplex(t *testing.T) {
 		})
 	}
 }
+
+func TestCompletionAtPos_exprAny_operators(t *testing.T) {
+	testCases := []struct {
+		testName           string
+		attrSchema         map[string]*schema.AttributeSchema
+		refTargets         reference.Targets
+		cfg                string
+		pos                hcl.Pos
+		expectedCandidates lang.Candidates
+	}{
+		{
+			"logical OR",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Bool,
+					},
+				},
+			},
+			reference.Targets{},
+			`attr = true || f
+`,
+			hcl.Pos{Line: 1, Column: 17, Byte: 16},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "false",
+					Detail: "bool",
+					Kind:   lang.BoolCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "false",
+						Snippet: "false",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 16, Byte: 15},
+							End:      hcl.Pos{Line: 1, Column: 17, Byte: 16},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"logical OR mismatching constraint",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Number,
+					},
+				},
+			},
+			reference.Targets{},
+			`attr = true || f
+`,
+			hcl.Pos{Line: 1, Column: 17, Byte: 16},
+			lang.CompleteCandidates([]lang.Candidate{}),
+		},
+		{
+			"adding",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Number,
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "bar"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 17},
+						End:      hcl.Pos{Line: 2, Column: 3, Byte: 19},
+					},
+					Type: cty.String,
+				},
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "foo"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 17},
+						End:      hcl.Pos{Line: 2, Column: 3, Byte: 19},
+					},
+					Type: cty.Number,
+				},
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "list"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 17},
+						End:      hcl.Pos{Line: 2, Column: 3, Byte: 19},
+					},
+					Type: cty.List(cty.String),
+				},
+			},
+			`attr = 42 + v
+`,
+			hcl.Pos{Line: 1, Column: 14, Byte: 13},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "var.bar",
+					Detail: "string",
+					Kind:   lang.TraversalCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "var.bar",
+						Snippet: "var.bar",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 13, Byte: 12},
+							End:      hcl.Pos{Line: 1, Column: 14, Byte: 13},
+						},
+					},
+				},
+				{
+					Label:  "var.foo",
+					Detail: "number",
+					Kind:   lang.TraversalCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "var.foo",
+						Snippet: "var.foo",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 13, Byte: 12},
+							End:      hcl.Pos{Line: 1, Column: 14, Byte: 13},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"negation",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Bool,
+					},
+				},
+			},
+			reference.Targets{},
+			`attr = !f
+`,
+			hcl.Pos{Line: 1, Column: 10, Byte: 9},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "false",
+					Detail: "bool",
+					Kind:   lang.BoolCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "false",
+						Snippet: "false",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+							End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"unterminated expression with unary op",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Bool,
+					},
+				},
+			},
+			reference.Targets{},
+			`attr = !
+`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "false",
+					Detail: "bool",
+					Kind:   lang.BoolCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "false",
+						Snippet: "false",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+							End:      hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						},
+					},
+				},
+				{
+					Label:  "true",
+					Detail: "bool",
+					Kind:   lang.BoolCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "true",
+						Snippet: "true",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+							End:      hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"unterminated expression with unary op and trailing dot",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Bool,
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "bar"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 17},
+						End:      hcl.Pos{Line: 2, Column: 3, Byte: 19},
+					},
+					Type: cty.Bool,
+				},
+			},
+			`attr = !var.
+`,
+			hcl.Pos{Line: 1, Column: 13, Byte: 12},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "var.bar",
+					Detail: "bool",
+					Kind:   lang.TraversalCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "var.bar",
+						Snippet: "var.bar",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+							End:      hcl.Pos{Line: 1, Column: 13, Byte: 12},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"unterminated expression with binary op",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Number,
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "bar"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 17},
+						End:      hcl.Pos{Line: 2, Column: 3, Byte: 19},
+					},
+					Type: cty.String,
+				},
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "foo"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 17},
+						End:      hcl.Pos{Line: 2, Column: 3, Byte: 19},
+					},
+					Type: cty.Number,
+				},
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "list"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 17},
+						End:      hcl.Pos{Line: 2, Column: 3, Byte: 19},
+					},
+					Type: cty.List(cty.String),
+				},
+			},
+			`attr = 42 +
+`,
+			hcl.Pos{Line: 1, Column: 12, Byte: 11},
+			lang.CompleteCandidates([]lang.Candidate{
+				// TODO: See https://github.com/hashicorp/hcl-lang/issues/321
+			}),
+		},
+		{
+			"unterminated expression with binary op and trailing dot",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Number,
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "bar"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 17},
+						End:      hcl.Pos{Line: 2, Column: 3, Byte: 19},
+					},
+					Type: cty.String,
+				},
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "foo"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 17},
+						End:      hcl.Pos{Line: 2, Column: 3, Byte: 19},
+					},
+					Type: cty.Number,
+				},
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "list"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 17},
+						End:      hcl.Pos{Line: 2, Column: 3, Byte: 19},
+					},
+					Type: cty.List(cty.String),
+				},
+			},
+			`attr = 42 + var.
+`,
+			hcl.Pos{Line: 1, Column: 17, Byte: 16},
+			lang.CompleteCandidates([]lang.Candidate{
+				// TODO: See https://github.com/hashicorp/hcl-lang/issues/321
+			}),
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%2d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := &schema.BodySchema{
+				Attributes: tc.attrSchema,
+			}
+
+			f, _ := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.tf": f,
+				},
+				ReferenceTargets: tc.refTargets,
+			})
+
+			ctx := context.Background()
+			candidates, err := d.CandidatesAtPos(ctx, "test.tf", tc.pos)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedCandidates, candidates); diff != "" {
+				t.Fatalf("unexpected candidates: %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Related:
 - https://github.com/hashicorp/terraform-ls/issues/529

Follow-up issue:
 - https://github.com/hashicorp/hcl-lang/issues/321
 - https://github.com/hashicorp/hcl-lang/issues/325

--- 

## Example UX

![2023-09-27 11 27 25](https://github.com/hashicorp/hcl-lang/assets/287584/d4a3844a-5817-4083-bf12-89fbf62d0d04)
