### PR TITLE
(fix) decoder: Ensure empty objects & tuples still get collected as targets

### DIFF
--- a/decoder/expr_object_ref_targets.go
+++ b/decoder/expr_object_ref_targets.go
@@ -26,10 +26,6 @@ func (obj Object) ReferenceTargets(ctx context.Context, targetCtx *TargetContext
 		return reference.Targets{}
 	}
 
-	if len(obj.cons.Attributes) == 0 {
-		return reference.Targets{}
-	}
-
 	for _, item := range items {
 		keyName, _, ok := rawObjectKey(item.Key)
 		if !ok {

--- a/decoder/expr_tuple_ref_targets.go
+++ b/decoder/expr_tuple_ref_targets.go
@@ -22,10 +22,6 @@ func (tuple Tuple) ReferenceTargets(ctx context.Context, targetCtx *TargetContex
 		return reference.Targets{}
 	}
 
-	if len(tuple.cons.Elems) == 0 {
-		return reference.Targets{}
-	}
-
 	elemTargets := tuple.collectTupleElemTargets(ctx, targetCtx, elems)
 
 	if targetCtx == nil {

--- a/decoder/reference_targets_collect_hcl_test.go
+++ b/decoder/reference_targets_collect_hcl_test.go
@@ -4952,6 +4952,48 @@ module "different" {
 				},
 			},
 		},
+		{
+			"empty tuple",
+			&schema.BodySchema{
+				Attributes: map[string]*schema.AttributeSchema{
+					"attr": {
+						Constraint: schema.LiteralType{Type: cty.DynamicPseudoType},
+						IsOptional: true,
+						Address: &schema.AttributeAddrSchema{
+							Steps: schema.Address{
+								schema.StaticStep{Name: "local"},
+								schema.AttrNameStep{},
+							},
+							ScopeId:    "test",
+							AsExprType: true,
+						},
+					},
+				},
+			},
+			`attr = []
+`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "attr"},
+					},
+					ScopeId: "test",
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+					Type:          cty.Tuple([]cty.Type{}),
+					NestedTargets: reference.Targets{},
+				},
+			},
+		},
 	}
 
 	for i, tc := range testCases {

--- a/decoder/reference_targets_collect_hcl_test.go
+++ b/decoder/reference_targets_collect_hcl_test.go
@@ -4994,6 +4994,48 @@ module "different" {
 				},
 			},
 		},
+		{
+			"empty map",
+			&schema.BodySchema{
+				Attributes: map[string]*schema.AttributeSchema{
+					"attr": {
+						Constraint: schema.LiteralType{Type: cty.Map(cty.String)},
+						IsOptional: true,
+						Address: &schema.AttributeAddrSchema{
+							Steps: schema.Address{
+								schema.StaticStep{Name: "local"},
+								schema.AttrNameStep{},
+							},
+							ScopeId:    "test",
+							AsExprType: true,
+						},
+					},
+				},
+			},
+			`attr = {}
+`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "attr"},
+					},
+					ScopeId: "test",
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+					Type:          cty.Map(cty.String),
+					NestedTargets: reference.Targets{},
+				},
+			},
+		},
 	}
 
 	for i, tc := range testCases {

--- a/decoder/reference_targets_collect_hcl_test.go
+++ b/decoder/reference_targets_collect_hcl_test.go
@@ -5078,6 +5078,48 @@ module "different" {
 				},
 			},
 		},
+		{
+			"empty set",
+			&schema.BodySchema{
+				Attributes: map[string]*schema.AttributeSchema{
+					"attr": {
+						Constraint: schema.LiteralType{Type: cty.Set(cty.String)},
+						IsOptional: true,
+						Address: &schema.AttributeAddrSchema{
+							Steps: schema.Address{
+								schema.StaticStep{Name: "local"},
+								schema.AttrNameStep{},
+							},
+							ScopeId:    "test",
+							AsExprType: true,
+						},
+					},
+				},
+			},
+			`attr = []
+`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "attr"},
+					},
+					ScopeId: "test",
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+					Type:          cty.Set(cty.String),
+					NestedTargets: reference.Targets{},
+				},
+			},
+		},
 	}
 
 	for i, tc := range testCases {

--- a/decoder/reference_targets_collect_hcl_test.go
+++ b/decoder/reference_targets_collect_hcl_test.go
@@ -4910,6 +4910,48 @@ module "different" {
 				},
 			},
 		},
+		{
+			"empty object",
+			&schema.BodySchema{
+				Attributes: map[string]*schema.AttributeSchema{
+					"attr": {
+						Constraint: schema.LiteralType{Type: cty.DynamicPseudoType},
+						IsOptional: true,
+						Address: &schema.AttributeAddrSchema{
+							Steps: schema.Address{
+								schema.StaticStep{Name: "local"},
+								schema.AttrNameStep{},
+							},
+							ScopeId:    "test",
+							AsExprType: true,
+						},
+					},
+				},
+			},
+			`attr = {}
+`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "attr"},
+					},
+					ScopeId: "test",
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+					Type:          cty.Object(map[string]cty.Type{}),
+					NestedTargets: reference.Targets{},
+				},
+			},
+		},
 	}
 
 	for i, tc := range testCases {

--- a/decoder/reference_targets_collect_hcl_test.go
+++ b/decoder/reference_targets_collect_hcl_test.go
@@ -5036,6 +5036,48 @@ module "different" {
 				},
 			},
 		},
+		{
+			"empty list",
+			&schema.BodySchema{
+				Attributes: map[string]*schema.AttributeSchema{
+					"attr": {
+						Constraint: schema.LiteralType{Type: cty.List(cty.String)},
+						IsOptional: true,
+						Address: &schema.AttributeAddrSchema{
+							Steps: schema.Address{
+								schema.StaticStep{Name: "local"},
+								schema.AttrNameStep{},
+							},
+							ScopeId:    "test",
+							AsExprType: true,
+						},
+					},
+				},
+			},
+			`attr = []
+`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "attr"},
+					},
+					ScopeId: "test",
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+					Type:          cty.List(cty.String),
+					NestedTargets: reference.Targets{},
+				},
+			},
+		},
 	}
 
 	for i, tc := range testCases {


### PR DESCRIPTION
As reported in https://github.com/hashicorp/vscode-terraform/issues/1576 we previously did not collect empty objects and tuples as targets, which caused us to raise this as diagnostics that wasn't relevant.

This PR fixes it and adds some additional tests for some other types just to ensure that we don't introduce similar problem in the future there either.

## Before

![2023-10-06 10 33 30](https://github.com/hashicorp/hcl-lang/assets/287584/8d605d7c-28b0-46af-aa43-fb71dc4d0e42)

## After

![2023-10-06 10 32 30](https://github.com/hashicorp/hcl-lang/assets/287584/744f521d-2642-4cbd-9eb1-1c828f4a7457)
