### PR TITLE
schema: Introduce `DefaultValue` for `AttributeSchema`

### DIFF
--- a/schema/attribute_schema.go
+++ b/schema/attribute_schema.go
@@ -27,6 +27,11 @@ type AttributeSchema struct {
 	// expressions are expected for the attribute
 	Constraint Constraint
 
+	// DefaultValue represents default value which applies
+	// if the attribute is not declared (e.g. when looking up
+	// attribute-dependent body).
+	DefaultValue Default
+
 	// IsDepKey describes whether to use this attribute (and its value)
 	// as key when looking up dependent schema
 	IsDepKey bool
@@ -144,6 +149,7 @@ func (as *AttributeSchema) Copy() *AttributeSchema {
 		IsComputed:             as.IsComputed,
 		IsSensitive:            as.IsSensitive,
 		IsDepKey:               as.IsDepKey,
+		DefaultValue:           as.DefaultValue,
 		Description:            as.Description,
 		Address:                as.Address.Copy(),
 		OriginForTarget:        as.OriginForTarget.Copy(),

--- a/schema/default_value.go
+++ b/schema/default_value.go
@@ -1,0 +1,25 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import "github.com/zclconf/go-cty/cty"
+
+type defaultSigil struct{}
+
+type Default interface {
+	isDefaultImpl() defaultSigil
+}
+
+type DefaultValue struct {
+	Value cty.Value
+}
+
+func (dv DefaultValue) isDefaultImpl() defaultSigil {
+	return defaultSigil{}
+}
+
+// TODO: DefaultKeyword
+// TODO: DefaultTypeDeclaration
+// TODO: defaults dependent on other attributes
+// TODO: defaults dependent on env variables


### PR DESCRIPTION
Related to:
 - https://github.com/hashicorp/hcl-lang/issues/120
 - https://github.com/hashicorp/vscode-terraform/issues/1573#issuecomment-1748331505
 - https://github.com/hashicorp/terraform-schema/pull/270

--- 

This allows us to address the issue surfaced in https://github.com/hashicorp/vscode-terraform/issues/1573#issuecomment-1748331505 without necessarily implementing all the things related to default value handling.

## Before

![2023-10-05 11 57 24](https://github.com/hashicorp/hcl-lang/assets/287584/25d115a1-0b17-4105-9fd8-57a6c2a4864b)

## After

![2023-10-05 11 58 04](https://github.com/hashicorp/hcl-lang/assets/287584/a8bd0a8c-de16-4603-bdb2-99f589b2e234)
