### PR TITLE
Rename TokenTypeCapsule to TokenTypeComplex

### DIFF
--- a/decoder/expr_type_declaration_semtok.go
+++ b/decoder/expr_type_declaration_semtok.go
@@ -31,7 +31,7 @@ func (td TypeDeclaration) SemanticTokens(ctx context.Context) []lang.SemanticTok
 			tokens := make([]lang.SemanticToken, 0)
 
 			tokens = append(tokens, lang.SemanticToken{
-				Type:      lang.TokenTypeCapsule,
+				Type:      lang.TokenTypeComplex,
 				Modifiers: []lang.SemanticTokenModifier{},
 				Range:     eType.NameRange,
 			})
@@ -67,7 +67,7 @@ func (td TypeDeclaration) SemanticTokens(ctx context.Context) []lang.SemanticTok
 func (td TypeDeclaration) objectSemanticTokens(ctx context.Context, funcExpr *hclsyntax.FunctionCallExpr) []lang.SemanticToken {
 	tokens := make([]lang.SemanticToken, 0)
 	tokens = append(tokens, lang.SemanticToken{
-		Type:      lang.TokenTypeCapsule,
+		Type:      lang.TokenTypeComplex,
 		Modifiers: []lang.SemanticTokenModifier{},
 		Range:     funcExpr.NameRange,
 	})
@@ -107,7 +107,7 @@ func (td TypeDeclaration) objectSemanticTokens(ctx context.Context, funcExpr *hc
 func (td TypeDeclaration) tupleSemanticTokens(ctx context.Context, funcExpr *hclsyntax.FunctionCallExpr) []lang.SemanticToken {
 	tokens := make([]lang.SemanticToken, 0)
 	tokens = append(tokens, lang.SemanticToken{
-		Type:      lang.TokenTypeCapsule,
+		Type:      lang.TokenTypeComplex,
 		Modifiers: []lang.SemanticTokenModifier{},
 		Range:     funcExpr.NameRange,
 	})

--- a/decoder/expr_type_declaration_semtok_test.go
+++ b/decoder/expr_type_declaration_semtok_test.go
@@ -90,7 +90,7 @@ func TestSemanticTokens_exprTypeDeclaration(t *testing.T) {
 					},
 				},
 				{
-					Type:      lang.TokenTypeCapsule,
+					Type:      lang.TokenTypeComplex,
 					Modifiers: lang.SemanticTokenModifiers{},
 					Range: hcl.Range{
 						Filename: "test.tf",
@@ -128,7 +128,7 @@ func TestSemanticTokens_exprTypeDeclaration(t *testing.T) {
 					},
 				},
 				{
-					Type:      lang.TokenTypeCapsule,
+					Type:      lang.TokenTypeComplex,
 					Modifiers: lang.SemanticTokenModifiers{},
 					Range: hcl.Range{
 						Filename: "test.tf",
@@ -187,7 +187,7 @@ func TestSemanticTokens_exprTypeDeclaration(t *testing.T) {
 					},
 				},
 				{
-					Type:      lang.TokenTypeCapsule,
+					Type:      lang.TokenTypeComplex,
 					Modifiers: lang.SemanticTokenModifiers{},
 					Range: hcl.Range{
 						Filename: "test.tf",
@@ -258,7 +258,7 @@ func TestSemanticTokens_exprTypeDeclaration(t *testing.T) {
 					},
 				},
 				{
-					Type:      lang.TokenTypeCapsule,
+					Type:      lang.TokenTypeComplex,
 					Modifiers: lang.SemanticTokenModifiers{},
 					Range: hcl.Range{
 						Filename: "test.tf",
@@ -276,7 +276,7 @@ func TestSemanticTokens_exprTypeDeclaration(t *testing.T) {
 					},
 				},
 				{
-					Type:      lang.TokenTypeCapsule,
+					Type:      lang.TokenTypeComplex,
 					Modifiers: lang.SemanticTokenModifiers{},
 					Range: hcl.Range{
 						Filename: "test.tf",
@@ -303,7 +303,7 @@ func TestSemanticTokens_exprTypeDeclaration(t *testing.T) {
 					},
 				},
 				{
-					Type:      lang.TokenTypeCapsule,
+					Type:      lang.TokenTypeComplex,
 					Modifiers: lang.SemanticTokenModifiers{},
 					Range: hcl.Range{
 						Start:    hcl.Pos{Line: 3, Column: 9, Byte: 45},
@@ -339,7 +339,7 @@ func TestSemanticTokens_exprTypeDeclaration(t *testing.T) {
 					},
 				},
 				{
-					Type:      lang.TokenTypeCapsule,
+					Type:      lang.TokenTypeComplex,
 					Modifiers: lang.SemanticTokenModifiers{},
 					Range: hcl.Range{
 						Filename: "test.tf",

--- a/decoder/semantic_tokens.go
+++ b/decoder/semantic_tokens.go
@@ -256,7 +256,7 @@ func (d *PathDecoder) tokensForExpression(ctx context.Context, expr hclsyntax.Ex
 		_, ok := constraints.TypeDeclarationExpr()
 		if ok && isComplexTypeDeclaration(eType.Name) {
 			tokens = append(tokens, lang.SemanticToken{
-				Type:      lang.TokenTypeCapsule,
+				Type:      lang.TokenTypeComplex,
 				Modifiers: []lang.SemanticTokenModifier{},
 				Range:     eType.NameRange,
 			})

--- a/decoder/semantic_tokens_expr_legacy_test.go
+++ b/decoder/semantic_tokens_expr_legacy_test.go
@@ -2161,7 +2161,7 @@ func TestLegacyDecoder_SemanticTokensInFile_typeDeclaration(t *testing.T) {
 					},
 				},
 				{
-					Type:      lang.TokenTypeCapsule,
+					Type:      lang.TokenTypeComplex,
 					Modifiers: []lang.SemanticTokenModifier{},
 					Range: hcl.Range{
 						Filename: "test.tf",
@@ -2253,7 +2253,7 @@ func TestLegacyDecoder_SemanticTokensInFile_typeDeclaration(t *testing.T) {
 					},
 				},
 				{
-					Type:      lang.TokenTypeCapsule,
+					Type:      lang.TokenTypeComplex,
 					Modifiers: []lang.SemanticTokenModifier{},
 					Range: hcl.Range{
 						Filename: "test.tf",

--- a/lang/semantic_token.go
+++ b/lang/semantic_token.go
@@ -31,7 +31,7 @@ const (
 	TokenMapKey        SemanticTokenType = "hcl-mapKey"
 	TokenKeyword       SemanticTokenType = "hcl-keyword"
 	TokenTraversalStep SemanticTokenType = "hcl-traversalStep"
-	TokenTypeCapsule   SemanticTokenType = "hcl-typeCapsule"
+	TokenTypeComplex   SemanticTokenType = "hcl-typeComplex"
 	TokenTypePrimitive SemanticTokenType = "hcl-typePrimitive"
 	TokenFunctionName  SemanticTokenType = "hcl-functionName"
 )
@@ -47,7 +47,7 @@ var SupportedSemanticTokenTypes = SemanticTokenTypes{
 	TokenMapKey,
 	TokenKeyword,
 	TokenTraversalStep,
-	TokenTypeCapsule,
+	TokenTypeComplex,
 	TokenTypePrimitive,
 	TokenFunctionName,
 }


### PR DESCRIPTION
This renames the existing token type TokenTypeCapsule to TokenTypeComplex to aid readability and reflect existing naming conventions.

This token represents `list` in `type = list(string)` and similar, i.e. the name of the complex type. The term "capsule" has slightly different meaning in cty and HCL and we should not use it in this context.
