### PR TITLE
decoder: Add support for parenthesis on RHS

### DIFF
--- a/decoder/expr_any_operator.go
+++ b/decoder/expr_any_operator.go
@@ -150,6 +150,10 @@ func (a Any) hoverOperatorExprAtPos(ctx context.Context, pos hcl.Pos) (*lang.Hov
 		}
 
 		return nil, true
+	case *hclsyntax.ParenthesesExpr:
+		if eType.Expression.Range().ContainsPos(pos) {
+			return newExpression(a.pathCtx, eType.Expression, a.cons).HoverAtPos(ctx, pos), true
+		}
 	}
 
 	return nil, false

--- a/decoder/expr_any_operator.go
+++ b/decoder/expr_any_operator.go
@@ -272,6 +272,10 @@ func (a Any) semanticTokensForOperatorExpr(ctx context.Context) ([]lang.Semantic
 		}).SemanticTokens(ctx)...)
 
 		return tokens, true
+
+	case *hclsyntax.ParenthesesExpr:
+		tokens = append(tokens, newExpression(a.pathCtx, eType.Expression, a.cons).SemanticTokens(ctx)...)
+		return tokens, true
 	}
 
 	return tokens, false

--- a/decoder/expr_any_operator.go
+++ b/decoder/expr_any_operator.go
@@ -87,6 +87,11 @@ func (a Any) completeOperatorExprAtPos(ctx context.Context, pos hcl.Pos) ([]lang
 		}
 
 		return candidates, false
+
+	case *hclsyntax.ParenthesesExpr:
+		if eType.Expression.Range().ContainsPos(pos) || eType.Expression.Range().End.Byte == pos.Byte {
+			return newExpression(a.pathCtx, eType.Expression, a.cons).CompletionAtPos(ctx, pos), true
+		}
 	}
 
 	return candidates, true

--- a/decoder/expr_any_operator.go
+++ b/decoder/expr_any_operator.go
@@ -220,6 +220,13 @@ func (a Any) refOriginsForOperatorExpr(ctx context.Context, allowSelfRefs bool) 
 		}
 
 		return origins, true
+	case *hclsyntax.ParenthesesExpr:
+		expr := newExpression(a.pathCtx, eType.Expression, a.cons)
+		if expr, ok := expr.(ReferenceOriginsExpression); ok {
+			origins = append(origins, expr.ReferenceOrigins(ctx, allowSelfRefs)...)
+		}
+
+		return origins, true
 	}
 
 	return origins, false


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-ls/issues/529

Operators were already implemented as part of https://github.com/hashicorp/hcl-lang/pull/320

--- 

This enables support for parenthesis on the RHS (right hand side), i.e. after `=`.

For example:

```hcl
attr = (var.foo + var.bar) * 2
```

## UX Examples

### Completion

![Screenshot 2024-01-18 at 20 43 49](https://github.com/hashicorp/hcl-lang/assets/287584/e82c27d6-7177-45d2-88fe-bb26c639daa1)

![Screenshot 2024-01-18 at 20 43 31](https://github.com/hashicorp/hcl-lang/assets/287584/168be235-98b4-4976-bbe8-6e004b7afa87)

### Hover

![Screenshot 2024-01-18 at 20 44 19](https://github.com/hashicorp/hcl-lang/assets/287584/483e7847-c5f6-46b8-bec7-4d80089fe249)

### Semantic Tokens

![Screenshot 2024-01-18 at 20 44 41](https://github.com/hashicorp/hcl-lang/assets/287584/7445f78b-777f-449b-be02-5f97d9f900d3)

### Reference Origins

![2024-01-18 20 45 17](https://github.com/hashicorp/hcl-lang/assets/287584/e5aa5243-f2bb-498c-9f87-55942fc2cda8)

--- 

## Follow-up Issues

 - https://github.com/hashicorp/terraform-ls/issues/1586
