### PR TITLE
decoder: allow objects in `for_each`

### DIFF
--- a/decoder/body_extensions_test.go
+++ b/decoder/body_extensions_test.go
@@ -667,7 +667,7 @@ func TestCompletionAtPos_BodySchema_Extensions_ForEach(t *testing.T) {
 					Value: "A meta-argument that accepts a map or a set of strings, and creates an instance for each item in that map or set.\n\n**Note**: A given block cannot use both `count` and `for_each`.",
 					Kind:  lang.MarkdownKind,
 				},
-				Detail: "optional, map of any single type or set of string",
+				Detail: "optional, map of any single type or set of string or object",
 				TextEdit: lang.TextEdit{
 					Range: hcl.Range{
 						Filename: "test.tf",
@@ -1101,6 +1101,20 @@ for_each =
 						Snippet: `[ "${1:value}" ]`,
 					},
 					Kind: lang.SetCandidateKind,
+				},
+				{
+					Label:  "{  }",
+					Detail: "object",
+					TextEdit: lang.TextEdit{
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 12, Byte: 43},
+							End:      hcl.Pos{Line: 2, Column: 12, Byte: 43},
+						},
+						NewText: "{\n}",
+						Snippet: "{\n}",
+					},
+					Kind: lang.ObjectCandidateKind,
 				},
 			}),
 		},

--- a/decoder/hover_test.go
+++ b/decoder/hover_test.go
@@ -1147,7 +1147,7 @@ func TestDecoder_HoverAtPos_extension_for_each(t *testing.T) {
 			hcl.Pos{Line: 2, Column: 5, Byte: 26},
 			&lang.HoverData{
 				Content: lang.MarkupContent{
-					Value: "**for_each** _optional, map of any single type or set of string_\n\n" +
+					Value: "**for_each** _optional, map of any single type or set of string or object_\n\n" +
 						"A meta-argument that accepts a map or a set of strings, and creates an instance for each item in that map or set.\n\n" +
 						"**Note**: A given block cannot use both `count` and `for_each`.",
 					Kind: lang.MarkdownKind,

--- a/decoder/internal/schemahelper/attribute_extensions.go
+++ b/decoder/internal/schemahelper/attribute_extensions.go
@@ -24,6 +24,12 @@ func ForEachAttributeSchema() *schema.AttributeSchema {
 		Constraint: schema.OneOf{
 			schema.AnyExpression{OfType: cty.Map(cty.DynamicPseudoType)},
 			schema.AnyExpression{OfType: cty.Set(cty.String)},
+			// Objects are still supported for backwards-compatible reasons
+			// but in general should be avoided here. We add it here because
+			// otherwise valid configuration would be flagged as invalid.
+			// We cannot suppress it in completion (yet) or otherwise inform
+			// the user of this anti-pattern though.
+			schema.AnyExpression{OfType: cty.EmptyObject},
 		},
 		Description: lang.Markdown("A meta-argument that accepts a map or a set of strings, and creates an instance for each item in that map or set.\n\n" +
 			"**Note**: A given block cannot use both `count` and `for_each`."),


### PR DESCRIPTION
Related to:

 - https://github.com/hashicorp/vscode-terraform/issues/1586

--- 

Relevant LOC in Terraform: https://github.com/hashicorp/terraform/blob/07b814c030daae39dea764571bef9cecf26e49be/internal/terraform/eval_for_each.go#L275-L284

As the in-line comment says:

Objects are still supported for backwards-compatible reasons but in general should be avoided. We add it here because otherwise valid configuration would be flagged as invalid. We cannot suppress it in completion (yet) or otherwise inform the user of this anti-pattern though.


## Before

![Screenshot 2023-10-11 at 15 28 32](https://github.com/hashicorp/hcl-lang/assets/287584/19ff8efe-91f0-4626-b425-c629e062c246)

## After

![Screenshot 2023-10-11 at 15 28 49](https://github.com/hashicorp/hcl-lang/assets/287584/e764df03-e41e-4eac-96dd-1fc7d5944baf)
