### PR TITLE
decoder: Ensure partially unknown dependent body is handled

### DIFF
--- a/decoder/hover.go
+++ b/decoder/hover.go
@@ -163,8 +163,8 @@ func (d *PathDecoder) hoverContentForLabel(i int, block *hclsyntax.Block, bSchem
 	labelSchema := bSchema.Labels[i]
 
 	if labelSchema.IsDepKey {
-		bs, _, ok := schemahelper.NewBlockSchema(bSchema).DependentBodySchema(block.AsHCLBlock())
-		if ok {
+		bs, _, result := schemahelper.NewBlockSchema(bSchema).DependentBodySchema(block.AsHCLBlock())
+		if result == schemahelper.LookupSuccessful || result == schemahelper.LookupPartiallySuccessful {
 			content := fmt.Sprintf("`%s`", value)
 			if bs.Detail != "" {
 				content += " " + bs.Detail

--- a/decoder/internal/schemahelper/dependent_body.go
+++ b/decoder/internal/schemahelper/dependent_body.go
@@ -12,6 +12,15 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
+type LookupResult int
+
+const (
+	LookupFailed LookupResult = iota
+	LookupSuccessful
+	LookupPartiallySuccessful
+	NoDependentKeys
+)
+
 type blockSchema struct {
 	*schema.BlockSchema
 	seenNestedDepKeys bool
@@ -23,16 +32,23 @@ func NewBlockSchema(bs *schema.BlockSchema) blockSchema {
 
 // DependentBodySchema finds relevant BodySchema based on dependency keys
 // such as a label or an attribute (or combination of both).
-func (bs blockSchema) DependentBodySchema(block *hcl.Block) (*schema.BodySchema, schema.DependencyKeys, bool) {
+func (bs blockSchema) DependentBodySchema(block *hcl.Block) (*schema.BodySchema, schema.DependencyKeys, LookupResult) {
+	result := LookupFailed
+
 	dks := dependencyKeysFromBlock(block, bs)
 	b, err := dks.MarshalJSON()
 	if err != nil {
-		return nil, schema.DependencyKeys{}, false
+		return nil, schema.DependencyKeys{}, result
+	}
+
+	if len(dks.Labels) == 0 && len(dks.Attributes) == 0 {
+		return bs.Body, schema.DependencyKeys{}, NoDependentKeys
 	}
 
 	key := schema.SchemaKey(string(b))
 	depBodySchema, ok := bs.DependentBody[key]
 	if ok {
+		result = LookupSuccessful
 		hasDepKeys := false
 		for _, attr := range depBodySchema.Attributes {
 			if attr.IsDepKey {
@@ -44,17 +60,17 @@ func (bs blockSchema) DependentBodySchema(block *hcl.Block) (*schema.BodySchema,
 			mergedBlockSchema := NewBlockSchema(bs.Copy())
 			mergedBlockSchema.seenNestedDepKeys = true
 			mergedBlockSchema.Body = depBodySchema
-			if depBodySchema, dks, nestedOk := mergedBlockSchema.DependentBodySchema(block); nestedOk {
-				return depBodySchema, dks, nestedOk
+			if depBodySchema, dks, nestedOk := mergedBlockSchema.DependentBodySchema(block); nestedOk == LookupSuccessful {
+				return depBodySchema, dks, LookupSuccessful
 			} else {
 				// Ensure we report lookup failure overall if we couldn't
 				// lookup nested dependent body
-				ok = false
+				result = LookupPartiallySuccessful
 			}
 		}
 	}
 
-	return depBodySchema, dks, ok
+	return depBodySchema, dks, result
 }
 
 func dependencyKeysFromBlock(block *hcl.Block, blockSchema blockSchema) schema.DependencyKeys {

--- a/decoder/internal/schemahelper/dependent_body.go
+++ b/decoder/internal/schemahelper/dependent_body.go
@@ -44,8 +44,12 @@ func (bs blockSchema) DependentBodySchema(block *hcl.Block) (*schema.BodySchema,
 			mergedBlockSchema := NewBlockSchema(bs.Copy())
 			mergedBlockSchema.seenNestedDepKeys = true
 			mergedBlockSchema.Body = depBodySchema
-			if depBodySchema, dks, ok := mergedBlockSchema.DependentBodySchema(block); ok {
-				return depBodySchema, dks, ok
+			if depBodySchema, dks, nestedOk := mergedBlockSchema.DependentBodySchema(block); nestedOk {
+				return depBodySchema, dks, nestedOk
+			} else {
+				// Ensure we report lookup failure overall if we couldn't
+				// lookup nested dependent body
+				ok = false
 			}
 		}
 	}

--- a/decoder/internal/schemahelper/dependent_body_test.go
+++ b/decoder/internal/schemahelper/dependent_body_test.go
@@ -52,8 +52,8 @@ func TestBodySchema_DependentBodySchema_label_basic(t *testing.T) {
 		},
 	}
 
-	bodySchema, _, ok := NewBlockSchema(bSchema).DependentBodySchema(block)
-	if !ok {
+	bodySchema, _, result := NewBlockSchema(bSchema).DependentBodySchema(block)
+	if result != LookupSuccessful {
 		t.Fatal("expected to find body schema for 'theircloud' label")
 	}
 	expectedSchema := &schema.BodySchema{
@@ -104,8 +104,8 @@ func TestBodySchema_DependentBodySchema_mismatchingLabels(t *testing.T) {
 		},
 	}
 
-	_, _, ok := NewBlockSchema(bSchema).DependentBodySchema(block)
-	if ok {
+	_, _, result := NewBlockSchema(bSchema).DependentBodySchema(block)
+	if result != LookupFailed {
 		t.Fatal("expected to not find body schema for mismatching label schema")
 	}
 }
@@ -170,17 +170,17 @@ func TestBodySchema_DependentBodySchema_dependentAttr(t *testing.T) {
 		},
 	}
 
-	bodySchema, _, ok := NewBlockSchema(bSchema).DependentBodySchema(&hcl.Block{
+	bodySchema, _, result := NewBlockSchema(bSchema).DependentBodySchema(&hcl.Block{
 		Labels: []string{"remote_state"},
 	})
-	if !ok {
+	if result != LookupSuccessful {
 		t.Fatal("expected to find body schema for nested dependent schema")
 	}
 	if diff := cmp.Diff(firstDepBody, bodySchema, ctydebug.CmpOptions); diff != "" {
 		t.Fatalf("mismatching body schema: %s", diff)
 	}
 
-	bodySchema, _, ok = NewBlockSchema(bSchema).DependentBodySchema(&hcl.Block{
+	bodySchema, _, result = NewBlockSchema(bSchema).DependentBodySchema(&hcl.Block{
 		Labels: []string{"remote_state"},
 		Body: &hclsyntax.Body{
 			Attributes: hclsyntax.Attributes{
@@ -193,7 +193,7 @@ func TestBodySchema_DependentBodySchema_dependentAttr(t *testing.T) {
 			},
 		},
 	})
-	if !ok {
+	if result != LookupSuccessful {
 		t.Fatal("expected to find body schema for nested dependent schema")
 	}
 	if diff := cmp.Diff(secondDepBody, bodySchema, ctydebug.CmpOptions); diff != "" {
@@ -256,7 +256,7 @@ func TestBodySchema_DependentBodySchema_missingDependentAttr(t *testing.T) {
 		},
 	}
 
-	bodySchema, _, ok := NewBlockSchema(bSchema).DependentBodySchema(&hcl.Block{
+	bodySchema, _, result := NewBlockSchema(bSchema).DependentBodySchema(&hcl.Block{
 		Labels: []string{"remote_state"},
 		Body: &hclsyntax.Body{
 			Attributes: hclsyntax.Attributes{
@@ -267,8 +267,8 @@ func TestBodySchema_DependentBodySchema_missingDependentAttr(t *testing.T) {
 			},
 		},
 	})
-	if !ok {
-		t.Fatal("expected to find first body schema for missing keys")
+	if result != LookupPartiallySuccessful {
+		t.Fatalf("expected to find first body schema for missing keys; reported: %q", result)
 	}
 	if diff := cmp.Diff(firstDepBody, bodySchema, ctydebug.CmpOptions); diff != "" {
 		t.Fatalf("mismatching body schema: %s", diff)
@@ -418,8 +418,8 @@ func TestBodySchema_DependentBodySchema_attributes(t *testing.T) {
 					Attributes: tc.attributes,
 				},
 			}
-			bodySchema, _, ok := tc.schema.DependentBodySchema(block)
-			if !ok {
+			bodySchema, _, result := tc.schema.DependentBodySchema(block)
+			if result != LookupSuccessful {
 				t.Fatalf("expected to find body schema for given block with %d attributes",
 					len(tc.attributes))
 			}
@@ -497,8 +497,8 @@ func TestBodySchema_DependentBodySchema_partialMergeFailure(t *testing.T) {
 		},
 	}
 
-	_, ok := MergeBlockBodySchemas(block, testSchema.BlockSchema)
-	if ok {
+	_, result := MergeBlockBodySchemas(block, testSchema.BlockSchema)
+	if result != LookupPartiallySuccessful {
 		t.Fatal("expected partially failed dependent body lookup to fail")
 	}
 }
@@ -508,8 +508,8 @@ func TestBodySchema_DependentBodySchema_label_notFound(t *testing.T) {
 		Labels: []string{"test", "mycloud"},
 		Body:   hcl.EmptyBody(),
 	}
-	_, _, ok := testSchemaWithLabels.DependentBodySchema(block)
-	if ok {
+	_, _, result := testSchemaWithLabels.DependentBodySchema(block)
+	if result != LookupFailed {
 		t.Fatal("expected not to find body schema for 'mycloud' 2nd label")
 	}
 }
@@ -519,8 +519,8 @@ func TestBodySchema_DependentBodySchema_label_storedUnsorted(t *testing.T) {
 		Labels: []string{"complexcloud", "pumpkin"},
 		Body:   hcl.EmptyBody(),
 	}
-	bodySchema, _, ok := testSchemaWithLabels.DependentBodySchema(block)
-	if !ok {
+	bodySchema, _, result := testSchemaWithLabels.DependentBodySchema(block)
+	if result != LookupSuccessful {
 		t.Fatal("expected to find body schema stored with unsorted keys")
 	}
 	expectedSchema := &schema.BodySchema{
@@ -538,8 +538,8 @@ func TestBodySchema_DependentBodySchema_label_lookupUnsorted(t *testing.T) {
 		Labels: []string{"apple", "crazycloud"},
 		Body:   hcl.EmptyBody(),
 	}
-	_, _, ok := testSchemaWithLabels.DependentBodySchema(block)
-	if ok {
+	_, _, result := testSchemaWithLabels.DependentBodySchema(block)
+	if result != LookupFailed {
 		t.Fatal("expected to not find body schema based on wrongly sorted labels")
 	}
 }

--- a/decoder/internal/walker/walker.go
+++ b/decoder/internal/walker/walker.go
@@ -88,8 +88,8 @@ func Walk(ctx context.Context, node hclsyntax.Node, nodeSchema schema.Schema, w 
 		var blockBodySchema schema.Schema = nil
 		bSchema, ok := nodeSchema.(*schema.BlockSchema)
 		if ok && bSchema.Body != nil {
-			mergedSchema, ok := schemahelper.MergeBlockBodySchemas(nodeType.AsHCLBlock(), bSchema)
-			if !ok {
+			mergedSchema, result := schemahelper.MergeBlockBodySchemas(nodeType.AsHCLBlock(), bSchema)
+			if result == schemahelper.LookupFailed || result == schemahelper.LookupPartiallySuccessful {
 				ctx = schemacontext.WithUnknownSchema(ctx)
 			}
 			blockBodySchema = mergedSchema

--- a/decoder/links.go
+++ b/decoder/links.go
@@ -46,8 +46,8 @@ func (d *PathDecoder) linksInBody(body *hclsyntax.Body, bodySchema *schema.BodyS
 
 		// Currently only block bodies have links associated
 		if block.Body != nil {
-			depSchema, dk, ok := schemahelper.NewBlockSchema(blockSchema).DependentBodySchema(block.AsHCLBlock())
-			if ok && depSchema.DocsLink != nil {
+			depSchema, dk, result := schemahelper.NewBlockSchema(blockSchema).DependentBodySchema(block.AsHCLBlock())
+			if (result == schemahelper.LookupSuccessful || result == schemahelper.LookupPartiallySuccessful || result == schemahelper.NoDependentKeys) && depSchema.DocsLink != nil {
 				link := depSchema.DocsLink
 				u, err := d.docsURL(link.URL, "documentLink")
 				if err != nil {

--- a/decoder/reference_targets.go
+++ b/decoder/reference_targets.go
@@ -202,8 +202,8 @@ func (d *PathDecoder) decodeReferenceTargetsForBody(body hcl.Body, parentBlock *
 				}
 			}
 
-			depSchema, _, ok := schemahelper.NewBlockSchema(bSchema).DependentBodySchema(blk.Block)
-			if ok {
+			depSchema, _, result := schemahelper.NewBlockSchema(bSchema).DependentBodySchema(blk.Block)
+			if result == schemahelper.LookupSuccessful {
 				fullSchema := depSchema
 				if bSchema.Address.BodyAsData {
 					mergedSchema, _ := schemahelper.MergeBlockBodySchemas(blk.Block, bSchema)


### PR DESCRIPTION
As demonstrated by the attached test, we can have a situation of "nested dependent modules" which was previously handled incorrectly. This is best explained on an example.

```hcl
variable "terraform_rs" {
  default = {
    backend              = "azurerm"
    workspace            = "***"
    storage_account_name = "***"
    container_name       = "***"
    key                  = "***"
    access_key           = "***"
  }
}

data "terraform_remote_state" "this" {
  backend   = var.terraform_rs.backend
  workspace = var.terraform_rs.workspace
  config = {
    storage_account_name = var.terraform_rs.storage_account_name
    container_name       = var.terraform_rs.container_name
    key                  = var.terraform_rs.key
    access_key           = var.terraform_rs.access_key
  }
}
```

Above, we have multiple dependent body schemas for the `data` block:

 - The first one is dependent on 1st label matching `terraform_remote_state` - that brings us `backend`, `workspace` and other attributes generally relevant for that particular data source
 - The second one is then dependent on the value of `backend` (i.e. attribute which was brought in as dependent from the earlier merging).

In the example above we would succeed in the first lookup, but fail in the second one - because we don't evaluate the expression in this context and cannot tell what `var.terraform_rs.backend` actually is. This is basically equivalent to any other invalid value, such as `backend = "foobar"` but the example above is a little more realistic. Now we report a more granular state reflecting the reality more accurately.

This is perhaps not ideal in the sense that although we suppress irrelevant diagnostics, we also suppress some helpful ones, e.g. invalid `backend`

```hcl
data "terraform_remote_state" "this" {
  backend   = "foobar"
  workspace = "noot"
}
```

Also we could run the validation in the top example with interpolated `var.terraform_rs.backend`, i.e. validate `config` in the context of `backend = "azurerm"` but interpolation is whole another problem we haven't really tackled yet.

We can treat this as an opportunity for future enhancements while reducing false negatives in the meantime.

## UX Before

![Screenshot 2023-11-02 at 14 28 16](https://github.com/hashicorp/hcl-lang/assets/287584/0b86c002-67dc-4df6-b4d9-f73a89c748bd)


## UX After

![Screenshot 2023-11-02 at 14 30 28](https://github.com/hashicorp/hcl-lang/assets/287584/c24ef73b-4928-4d82-965d-c2061921f8c0)
