### PR TITLE
Fix type-unaware target collection

### DIFF
--- a/decoder/expr_any_ref_targets.go
+++ b/decoder/expr_any_ref_targets.go
@@ -22,7 +22,7 @@ func (a Any) ReferenceTargets(ctx context.Context, targetCtx *TargetContext) ref
 		}
 	}
 
-	if targetCtx == nil || len(targetCtx.ParentAddress) == 0 {
+	if targetCtx == nil || len(targetCtx.ParentAddress) == 0 || !targetCtx.AsExprType {
 		return reference.Targets{}
 	}
 
@@ -34,11 +34,6 @@ func (a Any) ReferenceTargets(ctx context.Context, targetCtx *TargetContext) ref
 			rangePtr = a.expr.Range().Ptr()
 		}
 
-		var refType cty.Type
-		if targetCtx.AsExprType {
-			refType = typ
-		}
-
 		return reference.Targets{
 			{
 				Addr:                   targetCtx.ParentAddress,
@@ -47,7 +42,7 @@ func (a Any) ReferenceTargets(ctx context.Context, targetCtx *TargetContext) ref
 				ScopeId:                targetCtx.ScopeId,
 				RangePtr:               rangePtr,
 				DefRangePtr:            targetCtx.ParentDefRangePtr,
-				Type:                   refType,
+				Type:                   typ,
 			},
 		}
 	}

--- a/decoder/expr_any_ref_targets_test.go
+++ b/decoder/expr_any_ref_targets_test.go
@@ -26,6 +26,40 @@ func TestCollectRefTargets_exprAny_hcl(t *testing.T) {
 		expectedRefTargets reference.Targets
 	}{
 		{
+			"undeclared implied as type",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{OfType: cty.DynamicPseudoType},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`attr = null`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 12, Byte: 11},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+					Type: cty.DynamicPseudoType,
+				},
+			},
+		},
+		{
 			"constraint mismatch",
 			map[string]*schema.AttributeSchema{
 				"attr": {
@@ -1829,6 +1863,40 @@ func TestCollectRefTargets_exprAny_json(t *testing.T) {
 		cfg                string
 		expectedRefTargets reference.Targets
 	}{
+		{
+			"undeclared implied as type",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{OfType: cty.DynamicPseudoType},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						AsExprType: true,
+					},
+				},
+			},
+			`{"attr": null}`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 14, Byte: 13},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					},
+					Type: cty.DynamicPseudoType,
+				},
+			},
+		},
 		{
 			"constraint mismatch",
 			map[string]*schema.AttributeSchema{

--- a/decoder/expr_any_ref_targets_test.go
+++ b/decoder/expr_any_ref_targets_test.go
@@ -312,33 +312,8 @@ func TestCollectRefTargets_exprAny_hcl(t *testing.T) {
 						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
 						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
 					},
-					ScopeId: lang.ScopeId("test"),
-					NestedTargets: reference.Targets{
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.IndexStep{Key: cty.NumberIntVal(0)},
-							},
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl",
-								Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
-								End:      hcl.Pos{Line: 1, Column: 14, Byte: 13},
-							},
-							ScopeId: lang.ScopeId("test"),
-						},
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.IndexStep{Key: cty.NumberIntVal(1)},
-							},
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl",
-								Start:    hcl.Pos{Line: 1, Column: 16, Byte: 15},
-								End:      hcl.Pos{Line: 1, Column: 21, Byte: 20},
-							},
-							ScopeId: lang.ScopeId("test"),
-						},
-					},
+					ScopeId:       lang.ScopeId("test"),
+					NestedTargets: reference.Targets{},
 				},
 			},
 		},
@@ -836,33 +811,8 @@ func TestCollectRefTargets_exprAny_hcl(t *testing.T) {
 						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
 						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
 					},
-					ScopeId: lang.ScopeId("test"),
-					NestedTargets: reference.Targets{
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.IndexStep{Key: cty.NumberIntVal(0)},
-							},
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl",
-								Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
-								End:      hcl.Pos{Line: 1, Column: 14, Byte: 13},
-							},
-							ScopeId: lang.ScopeId("test"),
-						},
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.IndexStep{Key: cty.NumberIntVal(1)},
-							},
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl",
-								Start:    hcl.Pos{Line: 1, Column: 16, Byte: 15},
-								End:      hcl.Pos{Line: 1, Column: 21, Byte: 20},
-							},
-							ScopeId: lang.ScopeId("test"),
-						},
-					},
+					ScopeId:       lang.ScopeId("test"),
+					NestedTargets: reference.Targets{},
 				},
 			},
 		},
@@ -1321,42 +1271,7 @@ func TestCollectRefTargets_exprAny_hcl(t *testing.T) {
 						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
 						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
 					},
-					NestedTargets: reference.Targets{
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.AttrStep{Name: "bar"},
-							},
-							ScopeId: lang.ScopeId("test"),
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl",
-								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 25},
-								End:      hcl.Pos{Line: 3, Column: 11, Byte: 33},
-							},
-							DefRangePtr: &hcl.Range{
-								Filename: "test.hcl",
-								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 25},
-								End:      hcl.Pos{Line: 3, Column: 6, Byte: 28},
-							},
-						},
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.AttrStep{Name: "foo"},
-							},
-							ScopeId: lang.ScopeId("test"),
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl",
-								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
-								End:      hcl.Pos{Line: 2, Column: 14, Byte: 22},
-							},
-							DefRangePtr: &hcl.Range{
-								Filename: "test.hcl",
-								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
-								End:      hcl.Pos{Line: 2, Column: 6, Byte: 14},
-							},
-						},
-					},
+					NestedTargets: reference.Targets{},
 				},
 			},
 		},
@@ -1773,42 +1688,7 @@ func TestCollectRefTargets_exprAny_hcl(t *testing.T) {
 						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
 						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
 					},
-					NestedTargets: reference.Targets{
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.IndexStep{Key: cty.StringVal("bar")},
-							},
-							ScopeId: lang.ScopeId("test"),
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl",
-								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 25},
-								End:      hcl.Pos{Line: 3, Column: 11, Byte: 33},
-							},
-							DefRangePtr: &hcl.Range{
-								Filename: "test.hcl",
-								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 25},
-								End:      hcl.Pos{Line: 3, Column: 6, Byte: 28},
-							},
-						},
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.IndexStep{Key: cty.StringVal("foo")},
-							},
-							ScopeId: lang.ScopeId("test"),
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl",
-								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
-								End:      hcl.Pos{Line: 2, Column: 14, Byte: 22},
-							},
-							DefRangePtr: &hcl.Range{
-								Filename: "test.hcl",
-								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
-								End:      hcl.Pos{Line: 2, Column: 6, Byte: 14},
-							},
-						},
-					},
+					NestedTargets: reference.Targets{},
 				},
 			},
 		},
@@ -2236,33 +2116,8 @@ func TestCollectRefTargets_exprAny_json(t *testing.T) {
 						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
 						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
 					},
-					ScopeId: lang.ScopeId("test"),
-					NestedTargets: reference.Targets{
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.IndexStep{Key: cty.NumberIntVal(0)},
-							},
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl.json",
-								Start:    hcl.Pos{Line: 1, Column: 11, Byte: 10},
-								End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
-							},
-							ScopeId: lang.ScopeId("test"),
-						},
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.IndexStep{Key: cty.NumberIntVal(1)},
-							},
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl.json",
-								Start:    hcl.Pos{Line: 1, Column: 18, Byte: 17},
-								End:      hcl.Pos{Line: 1, Column: 23, Byte: 22},
-							},
-							ScopeId: lang.ScopeId("test"),
-						},
-					},
+					ScopeId:       lang.ScopeId("test"),
+					NestedTargets: reference.Targets{},
 				},
 			},
 		},
@@ -2696,33 +2551,8 @@ func TestCollectRefTargets_exprAny_json(t *testing.T) {
 						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
 						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
 					},
-					ScopeId: lang.ScopeId("test"),
-					NestedTargets: reference.Targets{
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.IndexStep{Key: cty.NumberIntVal(0)},
-							},
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl.json",
-								Start:    hcl.Pos{Line: 1, Column: 11, Byte: 10},
-								End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
-							},
-							ScopeId: lang.ScopeId("test"),
-						},
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.IndexStep{Key: cty.NumberIntVal(1)},
-							},
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl.json",
-								Start:    hcl.Pos{Line: 1, Column: 18, Byte: 17},
-								End:      hcl.Pos{Line: 1, Column: 23, Byte: 22},
-							},
-							ScopeId: lang.ScopeId("test"),
-						},
-					},
+					ScopeId:       lang.ScopeId("test"),
+					NestedTargets: reference.Targets{},
 				},
 			},
 		},
@@ -3172,42 +3002,7 @@ func TestCollectRefTargets_exprAny_json(t *testing.T) {
 						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
 						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
 					},
-					NestedTargets: reference.Targets{
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.AttrStep{Name: "bar"},
-							},
-							ScopeId: lang.ScopeId("test"),
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl.json",
-								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 29},
-								End:      hcl.Pos{Line: 3, Column: 12, Byte: 38},
-							},
-							DefRangePtr: &hcl.Range{
-								Filename: "test.hcl.json",
-								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 29},
-								End:      hcl.Pos{Line: 3, Column: 8, Byte: 34},
-							},
-						},
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.AttrStep{Name: "foo"},
-							},
-							ScopeId: lang.ScopeId("test"),
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl.json",
-								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 13},
-								End:      hcl.Pos{Line: 2, Column: 15, Byte: 25},
-							},
-							DefRangePtr: &hcl.Range{
-								Filename: "test.hcl.json",
-								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 13},
-								End:      hcl.Pos{Line: 2, Column: 8, Byte: 18},
-							},
-						},
-					},
+					NestedTargets: reference.Targets{},
 				},
 			},
 		},
@@ -3604,42 +3399,7 @@ func TestCollectRefTargets_exprAny_json(t *testing.T) {
 						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
 						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
 					},
-					NestedTargets: reference.Targets{
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.IndexStep{Key: cty.StringVal("bar")},
-							},
-							ScopeId: lang.ScopeId("test"),
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl.json",
-								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 29},
-								End:      hcl.Pos{Line: 3, Column: 12, Byte: 38},
-							},
-							DefRangePtr: &hcl.Range{
-								Filename: "test.hcl.json",
-								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 29},
-								End:      hcl.Pos{Line: 3, Column: 8, Byte: 34},
-							},
-						},
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.IndexStep{Key: cty.StringVal("foo")},
-							},
-							ScopeId: lang.ScopeId("test"),
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl.json",
-								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 13},
-								End:      hcl.Pos{Line: 2, Column: 15, Byte: 25},
-							},
-							DefRangePtr: &hcl.Range{
-								Filename: "test.hcl.json",
-								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 13},
-								End:      hcl.Pos{Line: 2, Column: 8, Byte: 18},
-							},
-						},
-					},
+					NestedTargets: reference.Targets{},
 				},
 			},
 		},

--- a/decoder/expr_list_ref_targets.go
+++ b/decoder/expr_list_ref_targets.go
@@ -92,19 +92,5 @@ func (list List) wholeListReferenceTargets(targetCtx *TargetContext, nestedTarge
 		}
 	}
 
-	// type-unaware
-	if targetCtx.AsReference {
-		targets = append(targets, reference.Target{
-			Addr:                   targetCtx.ParentAddress,
-			Name:                   targetCtx.FriendlyName,
-			ScopeId:                targetCtx.ScopeId,
-			RangePtr:               rangePtr,
-			DefRangePtr:            targetCtx.ParentDefRangePtr,
-			NestedTargets:          nestedTargets,
-			LocalAddr:              targetCtx.ParentLocalAddress,
-			TargetableFromRangePtr: targetCtx.TargetableFromRangePtr,
-		})
-	}
-
 	return targets
 }

--- a/decoder/expr_list_ref_targets_test.go
+++ b/decoder/expr_list_ref_targets_test.go
@@ -230,33 +230,8 @@ func TestCollectRefTargets_exprList_hcl(t *testing.T) {
 						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
 						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
 					},
-					ScopeId: lang.ScopeId("test"),
-					NestedTargets: reference.Targets{
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.IndexStep{Key: cty.NumberIntVal(0)},
-							},
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl",
-								Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
-								End:      hcl.Pos{Line: 1, Column: 14, Byte: 13},
-							},
-							ScopeId: lang.ScopeId("test"),
-						},
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.IndexStep{Key: cty.NumberIntVal(1)},
-							},
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl",
-								Start:    hcl.Pos{Line: 1, Column: 16, Byte: 15},
-								End:      hcl.Pos{Line: 1, Column: 21, Byte: 20},
-							},
-							ScopeId: lang.ScopeId("test"),
-						},
-					},
+					ScopeId:       lang.ScopeId("test"),
+					NestedTargets: reference.Targets{},
 				},
 			},
 		},
@@ -853,33 +828,8 @@ func TestCollectRefTargets_exprList_json(t *testing.T) {
 						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
 						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
 					},
-					ScopeId: lang.ScopeId("test"),
-					NestedTargets: reference.Targets{
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.IndexStep{Key: cty.NumberIntVal(0)},
-							},
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl.json",
-								Start:    hcl.Pos{Line: 1, Column: 11, Byte: 10},
-								End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
-							},
-							ScopeId: lang.ScopeId("test"),
-						},
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.IndexStep{Key: cty.NumberIntVal(1)},
-							},
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl.json",
-								Start:    hcl.Pos{Line: 1, Column: 18, Byte: 17},
-								End:      hcl.Pos{Line: 1, Column: 23, Byte: 22},
-							},
-							ScopeId: lang.ScopeId("test"),
-						},
-					},
+					ScopeId:       lang.ScopeId("test"),
+					NestedTargets: reference.Targets{},
 				},
 			},
 		},

--- a/decoder/expr_list_ref_targets_test.go
+++ b/decoder/expr_list_ref_targets_test.go
@@ -616,7 +616,24 @@ func TestCollectRefTargets_exprList_json(t *testing.T) {
 				},
 			},
 			`{"attr": null}`,
-			reference.Targets{},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 14, Byte: 13},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl.json",
+						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					},
+					NestedTargets: reference.Targets{},
+				},
+			},
 		},
 		{
 			"constraint mismatch",

--- a/decoder/expr_literal_type_ref_targets.go
+++ b/decoder/expr_literal_type_ref_targets.go
@@ -22,7 +22,7 @@ func (lt LiteralType) ReferenceTargets(ctx context.Context, targetCtx *TargetCon
 		}
 	}
 
-	if targetCtx == nil || len(targetCtx.ParentAddress) == 0 {
+	if targetCtx == nil || len(targetCtx.ParentAddress) == 0 || !targetCtx.AsExprType {
 		return reference.Targets{}
 	}
 
@@ -46,11 +46,6 @@ func (lt LiteralType) ReferenceTargets(ctx context.Context, targetCtx *TargetCon
 			rangePtr = lt.expr.Range().Ptr()
 		}
 
-		var refType cty.Type
-		if targetCtx.AsExprType {
-			refType = typ
-		}
-
 		return reference.Targets{
 			{
 				Addr:                   targetCtx.ParentAddress,
@@ -59,7 +54,7 @@ func (lt LiteralType) ReferenceTargets(ctx context.Context, targetCtx *TargetCon
 				ScopeId:                targetCtx.ScopeId,
 				RangePtr:               rangePtr,
 				DefRangePtr:            targetCtx.ParentDefRangePtr,
-				Type:                   refType,
+				Type:                   typ,
 			},
 		}
 	}

--- a/decoder/expr_literal_type_ref_targets_test.go
+++ b/decoder/expr_literal_type_ref_targets_test.go
@@ -295,33 +295,8 @@ func TestCollectRefTargets_exprLiteralType_hcl(t *testing.T) {
 						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
 						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
 					},
-					ScopeId: lang.ScopeId("test"),
-					NestedTargets: reference.Targets{
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.IndexStep{Key: cty.NumberIntVal(0)},
-							},
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl",
-								Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
-								End:      hcl.Pos{Line: 1, Column: 14, Byte: 13},
-							},
-							ScopeId: lang.ScopeId("test"),
-						},
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.IndexStep{Key: cty.NumberIntVal(1)},
-							},
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl",
-								Start:    hcl.Pos{Line: 1, Column: 16, Byte: 15},
-								End:      hcl.Pos{Line: 1, Column: 21, Byte: 20},
-							},
-							ScopeId: lang.ScopeId("test"),
-						},
-					},
+					ScopeId:       lang.ScopeId("test"),
+					NestedTargets: reference.Targets{},
 				},
 			},
 		},
@@ -819,33 +794,8 @@ func TestCollectRefTargets_exprLiteralType_hcl(t *testing.T) {
 						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
 						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
 					},
-					ScopeId: lang.ScopeId("test"),
-					NestedTargets: reference.Targets{
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.IndexStep{Key: cty.NumberIntVal(0)},
-							},
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl",
-								Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
-								End:      hcl.Pos{Line: 1, Column: 14, Byte: 13},
-							},
-							ScopeId: lang.ScopeId("test"),
-						},
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.IndexStep{Key: cty.NumberIntVal(1)},
-							},
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl",
-								Start:    hcl.Pos{Line: 1, Column: 16, Byte: 15},
-								End:      hcl.Pos{Line: 1, Column: 21, Byte: 20},
-							},
-							ScopeId: lang.ScopeId("test"),
-						},
-					},
+					ScopeId:       lang.ScopeId("test"),
+					NestedTargets: reference.Targets{},
 				},
 			},
 		},
@@ -1304,42 +1254,7 @@ func TestCollectRefTargets_exprLiteralType_hcl(t *testing.T) {
 						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
 						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
 					},
-					NestedTargets: reference.Targets{
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.AttrStep{Name: "bar"},
-							},
-							ScopeId: lang.ScopeId("test"),
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl",
-								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 25},
-								End:      hcl.Pos{Line: 3, Column: 11, Byte: 33},
-							},
-							DefRangePtr: &hcl.Range{
-								Filename: "test.hcl",
-								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 25},
-								End:      hcl.Pos{Line: 3, Column: 6, Byte: 28},
-							},
-						},
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.AttrStep{Name: "foo"},
-							},
-							ScopeId: lang.ScopeId("test"),
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl",
-								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
-								End:      hcl.Pos{Line: 2, Column: 14, Byte: 22},
-							},
-							DefRangePtr: &hcl.Range{
-								Filename: "test.hcl",
-								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
-								End:      hcl.Pos{Line: 2, Column: 6, Byte: 14},
-							},
-						},
-					},
+					NestedTargets: reference.Targets{},
 				},
 			},
 		},
@@ -1756,42 +1671,7 @@ func TestCollectRefTargets_exprLiteralType_hcl(t *testing.T) {
 						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
 						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
 					},
-					NestedTargets: reference.Targets{
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.IndexStep{Key: cty.StringVal("bar")},
-							},
-							ScopeId: lang.ScopeId("test"),
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl",
-								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 25},
-								End:      hcl.Pos{Line: 3, Column: 11, Byte: 33},
-							},
-							DefRangePtr: &hcl.Range{
-								Filename: "test.hcl",
-								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 25},
-								End:      hcl.Pos{Line: 3, Column: 6, Byte: 28},
-							},
-						},
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.IndexStep{Key: cty.StringVal("foo")},
-							},
-							ScopeId: lang.ScopeId("test"),
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl",
-								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
-								End:      hcl.Pos{Line: 2, Column: 14, Byte: 22},
-							},
-							DefRangePtr: &hcl.Range{
-								Filename: "test.hcl",
-								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
-								End:      hcl.Pos{Line: 2, Column: 6, Byte: 14},
-							},
-						},
-					},
+					NestedTargets: reference.Targets{},
 				},
 			},
 		},
@@ -2201,33 +2081,8 @@ func TestCollectRefTargets_exprLiteralType_json(t *testing.T) {
 						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
 						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
 					},
-					ScopeId: lang.ScopeId("test"),
-					NestedTargets: reference.Targets{
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.IndexStep{Key: cty.NumberIntVal(0)},
-							},
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl.json",
-								Start:    hcl.Pos{Line: 1, Column: 11, Byte: 10},
-								End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
-							},
-							ScopeId: lang.ScopeId("test"),
-						},
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.IndexStep{Key: cty.NumberIntVal(1)},
-							},
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl.json",
-								Start:    hcl.Pos{Line: 1, Column: 18, Byte: 17},
-								End:      hcl.Pos{Line: 1, Column: 23, Byte: 22},
-							},
-							ScopeId: lang.ScopeId("test"),
-						},
-					},
+					ScopeId:       lang.ScopeId("test"),
+					NestedTargets: reference.Targets{},
 				},
 			},
 		},
@@ -2661,33 +2516,8 @@ func TestCollectRefTargets_exprLiteralType_json(t *testing.T) {
 						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
 						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
 					},
-					ScopeId: lang.ScopeId("test"),
-					NestedTargets: reference.Targets{
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.IndexStep{Key: cty.NumberIntVal(0)},
-							},
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl.json",
-								Start:    hcl.Pos{Line: 1, Column: 11, Byte: 10},
-								End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
-							},
-							ScopeId: lang.ScopeId("test"),
-						},
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.IndexStep{Key: cty.NumberIntVal(1)},
-							},
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl.json",
-								Start:    hcl.Pos{Line: 1, Column: 18, Byte: 17},
-								End:      hcl.Pos{Line: 1, Column: 23, Byte: 22},
-							},
-							ScopeId: lang.ScopeId("test"),
-						},
-					},
+					ScopeId:       lang.ScopeId("test"),
+					NestedTargets: reference.Targets{},
 				},
 			},
 		},
@@ -3137,42 +2967,7 @@ func TestCollectRefTargets_exprLiteralType_json(t *testing.T) {
 						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
 						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
 					},
-					NestedTargets: reference.Targets{
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.AttrStep{Name: "bar"},
-							},
-							ScopeId: lang.ScopeId("test"),
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl.json",
-								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 29},
-								End:      hcl.Pos{Line: 3, Column: 12, Byte: 38},
-							},
-							DefRangePtr: &hcl.Range{
-								Filename: "test.hcl.json",
-								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 29},
-								End:      hcl.Pos{Line: 3, Column: 8, Byte: 34},
-							},
-						},
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.AttrStep{Name: "foo"},
-							},
-							ScopeId: lang.ScopeId("test"),
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl.json",
-								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 13},
-								End:      hcl.Pos{Line: 2, Column: 15, Byte: 25},
-							},
-							DefRangePtr: &hcl.Range{
-								Filename: "test.hcl.json",
-								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 13},
-								End:      hcl.Pos{Line: 2, Column: 8, Byte: 18},
-							},
-						},
-					},
+					NestedTargets: reference.Targets{},
 				},
 			},
 		},
@@ -3569,42 +3364,7 @@ func TestCollectRefTargets_exprLiteralType_json(t *testing.T) {
 						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
 						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
 					},
-					NestedTargets: reference.Targets{
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.IndexStep{Key: cty.StringVal("bar")},
-							},
-							ScopeId: lang.ScopeId("test"),
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl.json",
-								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 29},
-								End:      hcl.Pos{Line: 3, Column: 12, Byte: 38},
-							},
-							DefRangePtr: &hcl.Range{
-								Filename: "test.hcl.json",
-								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 29},
-								End:      hcl.Pos{Line: 3, Column: 8, Byte: 34},
-							},
-						},
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.IndexStep{Key: cty.StringVal("foo")},
-							},
-							ScopeId: lang.ScopeId("test"),
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl.json",
-								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 13},
-								End:      hcl.Pos{Line: 2, Column: 15, Byte: 25},
-							},
-							DefRangePtr: &hcl.Range{
-								Filename: "test.hcl.json",
-								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 13},
-								End:      hcl.Pos{Line: 2, Column: 8, Byte: 18},
-							},
-						},
-					},
+					NestedTargets: reference.Targets{},
 				},
 			},
 		},

--- a/decoder/expr_map_ref_targets.go
+++ b/decoder/expr_map_ref_targets.go
@@ -105,18 +105,5 @@ func (m Map) wholeMapReferenceTargets(targetCtx *TargetContext, nestedTargets re
 		}
 	}
 
-	// type-unaware
-	if targetCtx.AsReference {
-		targets = append(targets, reference.Target{
-			Addr:                   targetCtx.ParentAddress,
-			Name:                   targetCtx.FriendlyName,
-			ScopeId:                targetCtx.ScopeId,
-			RangePtr:               rangePtr,
-			DefRangePtr:            targetCtx.ParentDefRangePtr,
-			NestedTargets:          nestedTargets,
-			LocalAddr:              targetCtx.ParentLocalAddress,
-			TargetableFromRangePtr: targetCtx.TargetableFromRangePtr,
-		})
-	}
 	return targets
 }

--- a/decoder/expr_map_ref_targets_test.go
+++ b/decoder/expr_map_ref_targets_test.go
@@ -377,42 +377,7 @@ func TestCollectRefTargets_exprMap_hcl(t *testing.T) {
 						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
 						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
 					},
-					NestedTargets: reference.Targets{
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.IndexStep{Key: cty.StringVal("bar")},
-							},
-							ScopeId: lang.ScopeId("test"),
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl",
-								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 25},
-								End:      hcl.Pos{Line: 3, Column: 11, Byte: 33},
-							},
-							DefRangePtr: &hcl.Range{
-								Filename: "test.hcl",
-								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 25},
-								End:      hcl.Pos{Line: 3, Column: 6, Byte: 28},
-							},
-						},
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.IndexStep{Key: cty.StringVal("foo")},
-							},
-							ScopeId: lang.ScopeId("test"),
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl",
-								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
-								End:      hcl.Pos{Line: 2, Column: 14, Byte: 22},
-							},
-							DefRangePtr: &hcl.Range{
-								Filename: "test.hcl",
-								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
-								End:      hcl.Pos{Line: 2, Column: 6, Byte: 14},
-							},
-						},
-					},
+					NestedTargets: reference.Targets{},
 				},
 			},
 		},
@@ -1112,42 +1077,7 @@ func TestCollectRefTargets_exprMap_json(t *testing.T) {
 						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
 						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
 					},
-					NestedTargets: reference.Targets{
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.IndexStep{Key: cty.StringVal("bar")},
-							},
-							ScopeId: lang.ScopeId("test"),
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl.json",
-								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 29},
-								End:      hcl.Pos{Line: 3, Column: 12, Byte: 38},
-							},
-							DefRangePtr: &hcl.Range{
-								Filename: "test.hcl.json",
-								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 29},
-								End:      hcl.Pos{Line: 3, Column: 8, Byte: 34},
-							},
-						},
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.IndexStep{Key: cty.StringVal("foo")},
-							},
-							ScopeId: lang.ScopeId("test"),
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl.json",
-								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 13},
-								End:      hcl.Pos{Line: 2, Column: 15, Byte: 25},
-							},
-							DefRangePtr: &hcl.Range{
-								Filename: "test.hcl.json",
-								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 13},
-								End:      hcl.Pos{Line: 2, Column: 8, Byte: 18},
-							},
-						},
-					},
+					NestedTargets: reference.Targets{},
 				},
 			},
 		},

--- a/decoder/expr_object_ref_targets.go
+++ b/decoder/expr_object_ref_targets.go
@@ -142,18 +142,5 @@ func (obj Object) wholeObjectReferenceTargets(targetCtx *TargetContext, nestedTa
 		}
 	}
 
-	// type-unaware
-	if targetCtx.AsReference {
-		targets = append(targets, reference.Target{
-			Addr:                   targetCtx.ParentAddress,
-			Name:                   targetCtx.FriendlyName,
-			ScopeId:                targetCtx.ScopeId,
-			DefRangePtr:            targetCtx.ParentDefRangePtr,
-			RangePtr:               rangePtr,
-			NestedTargets:          nestedTargets,
-			LocalAddr:              targetCtx.ParentLocalAddress,
-			TargetableFromRangePtr: targetCtx.TargetableFromRangePtr,
-		})
-	}
 	return targets
 }

--- a/decoder/expr_object_ref_targets_test.go
+++ b/decoder/expr_object_ref_targets_test.go
@@ -491,42 +491,7 @@ func TestCollectRefTargets_exprObject_hcl(t *testing.T) {
 						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
 						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
 					},
-					NestedTargets: reference.Targets{
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.AttrStep{Name: "bar"},
-							},
-							ScopeId: lang.ScopeId("test"),
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl",
-								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 25},
-								End:      hcl.Pos{Line: 3, Column: 11, Byte: 33},
-							},
-							DefRangePtr: &hcl.Range{
-								Filename: "test.hcl",
-								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 25},
-								End:      hcl.Pos{Line: 3, Column: 6, Byte: 28},
-							},
-						},
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.AttrStep{Name: "foo"},
-							},
-							ScopeId: lang.ScopeId("test"),
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl",
-								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
-								End:      hcl.Pos{Line: 2, Column: 14, Byte: 22},
-							},
-							DefRangePtr: &hcl.Range{
-								Filename: "test.hcl",
-								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 11},
-								End:      hcl.Pos{Line: 2, Column: 6, Byte: 14},
-							},
-						},
-					},
+					NestedTargets: reference.Targets{},
 				},
 			},
 		},
@@ -1409,42 +1374,7 @@ func TestCollectRefTargets_exprObject_json(t *testing.T) {
 						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
 						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
 					},
-					NestedTargets: reference.Targets{
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.AttrStep{Name: "bar"},
-							},
-							ScopeId: lang.ScopeId("test"),
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl.json",
-								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 29},
-								End:      hcl.Pos{Line: 3, Column: 12, Byte: 38},
-							},
-							DefRangePtr: &hcl.Range{
-								Filename: "test.hcl.json",
-								Start:    hcl.Pos{Line: 3, Column: 3, Byte: 29},
-								End:      hcl.Pos{Line: 3, Column: 8, Byte: 34},
-							},
-						},
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.AttrStep{Name: "foo"},
-							},
-							ScopeId: lang.ScopeId("test"),
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl.json",
-								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 13},
-								End:      hcl.Pos{Line: 2, Column: 15, Byte: 25},
-							},
-							DefRangePtr: &hcl.Range{
-								Filename: "test.hcl.json",
-								Start:    hcl.Pos{Line: 2, Column: 3, Byte: 13},
-								End:      hcl.Pos{Line: 2, Column: 8, Byte: 18},
-							},
-						},
-					},
+					NestedTargets: reference.Targets{},
 				},
 			},
 		},

--- a/decoder/expr_set_ref_targets.go
+++ b/decoder/expr_set_ref_targets.go
@@ -80,18 +80,5 @@ func (set Set) wholeSetReferenceTargets(targetCtx *TargetContext, nestedTargets 
 		}
 	}
 
-	// type-unaware
-	if targetCtx.AsReference {
-		targets = append(targets, reference.Target{
-			Addr:                   targetCtx.ParentAddress,
-			Name:                   targetCtx.FriendlyName,
-			ScopeId:                targetCtx.ScopeId,
-			RangePtr:               rangePtr,
-			DefRangePtr:            targetCtx.ParentDefRangePtr,
-			NestedTargets:          nestedTargets,
-			LocalAddr:              targetCtx.ParentLocalAddress,
-			TargetableFromRangePtr: targetCtx.TargetableFromRangePtr,
-		})
-	}
 	return targets
 }

--- a/decoder/expr_tuple_ref_targets.go
+++ b/decoder/expr_tuple_ref_targets.go
@@ -99,19 +99,5 @@ func (tuple Tuple) wholeTupleReferenceTargets(targetCtx *TargetContext, nestedTa
 		}
 	}
 
-	// type-unaware
-	if targetCtx.AsReference {
-		targets = append(targets, reference.Target{
-			Addr:                   targetCtx.ParentAddress,
-			Name:                   targetCtx.FriendlyName,
-			ScopeId:                targetCtx.ScopeId,
-			RangePtr:               rangePtr,
-			DefRangePtr:            targetCtx.ParentDefRangePtr,
-			NestedTargets:          nestedTargets,
-			LocalAddr:              targetCtx.ParentLocalAddress,
-			TargetableFromRangePtr: targetCtx.TargetableFromRangePtr,
-		})
-	}
-
 	return targets
 }

--- a/decoder/expr_tuple_ref_targets_test.go
+++ b/decoder/expr_tuple_ref_targets_test.go
@@ -333,33 +333,8 @@ func TestCollectRefTargets_exprTuple_hcl(t *testing.T) {
 						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
 						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
 					},
-					ScopeId: lang.ScopeId("test"),
-					NestedTargets: reference.Targets{
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.IndexStep{Key: cty.NumberIntVal(0)},
-							},
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl",
-								Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
-								End:      hcl.Pos{Line: 1, Column: 14, Byte: 13},
-							},
-							ScopeId: lang.ScopeId("test"),
-						},
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.IndexStep{Key: cty.NumberIntVal(1)},
-							},
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl",
-								Start:    hcl.Pos{Line: 1, Column: 16, Byte: 15},
-								End:      hcl.Pos{Line: 1, Column: 21, Byte: 20},
-							},
-							ScopeId: lang.ScopeId("test"),
-						},
-					},
+					ScopeId:       lang.ScopeId("test"),
+					NestedTargets: reference.Targets{},
 				},
 			},
 		},
@@ -1001,33 +976,8 @@ func TestCollectRefTargets_exprTuple_json(t *testing.T) {
 						Start:    hcl.Pos{Line: 1, Column: 2, Byte: 1},
 						End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
 					},
-					ScopeId: lang.ScopeId("test"),
-					NestedTargets: reference.Targets{
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.IndexStep{Key: cty.NumberIntVal(0)},
-							},
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl.json",
-								Start:    hcl.Pos{Line: 1, Column: 11, Byte: 10},
-								End:      hcl.Pos{Line: 1, Column: 16, Byte: 15},
-							},
-							ScopeId: lang.ScopeId("test"),
-						},
-						{
-							Addr: lang.Address{
-								lang.RootStep{Name: "attr"},
-								lang.IndexStep{Key: cty.NumberIntVal(1)},
-							},
-							RangePtr: &hcl.Range{
-								Filename: "test.hcl.json",
-								Start:    hcl.Pos{Line: 1, Column: 18, Byte: 17},
-								End:      hcl.Pos{Line: 1, Column: 23, Byte: 22},
-							},
-							ScopeId: lang.ScopeId("test"),
-						},
-					},
+					ScopeId:       lang.ScopeId("test"),
+					NestedTargets: reference.Targets{},
 				},
 			},
 		},

--- a/decoder/reference_targets.go
+++ b/decoder/reference_targets.go
@@ -286,6 +286,18 @@ func (d *PathDecoder) decodeReferenceTargetsForAttribute(attr *hcl.Attribute, at
 						ParentDefRangePtr: attr.NameRange.Ptr(),
 					}
 				}
+
+				if attrSchema.Address.AsReference {
+					ref := reference.Target{
+						Addr:          attrAddr,
+						ScopeId:       attrSchema.Address.ScopeId,
+						DefRangePtr:   attr.NameRange.Ptr(),
+						RangePtr:      attr.Range.Ptr(),
+						Name:          attrSchema.Address.FriendlyName,
+						NestedTargets: reference.Targets{},
+					}
+					refs = append(refs, ref)
+				}
 			}
 
 			refs = append(refs, eType.ReferenceTargets(ctx, targetCtx)...)

--- a/decoder/reference_targets_collect_hcl_test.go
+++ b/decoder/reference_targets_collect_hcl_test.go
@@ -77,6 +77,7 @@ func TestCollectReferenceTargets_hcl(t *testing.T) {
 							Byte:   8,
 						},
 					},
+					NestedTargets: reference.Targets{},
 				},
 			},
 		},

--- a/decoder/reference_targets_collect_json_test.go
+++ b/decoder/reference_targets_collect_json_test.go
@@ -76,6 +76,7 @@ func TestCollectReferenceTargets_json(t *testing.T) {
 							Byte:   11,
 						},
 					},
+					NestedTargets: reference.Targets{},
 				},
 			},
 		},


### PR DESCRIPTION
While working on https://github.com/hashicorp/terraform-schema/pull/292, we discovered that we failed to collect type-unaware targets for attributes with `AsReference` enabled. 

This also led to the discovery that we were incorrectly creating type-aware targets with a NilType, making them a type-unaware target.

This PR fixes all of that, allowing the correct collection of local targets for https://github.com/hashicorp/terraform-schema/pull/292.