### PR TITLE
decoder: Support template expressions

### DIFF
--- a/decoder/expr_any_completion_test.go
+++ b/decoder/expr_any_completion_test.go
@@ -3425,3 +3425,934 @@ func TestCompletionAtPos_exprAny_operators(t *testing.T) {
 		})
 	}
 }
+
+func TestCompletionAtPos_exprAny_template(t *testing.T) {
+	testCases := []struct {
+		testName           string
+		attrSchema         map[string]*schema.AttributeSchema
+		refTargets         reference.Targets
+		cfg                string
+		pos                hcl.Pos
+		expectedCandidates lang.Candidates
+	}{
+		{
+			"simple empty template",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "bar"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "variables.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 17},
+						End:      hcl.Pos{Line: 2, Column: 3, Byte: 19},
+					},
+					Type: cty.String,
+				},
+			},
+			`attr = "${}"
+`,
+			hcl.Pos{Line: 1, Column: 11, Byte: 10},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "var.bar",
+					Detail: "string",
+					Kind:   lang.TraversalCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "var.bar",
+						Snippet: "var.bar",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 11, Byte: 10},
+							End:      hcl.Pos{Line: 1, Column: 11, Byte: 10},
+						},
+					},
+				},
+				{
+					Label:       "element",
+					Detail:      "element(list dynamic, index number) dynamic",
+					Description: lang.Markdown("`element` retrieves a single element from a list."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "element()",
+						Snippet: "element(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 11, Byte: 10},
+							End:      hcl.Pos{Line: 1, Column: 11, Byte: 10},
+						},
+					},
+				},
+				{
+					Label:       "join",
+					Detail:      "join(separator string, …lists list of string) string",
+					Description: lang.Markdown("`join` produces a string by concatenating together all elements of a given list of strings with the given delimiter."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "join()",
+						Snippet: "join(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 11, Byte: 10},
+							End:      hcl.Pos{Line: 1, Column: 11, Byte: 10},
+						},
+					},
+				},
+				{
+					Label:       "keys",
+					Detail:      "keys(inputMap dynamic) dynamic",
+					Description: lang.Markdown("`keys` takes a map and returns a list containing the keys from that map."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "keys()",
+						Snippet: "keys(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 11, Byte: 10},
+							End:      hcl.Pos{Line: 1, Column: 11, Byte: 10},
+						},
+					},
+				},
+				{
+					Label:       "log",
+					Detail:      "log(num number, base number) number",
+					Description: lang.Markdown("`log` returns the logarithm of a given number in a given base."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "log()",
+						Snippet: "log(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 11, Byte: 10},
+							End:      hcl.Pos{Line: 1, Column: 11, Byte: 10},
+						},
+					},
+				},
+				{
+					Label:       "lower",
+					Detail:      "lower(str string) string",
+					Description: lang.Markdown("`lower` converts all cased letters in the given string to lowercase."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "lower()",
+						Snippet: "lower(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 11, Byte: 10},
+							End:      hcl.Pos{Line: 1, Column: 11, Byte: 10},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"multi line template",
+			map[string]*schema.AttributeSchema{
+				"content": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "bar"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "variables.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 17},
+						End:      hcl.Pos{Line: 2, Column: 3, Byte: 19},
+					},
+					Type: cty.String,
+				},
+			},
+			`content = <<-EOT
+  [Service]
+  User=${}
+EOT
+`,
+			hcl.Pos{Line: 3, Column: 10, Byte: 38},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "var.bar",
+					Detail: "string",
+					Kind:   lang.TraversalCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "var.bar",
+						Snippet: "var.bar",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 3, Column: 10, Byte: 38},
+							End:      hcl.Pos{Line: 3, Column: 10, Byte: 38},
+						},
+					},
+				},
+				{
+					Label:       "element",
+					Detail:      "element(list dynamic, index number) dynamic",
+					Description: lang.Markdown("`element` retrieves a single element from a list."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "element()",
+						Snippet: "element(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 3, Column: 10, Byte: 38},
+							End:      hcl.Pos{Line: 3, Column: 10, Byte: 38},
+						},
+					},
+				},
+				{
+					Label:       "join",
+					Detail:      "join(separator string, …lists list of string) string",
+					Description: lang.Markdown("`join` produces a string by concatenating together all elements of a given list of strings with the given delimiter."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "join()",
+						Snippet: "join(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 3, Column: 10, Byte: 38},
+							End:      hcl.Pos{Line: 3, Column: 10, Byte: 38},
+						},
+					},
+				},
+				{
+					Label:       "keys",
+					Detail:      "keys(inputMap dynamic) dynamic",
+					Description: lang.Markdown("`keys` takes a map and returns a list containing the keys from that map."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "keys()",
+						Snippet: "keys(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 3, Column: 10, Byte: 38},
+							End:      hcl.Pos{Line: 3, Column: 10, Byte: 38},
+						},
+					},
+				},
+				{
+					Label:       "log",
+					Detail:      "log(num number, base number) number",
+					Description: lang.Markdown("`log` returns the logarithm of a given number in a given base."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "log()",
+						Snippet: "log(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 3, Column: 10, Byte: 38},
+							End:      hcl.Pos{Line: 3, Column: 10, Byte: 38},
+						},
+					},
+				},
+				{
+					Label:       "lower",
+					Detail:      "lower(str string) string",
+					Description: lang.Markdown("`lower` converts all cased letters in the given string to lowercase."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "lower()",
+						Snippet: "lower(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 3, Column: 10, Byte: 38},
+							End:      hcl.Pos{Line: 3, Column: 10, Byte: 38},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"multiple expression, partial completion",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "bar"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "variables.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 17},
+						End:      hcl.Pos{Line: 2, Column: 3, Byte: 19},
+					},
+					Type: cty.String,
+				},
+			},
+			`attr = "foo-${var.bar}-bar-${l}"
+`,
+			hcl.Pos{Line: 1, Column: 31, Byte: 30},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:       "log",
+					Detail:      "log(num number, base number) number",
+					Description: lang.Markdown("`log` returns the logarithm of a given number in a given base."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "log()",
+						Snippet: "log(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 30, Byte: 29},
+							End:      hcl.Pos{Line: 1, Column: 31, Byte: 30},
+						},
+					},
+				},
+				{
+					Label:       "lower",
+					Detail:      "lower(str string) string",
+					Description: lang.Markdown("`lower` converts all cased letters in the given string to lowercase."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "lower()",
+						Snippet: "lower(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 30, Byte: 29},
+							End:      hcl.Pos{Line: 1, Column: 31, Byte: 30},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"no completion between $ and {",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			reference.Targets{},
+			`attr = "fo${var.bar}bar"
+`,
+			hcl.Pos{Line: 1, Column: 12, Byte: 11},
+			lang.CompleteCandidates([]lang.Candidate{}),
+		},
+		{
+			"no completion behind {",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			reference.Targets{},
+			`attr = "fo${var.bar}"
+`,
+			hcl.Pos{Line: 1, Column: 21, Byte: 20},
+			lang.CompleteCandidates([]lang.Candidate{}),
+		},
+		{
+			"completion within function within expression",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "bar"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "variables.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 17},
+						End:      hcl.Pos{Line: 2, Column: 3, Byte: 19},
+					},
+					Type: cty.String,
+				},
+			},
+			`attr = "foo-${element([0], )}-bar"
+`,
+			hcl.Pos{Line: 1, Column: 28, Byte: 27},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "var.bar",
+					Detail: "string",
+					Kind:   lang.TraversalCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "var.bar",
+						Snippet: "var.bar",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 28, Byte: 27},
+							End:      hcl.Pos{Line: 1, Column: 28, Byte: 27},
+						},
+					},
+				},
+				{
+					Label:       "element",
+					Detail:      "element(list dynamic, index number) dynamic",
+					Description: lang.Markdown("`element` retrieves a single element from a list."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "element()",
+						Snippet: "element(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 28, Byte: 27},
+							End:      hcl.Pos{Line: 1, Column: 28, Byte: 27},
+						},
+					},
+				},
+				{
+					Label:       "join",
+					Detail:      "join(separator string, …lists list of string) string",
+					Description: lang.Markdown("`join` produces a string by concatenating together all elements of a given list of strings with the given delimiter."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "join()",
+						Snippet: "join(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 28, Byte: 27},
+							End:      hcl.Pos{Line: 1, Column: 28, Byte: 27},
+						},
+					},
+				},
+				{
+					Label:       "keys",
+					Detail:      "keys(inputMap dynamic) dynamic",
+					Description: lang.Markdown("`keys` takes a map and returns a list containing the keys from that map."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "keys()",
+						Snippet: "keys(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 28, Byte: 27},
+							End:      hcl.Pos{Line: 1, Column: 28, Byte: 27},
+						},
+					},
+				},
+				{
+					Label:       "log",
+					Detail:      "log(num number, base number) number",
+					Description: lang.Markdown("`log` returns the logarithm of a given number in a given base."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "log()",
+						Snippet: "log(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 28, Byte: 27},
+							End:      hcl.Pos{Line: 1, Column: 28, Byte: 27},
+						},
+					},
+				},
+				{
+					Label:       "lower",
+					Detail:      "lower(str string) string",
+					Description: lang.Markdown("`lower` converts all cased letters in the given string to lowercase."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "lower()",
+						Snippet: "lower(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 28, Byte: 27},
+							End:      hcl.Pos{Line: 1, Column: 28, Byte: 27},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"expression within function expression",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "bar"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "variables.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 17},
+						End:      hcl.Pos{Line: 2, Column: 3, Byte: 19},
+					},
+					Type: cty.String,
+				},
+			},
+			`attr = lower("${var.}-${md5(local.name)}")
+`,
+			hcl.Pos{Line: 1, Column: 21, Byte: 20},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "var.bar",
+					Detail: "string",
+					Kind:   lang.TraversalCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "var.bar",
+						Snippet: "var.bar",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 17, Byte: 16},
+							End:      hcl.Pos{Line: 1, Column: 21, Byte: 20},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"expression with strip markers",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "bar"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "variables.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 17},
+						End:      hcl.Pos{Line: 2, Column: 3, Byte: 19},
+					},
+					Type: cty.String,
+				},
+			},
+			`attr = "Hello-${~ v}"
+`,
+			hcl.Pos{Line: 1, Column: 20, Byte: 19},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "var.bar",
+					Detail: "string",
+					Kind:   lang.TraversalCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "var.bar",
+						Snippet: "var.bar",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 19, Byte: 18},
+							End:      hcl.Pos{Line: 1, Column: 20, Byte: 19},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"expression within list",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.List{
+						Elem: schema.AnyExpression{OfType: cty.String},
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "bar"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "variables.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 17},
+						End:      hcl.Pos{Line: 2, Column: 3, Byte: 19},
+					},
+					Type: cty.String,
+				},
+			},
+			`attr = ["foo", "bar-${}"]
+`,
+			hcl.Pos{Line: 1, Column: 23, Byte: 22},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "var.bar",
+					Detail: "string",
+					Kind:   lang.TraversalCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "var.bar",
+						Snippet: "var.bar",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 23, Byte: 22},
+							End:      hcl.Pos{Line: 1, Column: 23, Byte: 22},
+						},
+					},
+				},
+				{
+					Label:       "element",
+					Detail:      "element(list dynamic, index number) dynamic",
+					Description: lang.Markdown("`element` retrieves a single element from a list."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "element()",
+						Snippet: "element(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 23, Byte: 22},
+							End:      hcl.Pos{Line: 1, Column: 23, Byte: 22},
+						},
+					},
+				},
+				{
+					Label:       "join",
+					Detail:      "join(separator string, …lists list of string) string",
+					Description: lang.Markdown("`join` produces a string by concatenating together all elements of a given list of strings with the given delimiter."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "join()",
+						Snippet: "join(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 23, Byte: 22},
+							End:      hcl.Pos{Line: 1, Column: 23, Byte: 22},
+						},
+					},
+				},
+				{
+					Label:       "keys",
+					Detail:      "keys(inputMap dynamic) dynamic",
+					Description: lang.Markdown("`keys` takes a map and returns a list containing the keys from that map."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "keys()",
+						Snippet: "keys(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 23, Byte: 22},
+							End:      hcl.Pos{Line: 1, Column: 23, Byte: 22},
+						},
+					},
+				},
+				{
+					Label:       "log",
+					Detail:      "log(num number, base number) number",
+					Description: lang.Markdown("`log` returns the logarithm of a given number in a given base."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "log()",
+						Snippet: "log(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 23, Byte: 22},
+							End:      hcl.Pos{Line: 1, Column: 23, Byte: 22},
+						},
+					},
+				},
+				{
+					Label:       "lower",
+					Detail:      "lower(str string) string",
+					Description: lang.Markdown("`lower` converts all cased letters in the given string to lowercase."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "lower()",
+						Snippet: "lower(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 23, Byte: 22},
+							End:      hcl.Pos{Line: 1, Column: 23, Byte: 22},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"expression within set",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Set{
+						Elem: schema.AnyExpression{OfType: cty.String},
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "bar"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "variables.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 17},
+						End:      hcl.Pos{Line: 2, Column: 3, Byte: 19},
+					},
+					Type: cty.String,
+				},
+			},
+			`attr = ["foo", "bar-${}"]
+`,
+			hcl.Pos{Line: 1, Column: 23, Byte: 22},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "var.bar",
+					Detail: "string",
+					Kind:   lang.TraversalCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "var.bar",
+						Snippet: "var.bar",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 23, Byte: 22},
+							End:      hcl.Pos{Line: 1, Column: 23, Byte: 22},
+						},
+					},
+				},
+				{
+					Label:       "element",
+					Detail:      "element(list dynamic, index number) dynamic",
+					Description: lang.Markdown("`element` retrieves a single element from a list."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "element()",
+						Snippet: "element(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 23, Byte: 22},
+							End:      hcl.Pos{Line: 1, Column: 23, Byte: 22},
+						},
+					},
+				},
+				{
+					Label:       "join",
+					Detail:      "join(separator string, …lists list of string) string",
+					Description: lang.Markdown("`join` produces a string by concatenating together all elements of a given list of strings with the given delimiter."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "join()",
+						Snippet: "join(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 23, Byte: 22},
+							End:      hcl.Pos{Line: 1, Column: 23, Byte: 22},
+						},
+					},
+				},
+				{
+					Label:       "keys",
+					Detail:      "keys(inputMap dynamic) dynamic",
+					Description: lang.Markdown("`keys` takes a map and returns a list containing the keys from that map."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "keys()",
+						Snippet: "keys(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 23, Byte: 22},
+							End:      hcl.Pos{Line: 1, Column: 23, Byte: 22},
+						},
+					},
+				},
+				{
+					Label:       "log",
+					Detail:      "log(num number, base number) number",
+					Description: lang.Markdown("`log` returns the logarithm of a given number in a given base."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "log()",
+						Snippet: "log(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 23, Byte: 22},
+							End:      hcl.Pos{Line: 1, Column: 23, Byte: 22},
+						},
+					},
+				},
+				{
+					Label:       "lower",
+					Detail:      "lower(str string) string",
+					Description: lang.Markdown("`lower` converts all cased letters in the given string to lowercase."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "lower()",
+						Snippet: "lower(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 23, Byte: 22},
+							End:      hcl.Pos{Line: 1, Column: 23, Byte: 22},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"expression within tuple",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Tuple{
+						Elems: []schema.Constraint{
+							schema.AnyExpression{OfType: cty.String},
+							schema.AnyExpression{OfType: cty.String},
+						},
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "bar"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "variables.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 17},
+						End:      hcl.Pos{Line: 2, Column: 3, Byte: 19},
+					},
+					Type: cty.String,
+				},
+			},
+			`attr = ["foo", "bar-${}"]
+`,
+			hcl.Pos{Line: 1, Column: 23, Byte: 22},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "var.bar",
+					Detail: "string",
+					Kind:   lang.TraversalCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "var.bar",
+						Snippet: "var.bar",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 23, Byte: 22},
+							End:      hcl.Pos{Line: 1, Column: 23, Byte: 22},
+						},
+					},
+				},
+				{
+					Label:       "element",
+					Detail:      "element(list dynamic, index number) dynamic",
+					Description: lang.Markdown("`element` retrieves a single element from a list."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "element()",
+						Snippet: "element(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 23, Byte: 22},
+							End:      hcl.Pos{Line: 1, Column: 23, Byte: 22},
+						},
+					},
+				},
+				{
+					Label:       "join",
+					Detail:      "join(separator string, …lists list of string) string",
+					Description: lang.Markdown("`join` produces a string by concatenating together all elements of a given list of strings with the given delimiter."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "join()",
+						Snippet: "join(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 23, Byte: 22},
+							End:      hcl.Pos{Line: 1, Column: 23, Byte: 22},
+						},
+					},
+				},
+				{
+					Label:       "keys",
+					Detail:      "keys(inputMap dynamic) dynamic",
+					Description: lang.Markdown("`keys` takes a map and returns a list containing the keys from that map."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "keys()",
+						Snippet: "keys(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 23, Byte: 22},
+							End:      hcl.Pos{Line: 1, Column: 23, Byte: 22},
+						},
+					},
+				},
+				{
+					Label:       "log",
+					Detail:      "log(num number, base number) number",
+					Description: lang.Markdown("`log` returns the logarithm of a given number in a given base."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "log()",
+						Snippet: "log(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 23, Byte: 22},
+							End:      hcl.Pos{Line: 1, Column: 23, Byte: 22},
+						},
+					},
+				},
+				{
+					Label:       "lower",
+					Detail:      "lower(str string) string",
+					Description: lang.Markdown("`lower` converts all cased letters in the given string to lowercase."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "lower()",
+						Snippet: "lower(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 23, Byte: 22},
+							End:      hcl.Pos{Line: 1, Column: 23, Byte: 22},
+						},
+					},
+				},
+			}),
+		},
+		// TODO: test if directive after https://github.com/hashicorp/terraform-ls/issues/528 lands
+		// TODO: test for directive after https://github.com/hashicorp/terraform-ls/issues/527 lands
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%2d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := &schema.BodySchema{
+				Attributes: tc.attrSchema,
+			}
+
+			f, _ := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.tf": f,
+				},
+				ReferenceTargets: tc.refTargets,
+				Functions:        testFunctionSignatures(),
+			})
+
+			ctx := context.Background()
+			candidates, err := d.CandidatesAtPos(ctx, "test.tf", tc.pos)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedCandidates, candidates); diff != "" {
+				t.Fatalf("unexpected candidates: %s", diff)
+			}
+		})
+	}
+}

--- a/decoder/expr_any_hover_test.go
+++ b/decoder/expr_any_hover_test.go
@@ -316,7 +316,14 @@ TEXT
 			},
 			`attr = "foo${bar}"`,
 			hcl.Pos{Line: 1, Column: 9, Byte: 8},
-			nil,
+			&lang.HoverData{
+				Content: lang.Markdown("_string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+					End:      hcl.Pos{Line: 1, Column: 12, Byte: 11},
+				},
+			},
 		},
 
 		// list
@@ -1689,6 +1696,63 @@ func TestHoverAtPos_exprAny_templates(t *testing.T) {
 					Filename: "test.tf",
 					Start:    hcl.Pos{Line: 1, Column: 15, Byte: 14},
 					End:      hcl.Pos{Line: 1, Column: 24, Byte: 23},
+				},
+			},
+		},
+		{
+			"heredoc with reference",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			reference.Origins{
+				reference.LocalOrigin{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "foo"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 3, Column: 3, Byte: 19},
+						End:      hcl.Pos{Line: 3, Column: 12, Byte: 28},
+					},
+					Constraints: reference.OriginConstraints{
+						{
+							OfType: cty.String,
+						},
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "foo"},
+					},
+					Type: cty.String,
+					RangePtr: &hcl.Range{
+						Filename: "variables.tf",
+						Start:    hcl.Pos{Line: 5, Column: 1, Byte: 34},
+						End:      hcl.Pos{Line: 5, Column: 13, Byte: 45},
+					},
+				},
+			},
+			`attr = <<EOT
+foo
+${local.foo}
+bar
+EOT
+`,
+			hcl.Pos{Line: 2, Column: 2, Byte: 14},
+			&lang.HoverData{
+				Content: lang.Markdown("_string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 2, Column: 1, Byte: 13},
+					End:      hcl.Pos{Line: 3, Column: 1, Byte: 17},
 				},
 			},
 		},

--- a/decoder/expr_any_ref_origins_test.go
+++ b/decoder/expr_any_ref_origins_test.go
@@ -61,7 +61,7 @@ func TestCollectRefOrigins_exprAny_references_hcl(t *testing.T) {
 					},
 					Constraints: reference.OriginConstraints{
 						{
-							OfType: cty.DynamicPseudoType,
+							OfType: cty.String,
 						},
 					},
 				},
@@ -90,7 +90,7 @@ func TestCollectRefOrigins_exprAny_references_hcl(t *testing.T) {
 					},
 					Constraints: reference.OriginConstraints{
 						{
-							OfType: cty.DynamicPseudoType,
+							OfType: cty.String,
 						},
 					},
 				},
@@ -508,7 +508,7 @@ func TestCollectRefOrigins_exprAny_functions_hcl(t *testing.T) {
 					},
 					Constraints: reference.OriginConstraints{
 						{
-							OfType: cty.DynamicPseudoType,
+							OfType: cty.String,
 						},
 					},
 				},

--- a/decoder/expr_any_semtok.go
+++ b/decoder/expr_any_semtok.go
@@ -195,7 +195,12 @@ func (a Any) semanticTokensForTemplateExpr(ctx context.Context) ([]lang.Semantic
 	switch eType := a.expr.(type) {
 	case *hclsyntax.TemplateExpr:
 		if eType.IsStringLiteral() {
-			return nil, false
+			cons := schema.LiteralType{
+				Type: cty.String,
+			}
+			expr := newExpression(a.pathCtx, eType, cons)
+			tokens = append(tokens, expr.SemanticTokens(ctx)...)
+			return tokens, true
 		}
 
 		for _, partExpr := range eType.Parts {

--- a/decoder/expr_any_semtok.go
+++ b/decoder/expr_any_semtok.go
@@ -95,15 +95,17 @@ func (a Any) SemanticTokens(ctx context.Context) []lang.SemanticToken {
 }
 
 func (a Any) semanticTokensForNonComplexExpr(ctx context.Context) []lang.SemanticToken {
-	// TODO: Support TemplateExpr https://github.com/hashicorp/terraform-ls/issues/522
 	// TODO: Support splat expression https://github.com/hashicorp/terraform-ls/issues/526
 	// TODO: Support for-in-if expression https://github.com/hashicorp/terraform-ls/issues/527
 	// TODO: Support conditional expression https://github.com/hashicorp/terraform-ls/issues/528
-	// TODO: Support operator expresssions https://github.com/hashicorp/terraform-ls/issues/529
 	// TODO: Support complex index expressions https://github.com/hashicorp/terraform-ls/issues/531
 	// TODO: Support relative traversals https://github.com/hashicorp/terraform-ls/issues/532
 
 	if tokens, ok := a.semanticTokensForOperatorExpr(ctx); ok {
+		return tokens
+	}
+
+	if tokens, ok := a.semanticTokensForTemplateExpr(ctx); ok {
 		return tokens
 	}
 
@@ -180,6 +182,37 @@ func (a Any) semanticTokensForOperatorExpr(ctx context.Context) ([]lang.Semantic
 		tokens = append(tokens, newExpression(a.pathCtx, eType.Val, schema.AnyExpression{
 			OfType: opFuncParams[0].Type,
 		}).SemanticTokens(ctx)...)
+
+		return tokens, true
+	}
+
+	return tokens, false
+}
+
+func (a Any) semanticTokensForTemplateExpr(ctx context.Context) ([]lang.SemanticToken, bool) {
+	tokens := make([]lang.SemanticToken, 0)
+
+	switch eType := a.expr.(type) {
+	case *hclsyntax.TemplateExpr:
+		if eType.IsStringLiteral() {
+			return nil, false
+		}
+
+		for _, partExpr := range eType.Parts {
+			cons := schema.AnyExpression{
+				OfType: cty.String,
+			}
+			expr := newExpression(a.pathCtx, partExpr, cons)
+			tokens = append(tokens, expr.SemanticTokens(ctx)...)
+		}
+
+		return tokens, true
+	case *hclsyntax.TemplateWrapExpr:
+		cons := schema.AnyExpression{
+			OfType: cty.String,
+		}
+		expr := newExpression(a.pathCtx, eType.Wrapped, cons)
+		tokens = append(tokens, expr.SemanticTokens(ctx)...)
 
 		return tokens, true
 	}

--- a/decoder/expr_any_semtok_test.go
+++ b/decoder/expr_any_semtok_test.go
@@ -2695,8 +2695,26 @@ func TestSemanticTokens_exprAny_templates(t *testing.T) {
 					Modifiers: lang.SemanticTokenModifiers{},
 					Range: hcl.Range{
 						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						End:      hcl.Pos{Line: 1, Column: 13, Byte: 12},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
 						Start:    hcl.Pos{Line: 1, Column: 15, Byte: 14},
 						End:      hcl.Pos{Line: 1, Column: 20, Byte: 19},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 21, Byte: 20},
+						End:      hcl.Pos{Line: 1, Column: 25, Byte: 24},
 					},
 				},
 			},
@@ -2755,6 +2773,15 @@ func TestSemanticTokens_exprAny_templates(t *testing.T) {
 					},
 				},
 				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						End:      hcl.Pos{Line: 1, Column: 13, Byte: 12},
+					},
+				},
+				{
 					Type:      lang.TokenTraversalStep,
 					Modifiers: lang.SemanticTokenModifiers{},
 					Range: hcl.Range{
@@ -2770,6 +2797,110 @@ func TestSemanticTokens_exprAny_templates(t *testing.T) {
 						Filename: "test.tf",
 						Start:    hcl.Pos{Line: 1, Column: 21, Byte: 20},
 						End:      hcl.Pos{Line: 1, Column: 24, Byte: 23},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 25, Byte: 24},
+						End:      hcl.Pos{Line: 1, Column: 29, Byte: 28},
+					},
+				},
+			},
+		},
+		{
+			"heredoc with reference",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			reference.Origins{
+				reference.LocalOrigin{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "foo"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 15, Byte: 14},
+						End:      hcl.Pos{Line: 1, Column: 24, Byte: 23},
+					},
+					Constraints: reference.OriginConstraints{
+						{
+							OfType: cty.String,
+						},
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "foo"},
+					},
+					Type: cty.String,
+					RangePtr: &hcl.Range{
+						Filename: "variables.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 17},
+						End:      hcl.Pos{Line: 2, Column: 13, Byte: 29},
+					},
+				},
+			},
+			`attr = <<EOT
+foo
+${local.foo}
+bar
+EOT
+`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 13}, // TODO: multi-line tokens?
+						End:      hcl.Pos{Line: 3, Column: 1, Byte: 17},
+					},
+				},
+				{
+					Type:      lang.TokenTraversalStep,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 3, Column: 3, Byte: 19},
+						End:      hcl.Pos{Line: 3, Column: 8, Byte: 24},
+					},
+				},
+				{
+					Type:      lang.TokenTraversalStep,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 3, Column: 9, Byte: 25},
+						End:      hcl.Pos{Line: 3, Column: 12, Byte: 28},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 3, Column: 13, Byte: 29},
+						End:      hcl.Pos{Line: 5, Column: 1, Byte: 34},
 					},
 				},
 			},

--- a/decoder/expr_any_semtok_test.go
+++ b/decoder/expr_any_semtok_test.go
@@ -2657,3 +2657,150 @@ func TestSemanticTokens_exprAny_operators(t *testing.T) {
 		})
 	}
 }
+
+func TestSemanticTokens_exprAny_templates(t *testing.T) {
+	testCases := []struct {
+		testName               string
+		attrSchema             map[string]*schema.AttributeSchema
+		refOrigins             reference.Origins
+		refTargets             reference.Targets
+		cfg                    string
+		expectedSemanticTokens []lang.SemanticToken
+	}{
+		{
+			"expression string",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			reference.Origins{},
+			reference.Targets{},
+			`attr = "foo-${"bar"}-bar"
+`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenString,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 15, Byte: 14},
+						End:      hcl.Pos{Line: 1, Column: 20, Byte: 19},
+					},
+				},
+			},
+		},
+		{
+			"expression with reference",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			reference.Origins{
+				reference.LocalOrigin{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "foo"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 15, Byte: 14},
+						End:      hcl.Pos{Line: 1, Column: 24, Byte: 23},
+					},
+					Constraints: reference.OriginConstraints{
+						{
+							OfType: cty.String,
+						},
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "foo"},
+					},
+					Type: cty.String,
+					RangePtr: &hcl.Range{
+						Filename: "variables.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 17},
+						End:      hcl.Pos{Line: 2, Column: 13, Byte: 29},
+					},
+				},
+			},
+			`attr = "foo-${local.foo}-bar"
+`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenTraversalStep,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 15, Byte: 14},
+						End:      hcl.Pos{Line: 1, Column: 20, Byte: 19},
+					},
+				},
+				{
+					Type:      lang.TokenTraversalStep,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 21, Byte: 20},
+						End:      hcl.Pos{Line: 1, Column: 24, Byte: 23},
+					},
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := &schema.BodySchema{
+				Attributes: tc.attrSchema,
+			}
+
+			f, _ := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.tf": f,
+				},
+				ReferenceOrigins: tc.refOrigins,
+				ReferenceTargets: tc.refTargets,
+			})
+
+			ctx := context.Background()
+			tokens, err := d.SemanticTokensInFile(ctx, "test.tf")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedSemanticTokens, tokens); diff != "" {
+				t.Fatalf("unexpected tokens: %s", diff)
+			}
+		})
+	}
+}

--- a/decoder/expr_literal_type_hover.go
+++ b/decoder/expr_literal_type_hover.go
@@ -28,17 +28,14 @@ func (lt LiteralType) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverDa
 	// even if there's no templating involved
 	if typ == cty.String {
 		expr, ok := lt.expr.(*hclsyntax.TemplateExpr)
-		if !ok {
-			return nil
-		}
-		if expr.IsStringLiteral() || isMultilineStringLiteral(expr) {
+		if ok && (expr.IsStringLiteral() || isMultilineStringLiteral(expr)) {
 			return &lang.HoverData{
 				Content: lang.Markdown(fmt.Sprintf(`_%s_`, typ.FriendlyName())),
 				Range:   expr.Range(),
 			}
 		}
-
-		return nil
+		// We may however land here from within AnyExpression, in which case
+		// the embedded string is in fact LiteralValueExpr and it is handled below.
 	}
 
 	if typ.IsPrimitiveType() {

--- a/decoder/reference_origins_collect_hcl_test.go
+++ b/decoder/reference_origins_collect_hcl_test.go
@@ -162,7 +162,7 @@ attr3 = onestep`,
 						lang.RootStep{Name: "onestep"},
 					},
 					Constraints: reference.OriginConstraints{
-						{OfType: cty.DynamicPseudoType},
+						{OfType: cty.String},
 					},
 					Range: hcl.Range{
 						Filename: "test.tf",
@@ -183,7 +183,7 @@ attr3 = onestep`,
 						lang.RootStep{Name: "onestep"},
 					},
 					Constraints: reference.OriginConstraints{
-						{OfType: cty.DynamicPseudoType},
+						{OfType: cty.String},
 					},
 					Range: hcl.Range{
 						Filename: "test.tf",
@@ -206,7 +206,7 @@ attr3 = onestep`,
 						lang.AttrStep{Name: "bar"},
 					},
 					Constraints: reference.OriginConstraints{
-						{OfType: cty.DynamicPseudoType},
+						{OfType: cty.String},
 					},
 					Range: hcl.Range{
 						Filename: "test.tf",


### PR DESCRIPTION
* Part of https://github.com/hashicorp/terraform-ls/issues/496
* Related to https://github.com/hashicorp/terraform-ls/issues/522

---

This PR adds support for template expressions inside single and multiline strings.

I filed https://github.com/hashicorp/hcl-lang/issues/345 to track edge cases for empty template expressions inside maps and objects.

### Example UX
![2023-11-17 14 45 22](https://github.com/hashicorp/hcl-lang/assets/45985/38fad863-ddea-43a6-ab34-bad3e04c3930)

### Directives

`if` directives within template expressions are [turned into conditional expressions](https://github.com/hashicorp/hcl/blob/c964a71ca32006c9e7a0730b5a0e1dd60b05d308/hclsyntax/parser_template.go#L242-L248) and `for` directives are [turned into for expressions](https://github.com/hashicorp/hcl/blob/c964a71ca32006c9e7a0730b5a0e1dd60b05d308/hclsyntax/parser_template.go#L331-L341). So I would defer support for this until those expressions land
* https://github.com/hashicorp/terraform-ls/issues/527 
* https://github.com/hashicorp/terraform-ls/issues/528