### PR TITLE
Improve traversal completion for lists, tuples, and sets

### DIFF
--- a/decoder/expr_list_completion.go
+++ b/decoder/expr_list_completion.go
@@ -77,6 +77,14 @@ func (list List) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candid
 			if elemExpr.Range().ContainsPos(pos) || elemExpr.Range().End.Byte == pos.Byte {
 				return newExpression(list.pathCtx, elemExpr, list.cons.Elem).CompletionAtPos(ctx, pos)
 			}
+			if pos.Byte-elemExpr.Range().End.Byte == 1 {
+				fileBytes := list.pathCtx.Files[eType.Range().Filename].Bytes
+				trailingRune := fileBytes[elemExpr.Range().End.Byte:pos.Byte][0]
+
+				if trailingRune == '.' {
+					return newExpression(list.pathCtx, elemExpr, list.cons.Elem).CompletionAtPos(ctx, pos)
+				}
+			}
 		}
 
 		expr := newEmptyExpressionAtPos(eType.Range().Filename, pos)

--- a/decoder/expr_list_completion_test.go
+++ b/decoder/expr_list_completion_test.go
@@ -703,9 +703,7 @@ func TestCompletionAtPos_exprList_references(t *testing.T) {
 			map[string]*schema.AttributeSchema{
 				"attr": {
 					Constraint: schema.List{
-						Elem: schema.OneOf{
-							schema.Reference{OfScopeId: lang.ScopeId("variable")},
-						},
+						Elem: schema.Reference{OfScopeId: lang.ScopeId("variable")},
 					},
 				},
 			},

--- a/decoder/expr_list_completion_test.go
+++ b/decoder/expr_list_completion_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/reference"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -672,6 +673,91 @@ func TestCompletionAtPos_exprList(t *testing.T) {
 				Files: map[string]*hcl.File{
 					"test.tf": f,
 				},
+			})
+
+			ctx := context.Background()
+			candidates, err := d.CandidatesAtPos(ctx, "test.tf", tc.pos)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedCandidates, candidates); diff != "" {
+				t.Logf("position: %#v in config: %s", tc.pos, tc.cfg)
+				t.Fatalf("unexpected candidates: %s", diff)
+			}
+		})
+	}
+}
+
+func TestCompletionAtPos_exprList_references(t *testing.T) {
+	testCases := []struct {
+		testName           string
+		attrSchema         map[string]*schema.AttributeSchema
+		refTargets         reference.Targets
+		cfg                string
+		pos                hcl.Pos
+		expectedCandidates lang.Candidates
+	}{
+		{
+			"single-line with trailing dot",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.List{
+						Elem: schema.OneOf{
+							schema.Reference{OfScopeId: lang.ScopeId("variable")},
+						},
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "bar"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "variables.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 17},
+						End:      hcl.Pos{Line: 2, Column: 3, Byte: 19},
+					},
+					ScopeId: lang.ScopeId("variable"),
+				},
+			},
+			`attr = [ var. ]
+`,
+			hcl.Pos{Line: 1, Column: 14, Byte: 13},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "var.bar",
+					Detail: "reference",
+					Kind:   lang.TraversalCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "var.bar",
+						Snippet: "var.bar",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+							End:      hcl.Pos{Line: 1, Column: 14, Byte: 13},
+						},
+					},
+				},
+			}),
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%2d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := &schema.BodySchema{
+				Attributes: tc.attrSchema,
+			}
+
+			f, _ := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.tf": f,
+				},
+				ReferenceTargets: tc.refTargets,
 			})
 
 			ctx := context.Background()

--- a/decoder/expr_set_completion.go
+++ b/decoder/expr_set_completion.go
@@ -81,6 +81,14 @@ func (set Set) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidat
 			if elemExpr.Range().ContainsPos(pos) || elemExpr.Range().End.Byte == pos.Byte {
 				return newExpression(set.pathCtx, elemExpr, set.cons.Elem).CompletionAtPos(ctx, pos)
 			}
+			if pos.Byte-elemExpr.Range().End.Byte == 1 {
+				fileBytes := set.pathCtx.Files[eType.Range().Filename].Bytes
+				trailingRune := fileBytes[elemExpr.Range().End.Byte:pos.Byte][0]
+
+				if trailingRune == '.' {
+					return newExpression(set.pathCtx, elemExpr, set.cons.Elem).CompletionAtPos(ctx, pos)
+				}
+			}
 		}
 
 		expr := newEmptyExpressionAtPos(eType.Range().Filename, pos)

--- a/decoder/expr_set_completion_test.go
+++ b/decoder/expr_set_completion_test.go
@@ -664,9 +664,7 @@ func TestCompletionAtPos_exprSet_references(t *testing.T) {
 			map[string]*schema.AttributeSchema{
 				"attr": {
 					Constraint: schema.Set{
-						Elem: schema.OneOf{
-							schema.Reference{OfScopeId: lang.ScopeId("variable")},
-						},
+						Elem: schema.Reference{OfScopeId: lang.ScopeId("variable")},
 					},
 				},
 			},

--- a/decoder/expr_tuple_completion.go
+++ b/decoder/expr_tuple_completion.go
@@ -98,6 +98,14 @@ func (tuple Tuple) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Cand
 		if elemExpr.Range().ContainsPos(pos) || elemExpr.Range().End.Byte == pos.Byte {
 			return newExpression(tuple.pathCtx, elemExpr, tuple.cons.Elems[i]).CompletionAtPos(ctx, pos)
 		}
+		if pos.Byte-elemExpr.Range().End.Byte == 1 {
+			fileBytes := tuple.pathCtx.Files[eType.Range().Filename].Bytes
+			trailingRune := fileBytes[elemExpr.Range().End.Byte:pos.Byte][0]
+
+			if trailingRune == '.' {
+				return newExpression(tuple.pathCtx, elemExpr, tuple.cons.Elems[i]).CompletionAtPos(ctx, pos)
+			}
+		}
 		lastElemEndPos = elemExpr.Range().End
 		lastElemIdx = i
 	}

--- a/decoder/expr_tuple_completion_test.go
+++ b/decoder/expr_tuple_completion_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/reference"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -746,6 +747,91 @@ func TestCompletionAtPos_exprTuple(t *testing.T) {
 				Files: map[string]*hcl.File{
 					"test.tf": f,
 				},
+			})
+
+			ctx := context.Background()
+			candidates, err := d.CandidatesAtPos(ctx, "test.tf", tc.pos)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expectedCandidates, candidates); diff != "" {
+				t.Logf("position: %#v in config: %s", tc.pos, tc.cfg)
+				t.Fatalf("unexpected candidates: %s", diff)
+			}
+		})
+	}
+}
+
+func TestCompletionAtPos_exprTuple_references(t *testing.T) {
+	testCases := []struct {
+		testName           string
+		attrSchema         map[string]*schema.AttributeSchema
+		refTargets         reference.Targets
+		cfg                string
+		pos                hcl.Pos
+		expectedCandidates lang.Candidates
+	}{
+		{
+			"single-line with trailing dot",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Tuple{
+						Elems: []schema.Constraint{
+							schema.Reference{OfScopeId: lang.ScopeId("variable")},
+						},
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "bar"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "variables.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 17},
+						End:      hcl.Pos{Line: 2, Column: 3, Byte: 19},
+					},
+					ScopeId: lang.ScopeId("variable"),
+				},
+			},
+			`attr = [ var. ]
+`,
+			hcl.Pos{Line: 1, Column: 14, Byte: 13},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "var.bar",
+					Detail: "reference",
+					Kind:   lang.TraversalCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "var.bar",
+						Snippet: "var.bar",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+							End:      hcl.Pos{Line: 1, Column: 14, Byte: 13},
+						},
+					},
+				},
+			}),
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%2d-%s", i, tc.testName), func(t *testing.T) {
+			bodySchema := &schema.BodySchema{
+				Attributes: tc.attrSchema,
+			}
+
+			f, _ := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+			d := testPathDecoder(t, &PathContext{
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"test.tf": f,
+				},
+				ReferenceTargets: tc.refTargets,
 			})
 
 			ctx := context.Background()


### PR DESCRIPTION
This PR improves the partial traversal completion within lists, tuples, and sets by recovering the trailing dot.

Since I recently worked on this for template expressions, I thought I could fix it for lists, tuples, and sets as well.

### UX Before
![2023-11-13 12 10 12](https://github.com/hashicorp/hcl-lang/assets/45985/72cacc4d-e49f-452f-bb94-2f0ea2fe0b0d)

### UX After
![2023-11-13 12 10 37](https://github.com/hashicorp/hcl-lang/assets/45985/d8b13cbb-5b3d-48b2-8e15-97ddf1115b00)

Closes https://github.com/hashicorp/vscode-terraform/issues/1624