### PR TITLE
Skip inferring variable type from default values

### DIFF
--- a/decoder/expression_candidates_legacy_test.go
+++ b/decoder/expression_candidates_legacy_test.go
@@ -2476,8 +2476,7 @@ variable "ccc" {}
 					FriendlyName: "variable",
 					ScopeId:      lang.ScopeId("variable"),
 					AsTypeOf: &schema.BlockAsTypeOf{
-						AttributeExpr:  "type",
-						AttributeValue: "default",
+						AttributeExpr: "type",
 					},
 				},
 			},

--- a/decoder/hover_test.go
+++ b/decoder/hover_test.go
@@ -1651,8 +1651,7 @@ func TestDecoder_HoverAtPos_extensions_references(t *testing.T) {
 							ScopeId:     lang.ScopeId("variable"),
 							AsReference: true,
 							AsTypeOf: &schema.BlockAsTypeOf{
-								AttributeExpr:  "type",
-								AttributeValue: "default",
+								AttributeExpr: "type",
 							},
 						},
 						Labels: []*schema.LabelSchema{
@@ -1719,8 +1718,7 @@ variable "name" {
 							ScopeId:     lang.ScopeId("variable"),
 							AsReference: true,
 							AsTypeOf: &schema.BlockAsTypeOf{
-								AttributeExpr:  "type",
-								AttributeValue: "default",
+								AttributeExpr: "type",
 							},
 						},
 						Labels: []*schema.LabelSchema{

--- a/decoder/reference_targets.go
+++ b/decoder/reference_targets.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/hcl/v2/ext/typeexpr"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/zclconf/go-cty/cty"
-	"github.com/zclconf/go-cty/cty/convert"
 )
 
 type ReferenceTargets []*ReferenceTarget
@@ -466,28 +465,11 @@ func referenceAsTypeOf(block *hcl.Block, rngPtr *hcl.Range, bSchema *schema.Bloc
 
 	if bSchema.Address.AsTypeOf.AttributeExpr != "" {
 		typeDecl, ok := asTypeOfAttrExpr(attrs, bSchema)
-		if !ok && bSchema.Address.AsTypeOf.AttributeValue == "" {
+		if !ok {
 			// nothing to fall back to, exit early
 			return reference.Targets{ref}
 		}
 		ref.Type = typeDecl
-	}
-
-	if bSchema.Address.AsTypeOf.AttributeValue != "" {
-		attr, ok := attrs[bSchema.Address.AsTypeOf.AttributeValue]
-		if !ok {
-			return reference.Targets{ref}
-		}
-		value, diags := attr.Expr.Value(nil)
-		if diags.HasErrors() {
-			return reference.Targets{ref}
-		}
-		val, err := convert.Convert(value, ref.Type)
-		if err != nil {
-			// type does not comply with type constraint
-			return reference.Targets{ref}
-		}
-		ref.Type = val.Type()
 	}
 
 	return reference.Targets{ref}

--- a/decoder/reference_targets_collect_hcl_test.go
+++ b/decoder/reference_targets_collect_hcl_test.go
@@ -3797,77 +3797,6 @@ provider "test" {
 			},
 		},
 		{
-			"block as data type per attribute - default string",
-			&schema.BodySchema{
-				Blocks: map[string]*schema.BlockSchema{
-					"variable": {
-						Labels: []*schema.LabelSchema{
-							{Name: "name"},
-						},
-						Address: &schema.BlockAddrSchema{
-							Steps: []schema.AddrStep{
-								schema.LabelStep{Index: 0},
-							},
-							AsTypeOf: &schema.BlockAsTypeOf{
-								AttributeValue: "default",
-							},
-						},
-						Type: schema.BlockTypeObject,
-						Body: &schema.BodySchema{
-							Attributes: map[string]*schema.AttributeSchema{
-								"type": {
-									IsOptional: true,
-									Constraint: schema.TypeDeclaration{},
-								},
-								"default": {
-									IsOptional: true,
-									Constraint: schema.LiteralType{Type: cty.DynamicPseudoType},
-								},
-							},
-						},
-					},
-				},
-			},
-			`variable "test" {
-  default = "something"
-}
-`,
-			reference.Targets{
-				{
-					Addr: lang.Address{
-						lang.RootStep{Name: "test"},
-					},
-					Type: cty.String,
-					RangePtr: &hcl.Range{
-						Filename: "test.tf",
-						Start: hcl.Pos{
-							Line:   1,
-							Column: 1,
-							Byte:   0,
-						},
-						End: hcl.Pos{
-							Line:   3,
-							Column: 2,
-							Byte:   43,
-						},
-					},
-					DefRangePtr: &hcl.Range{
-						Filename: "test.tf",
-						Start: hcl.Pos{
-							Line:   1,
-							Column: 1,
-							Byte:   0,
-						},
-						End: hcl.Pos{
-							Line:   1,
-							Column: 16,
-							Byte:   15,
-						},
-					},
-				},
-			},
-		},
-		{
 			"block as data type per attribute - default tuple constant",
 			&schema.BodySchema{
 				Blocks: map[string]*schema.BlockSchema{
@@ -3880,8 +3809,7 @@ provider "test" {
 								schema.LabelStep{Index: 0},
 							},
 							AsTypeOf: &schema.BlockAsTypeOf{
-								AttributeExpr:  "type",
-								AttributeValue: "default",
+								AttributeExpr: "type",
 							},
 						},
 						Type: schema.BlockTypeObject,
@@ -3909,7 +3837,7 @@ provider "test" {
 					Addr: lang.Address{
 						lang.RootStep{Name: "test"},
 					},
-					Type: cty.Tuple([]cty.Type{cty.String}),
+					Type: cty.DynamicPseudoType,
 					RangePtr: &hcl.Range{
 						Filename: "test.tf",
 						Start: hcl.Pos{
@@ -3952,8 +3880,7 @@ provider "test" {
 								schema.LabelStep{Index: 0},
 							},
 							AsTypeOf: &schema.BlockAsTypeOf{
-								AttributeExpr:  "type",
-								AttributeValue: "default",
+								AttributeExpr: "type",
 							},
 						},
 						Type: schema.BlockTypeObject,
@@ -3984,7 +3911,7 @@ provider "test" {
 					Addr: lang.Address{
 						lang.RootStep{Name: "test"},
 					},
-					Type: cty.List(cty.String),
+					Type: cty.List(cty.DynamicPseudoType),
 					RangePtr: &hcl.Range{
 						Filename: "test.tf",
 						Start: hcl.Pos{
@@ -3996,78 +3923,6 @@ provider "test" {
 							Line:   6,
 							Column: 2,
 							Byte:   66,
-						},
-					},
-					DefRangePtr: &hcl.Range{
-						Filename: "test.tf",
-						Start: hcl.Pos{
-							Line:   1,
-							Column: 1,
-							Byte:   0,
-						},
-						End: hcl.Pos{
-							Line:   1,
-							Column: 16,
-							Byte:   15,
-						},
-					},
-				},
-			},
-		},
-		{
-			"block as data type per attribute - both type and default",
-			&schema.BodySchema{
-				Blocks: map[string]*schema.BlockSchema{
-					"variable": {
-						Labels: []*schema.LabelSchema{
-							{Name: "name"},
-						},
-						Address: &schema.BlockAddrSchema{
-							Steps: []schema.AddrStep{
-								schema.LabelStep{Index: 0},
-							},
-							AsTypeOf: &schema.BlockAsTypeOf{
-								AttributeValue: "default",
-							},
-						},
-						Type: schema.BlockTypeObject,
-						Body: &schema.BodySchema{
-							Attributes: map[string]*schema.AttributeSchema{
-								"type": {
-									IsOptional: true,
-									Constraint: schema.TypeDeclaration{},
-								},
-								"default": {
-									IsOptional: true,
-									Constraint: schema.LiteralType{Type: cty.DynamicPseudoType},
-								},
-							},
-						},
-					},
-				},
-			},
-			`variable "test" {
-  type = any
-  default = "something"
-}
-`,
-			reference.Targets{
-				{
-					Addr: lang.Address{
-						lang.RootStep{Name: "test"},
-					},
-					Type: cty.String,
-					RangePtr: &hcl.Range{
-						Filename: "test.tf",
-						Start: hcl.Pos{
-							Line:   1,
-							Column: 1,
-							Byte:   0,
-						},
-						End: hcl.Pos{
-							Line:   4,
-							Column: 2,
-							Byte:   56,
 						},
 					},
 					DefRangePtr: &hcl.Range{

--- a/decoder/reference_targets_collect_json_test.go
+++ b/decoder/reference_targets_collect_json_test.go
@@ -3696,81 +3696,6 @@ func TestCollectReferenceTargets_json(t *testing.T) {
 			},
 		},
 		{
-			"block as data type per attribute - default string",
-			&schema.BodySchema{
-				Blocks: map[string]*schema.BlockSchema{
-					"variable": {
-						Labels: []*schema.LabelSchema{
-							{Name: "name"},
-						},
-						Address: &schema.BlockAddrSchema{
-							Steps: []schema.AddrStep{
-								schema.LabelStep{Index: 0},
-							},
-							AsTypeOf: &schema.BlockAsTypeOf{
-								AttributeValue: "default",
-							},
-						},
-						Type: schema.BlockTypeObject,
-						Body: &schema.BodySchema{
-							Attributes: map[string]*schema.AttributeSchema{
-								"type": {
-									IsOptional: true,
-									Constraint: schema.TypeDeclaration{},
-								},
-								"default": {
-									IsOptional: true,
-									Constraint: schema.LiteralType{Type: cty.DynamicPseudoType},
-								},
-							},
-						},
-					},
-				},
-			},
-			`{
-  "variable": {
-    "test": {
-      "default": "something"
-    }
-  }
-}
-`,
-			reference.Targets{
-				{
-					Addr: lang.Address{
-						lang.RootStep{Name: "test"},
-					},
-					Type: cty.String,
-					RangePtr: &hcl.Range{
-						Filename: "test.tf.json",
-						Start: hcl.Pos{
-							Line:   3,
-							Column: 13,
-							Byte:   30,
-						},
-						End: hcl.Pos{
-							Line:   5,
-							Column: 6,
-							Byte:   66,
-						},
-					},
-					DefRangePtr: &hcl.Range{
-						Filename: "test.tf.json",
-						Start: hcl.Pos{
-							Line:   3,
-							Column: 13,
-							Byte:   30,
-						},
-						End: hcl.Pos{
-							Line:   3,
-							Column: 14,
-							Byte:   31,
-						},
-					},
-				},
-			},
-		},
-		{
 			"block as data type per attribute - default tuple constant",
 			&schema.BodySchema{
 				Blocks: map[string]*schema.BlockSchema{
@@ -3783,8 +3708,7 @@ func TestCollectReferenceTargets_json(t *testing.T) {
 								schema.LabelStep{Index: 0},
 							},
 							AsTypeOf: &schema.BlockAsTypeOf{
-								AttributeExpr:  "type",
-								AttributeValue: "default",
+								AttributeExpr: "type",
 							},
 						},
 						Type: schema.BlockTypeObject,
@@ -3816,7 +3740,7 @@ func TestCollectReferenceTargets_json(t *testing.T) {
 					Addr: lang.Address{
 						lang.RootStep{Name: "test"},
 					},
-					Type: cty.Tuple([]cty.Type{cty.String}),
+					Type: cty.DynamicPseudoType,
 					RangePtr: &hcl.Range{
 						Filename: "test.tf.json",
 						Start: hcl.Pos{
@@ -3859,8 +3783,7 @@ func TestCollectReferenceTargets_json(t *testing.T) {
 								schema.LabelStep{Index: 0},
 							},
 							AsTypeOf: &schema.BlockAsTypeOf{
-								AttributeExpr:  "type",
-								AttributeValue: "default",
+								AttributeExpr: "type",
 							},
 						},
 						Type: schema.BlockTypeObject,
@@ -3893,7 +3816,7 @@ func TestCollectReferenceTargets_json(t *testing.T) {
 					Addr: lang.Address{
 						lang.RootStep{Name: "test"},
 					},
-					Type: cty.List(cty.String),
+					Type: cty.List(cty.DynamicPseudoType),
 					RangePtr: &hcl.Range{
 						Filename: "test.tf.json",
 						Start: hcl.Pos{
@@ -3905,81 +3828,6 @@ func TestCollectReferenceTargets_json(t *testing.T) {
 							Line:   6,
 							Column: 6,
 							Byte:   91,
-						},
-					},
-					DefRangePtr: &hcl.Range{
-						Filename: "test.tf.json",
-						Start: hcl.Pos{
-							Line:   3,
-							Column: 13,
-							Byte:   30,
-						},
-						End: hcl.Pos{
-							Line:   3,
-							Column: 14,
-							Byte:   31,
-						},
-					},
-				},
-			},
-		},
-		{
-			"block as data type per attribute - both type and default",
-			&schema.BodySchema{
-				Blocks: map[string]*schema.BlockSchema{
-					"variable": {
-						Labels: []*schema.LabelSchema{
-							{Name: "name"},
-						},
-						Address: &schema.BlockAddrSchema{
-							Steps: []schema.AddrStep{
-								schema.LabelStep{Index: 0},
-							},
-							AsTypeOf: &schema.BlockAsTypeOf{
-								AttributeValue: "default",
-							},
-						},
-						Type: schema.BlockTypeObject,
-						Body: &schema.BodySchema{
-							Attributes: map[string]*schema.AttributeSchema{
-								"type": {
-									IsOptional: true,
-									Constraint: schema.TypeDeclaration{},
-								},
-								"default": {
-									IsOptional: true,
-									Constraint: schema.LiteralType{Type: cty.DynamicPseudoType},
-								},
-							},
-						},
-					},
-				},
-			},
-			`{
-  "variable": {
-    "test": {
-      "type": "any",
-      "default": "something"
-    }
-  }
-}`,
-			reference.Targets{
-				{
-					Addr: lang.Address{
-						lang.RootStep{Name: "test"},
-					},
-					Type: cty.String,
-					RangePtr: &hcl.Range{
-						Filename: "test.tf.json",
-						Start: hcl.Pos{
-							Line:   3,
-							Column: 13,
-							Byte:   30,
-						},
-						End: hcl.Pos{
-							Line:   6,
-							Column: 6,
-							Byte:   87,
 						},
 					},
 					DefRangePtr: &hcl.Range{

--- a/schema/block_schema.go
+++ b/schema/block_schema.go
@@ -99,14 +99,6 @@ type BlockAsTypeOf struct {
 	// is addressable as a particular type declared
 	// directly as expression of the attribute
 	AttributeExpr string
-
-	// AttributeValue defines whether the block
-	// is addressable as a type of the attribute value.
-	//
-	// This will be used as a fallback if AttributeExpr
-	// is also defined, or when the attribute defined there
-	// is of cty.DynamicPseudoType.
-	AttributeValue string
 }
 
 func (bas *BlockAddrSchema) Validate() error {
@@ -156,8 +148,7 @@ func (bato *BlockAsTypeOf) Copy() *BlockAsTypeOf {
 	}
 
 	return &BlockAsTypeOf{
-		AttributeExpr:  bato.AttributeExpr,
-		AttributeValue: bato.AttributeValue,
+		AttributeExpr: bato.AttributeExpr,
 	}
 }
 


### PR DESCRIPTION
This PR removes the concept of inferring types from default values via `AttributeValue`.

See Radek's comment below for more information.

## UX

**Before**
<img width="310" alt="CleanShot 2023-11-01 at 17 28 59@2x" src="https://github.com/hashicorp/hcl-lang/assets/45985/2de16c93-5a16-4cd1-93c0-d019ed1ec7be">

**After**
<img width="320" alt="CleanShot 2023-11-01 at 17 29 21@2x" src="https://github.com/hashicorp/hcl-lang/assets/45985/5f5426bf-d4b9-482c-aa6a-962f0dcae14d">


---

* Related to https://github.com/hashicorp/vscode-terraform/issues/1592