### PR TITLE
decoder: Add support for parenthesis on LHS (map keys & attribute names)

### DIFF
--- a/decoder/expr_any_completion.go
+++ b/decoder/expr_any_completion.go
@@ -87,7 +87,8 @@ func (a Any) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate 
 		}
 
 		cons := schema.Object{
-			Attributes: ctyObjectToObjectAttributes(typ),
+			Attributes:                ctyObjectToObjectAttributes(typ),
+			AllowInterpolatedAttrName: true,
 		}
 		return newExpression(a.pathCtx, expr, cons).CompletionAtPos(ctx, pos)
 	}

--- a/decoder/expr_any_completion.go
+++ b/decoder/expr_any_completion.go
@@ -87,8 +87,8 @@ func (a Any) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate 
 		}
 
 		cons := schema.Object{
-			Attributes:                ctyObjectToObjectAttributes(typ),
-			AllowInterpolatedAttrName: true,
+			Attributes:            ctyObjectToObjectAttributes(typ),
+			AllowInterpolatedKeys: true,
 		}
 		return newExpression(a.pathCtx, expr, cons).CompletionAtPos(ctx, pos)
 	}

--- a/decoder/expr_any_completion.go
+++ b/decoder/expr_any_completion.go
@@ -74,7 +74,9 @@ func (a Any) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate 
 			Elem: schema.AnyExpression{
 				OfType: typ.ElementType(),
 			},
+			AllowInterpolatedKeys: true,
 		}
+
 		return newExpression(a.pathCtx, expr, cons).CompletionAtPos(ctx, pos)
 	}
 

--- a/decoder/expr_any_completion_test.go
+++ b/decoder/expr_any_completion_test.go
@@ -3609,6 +3609,136 @@ func TestCompletionAtPos_exprAny_parentheses(t *testing.T) {
 				},
 			}),
 		},
+		{
+			"empty parentheses as map key",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Map(cty.String),
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "foo"},
+					},
+					Type: cty.String,
+				},
+			},
+			`attr = {
+  () = "foo"
+}
+`,
+			hcl.Pos{Line: 2, Column: 4, Byte: 12},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "var.foo",
+					Detail: "string",
+					Kind:   lang.ReferenceCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "var.foo",
+						Snippet: "var.foo",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 4, Byte: 12},
+							End:      hcl.Pos{Line: 2, Column: 4, Byte: 12},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"parentheses with prefix as map key",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Map(cty.String),
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "foo"},
+					},
+					Type: cty.String,
+				},
+			},
+			`attr = {
+  (var) = "foo"
+}
+`,
+			hcl.Pos{Line: 2, Column: 7, Byte: 15},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "var.foo",
+					Detail: "string",
+					Kind:   lang.ReferenceCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "var.foo",
+						Snippet: "var.foo",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 4, Byte: 12},
+							End:      hcl.Pos{Line: 2, Column: 7, Byte: 15},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"empty parentheses as map key in static map",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Map{
+						Elem: schema.LiteralType{Type: cty.String},
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "foo"},
+					},
+					Type: cty.String,
+				},
+			},
+			`attr = {
+  () = "foo"
+}
+`,
+			hcl.Pos{Line: 2, Column: 4, Byte: 12},
+			lang.CompleteCandidates([]lang.Candidate{}),
+		},
+		{
+			"parentheses with prefix as map key in static map",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Map{
+						Elem: schema.LiteralType{Type: cty.String},
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "foo"},
+					},
+					Type: cty.String,
+				},
+			},
+			`attr = {
+  (var) = "foo"
+}
+`,
+			hcl.Pos{Line: 2, Column: 7, Byte: 15},
+			lang.CompleteCandidates([]lang.Candidate{}),
+		},
 	}
 
 	for i, tc := range testCases {

--- a/decoder/expr_any_completion_test.go
+++ b/decoder/expr_any_completion_test.go
@@ -3739,6 +3739,148 @@ func TestCompletionAtPos_exprAny_parentheses(t *testing.T) {
 			hcl.Pos{Line: 2, Column: 7, Byte: 15},
 			lang.CompleteCandidates([]lang.Candidate{}),
 		},
+		{
+			"empty parentheses as object attribute name",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Object(map[string]cty.Type{
+							"bar": cty.String,
+						}),
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "foo"},
+					},
+					Type: cty.String,
+				},
+			},
+			`attr = {
+  () = "foo"
+}
+`,
+			hcl.Pos{Line: 2, Column: 4, Byte: 12},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "var.foo",
+					Detail: "string",
+					Kind:   lang.ReferenceCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "var.foo",
+						Snippet: "var.foo",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 4, Byte: 12},
+							End:      hcl.Pos{Line: 2, Column: 4, Byte: 12},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"parentheses with prefix as object attribute name",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Object(map[string]cty.Type{
+							"bar": cty.String,
+						}),
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "foo"},
+					},
+					Type: cty.String,
+				},
+			},
+			`attr = {
+  (var) = "foo"
+}
+`,
+			hcl.Pos{Line: 2, Column: 7, Byte: 15},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "var.foo",
+					Detail: "string",
+					Kind:   lang.ReferenceCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "var.foo",
+						Snippet: "var.foo",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 4, Byte: 12},
+							End:      hcl.Pos{Line: 2, Column: 7, Byte: 15},
+						},
+					},
+				},
+			}),
+		},
+		{
+			"empty parentheses as object attribute name in static object",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Object{
+						Attributes: schema.ObjectAttributes{
+							"foo": &schema.AttributeSchema{
+								Constraint: schema.LiteralType{Type: cty.String},
+							},
+						},
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "foo"},
+					},
+					Type: cty.String,
+				},
+			},
+			`attr = {
+  () = "foo"
+}
+`,
+			hcl.Pos{Line: 2, Column: 4, Byte: 12},
+			lang.CompleteCandidates([]lang.Candidate{}),
+		},
+		{
+			"parentheses with prefix as map key in static map",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Object{
+						Attributes: schema.ObjectAttributes{
+							"foo": &schema.AttributeSchema{
+								Constraint: schema.LiteralType{Type: cty.String},
+							},
+						},
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "foo"},
+					},
+					Type: cty.String,
+				},
+			},
+			`attr = {
+  (var) = "foo"
+}
+`,
+			hcl.Pos{Line: 2, Column: 7, Byte: 15},
+			lang.CompleteCandidates([]lang.Candidate{}),
+		},
 	}
 
 	for i, tc := range testCases {

--- a/decoder/expr_any_hover.go
+++ b/decoder/expr_any_hover.go
@@ -74,6 +74,7 @@ func (a Any) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData {
 			Elem: schema.AnyExpression{
 				OfType: typ.ElementType(),
 			},
+			AllowInterpolatedKeys: true,
 		}
 		return newExpression(a.pathCtx, expr, cons).HoverAtPos(ctx, pos)
 	}

--- a/decoder/expr_any_hover.go
+++ b/decoder/expr_any_hover.go
@@ -86,7 +86,8 @@ func (a Any) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData {
 		}
 
 		cons := schema.Object{
-			Attributes: ctyObjectToObjectAttributes(typ),
+			Attributes:                ctyObjectToObjectAttributes(typ),
+			AllowInterpolatedAttrName: true,
 		}
 		return newExpression(a.pathCtx, expr, cons).HoverAtPos(ctx, pos)
 	}

--- a/decoder/expr_any_hover.go
+++ b/decoder/expr_any_hover.go
@@ -86,8 +86,8 @@ func (a Any) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData {
 		}
 
 		cons := schema.Object{
-			Attributes:                ctyObjectToObjectAttributes(typ),
-			AllowInterpolatedAttrName: true,
+			Attributes:            ctyObjectToObjectAttributes(typ),
+			AllowInterpolatedKeys: true,
 		}
 		return newExpression(a.pathCtx, expr, cons).HoverAtPos(ctx, pos)
 	}

--- a/decoder/expr_any_hover_test.go
+++ b/decoder/expr_any_hover_test.go
@@ -1733,6 +1733,56 @@ func TestHoverAtPos_exprAny_parenthesis(t *testing.T) {
 				},
 			},
 		},
+		{
+			"reference as object attribute name",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Object(map[string]cty.Type{
+							"bar": cty.String,
+						}),
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "foo"},
+					},
+					Type: cty.String,
+				},
+			},
+			reference.Origins{
+				reference.LocalOrigin{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "foo"},
+					},
+					Constraints: reference.OriginConstraints{
+						{OfType: cty.String},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 4, Byte: 12},
+						End:      hcl.Pos{Line: 2, Column: 11, Byte: 19},
+					},
+				},
+			},
+			`attr = {
+  (var.foo) = "foo"
+}
+`,
+			hcl.Pos{Line: 2, Column: 7, Byte: 15},
+			&lang.HoverData{
+				Content: lang.Markdown("`var.foo`\n_string_"),
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 2, Column: 4, Byte: 12},
+					End:      hcl.Pos{Line: 2, Column: 11, Byte: 19},
+				},
+			},
+		},
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {

--- a/decoder/expr_any_ref_origins.go
+++ b/decoder/expr_any_ref_origins.go
@@ -105,7 +105,8 @@ func (a Any) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference
 			expr:    a.expr,
 			pathCtx: a.pathCtx,
 			cons: schema.Object{
-				Attributes: ctyObjectToObjectAttributes(typ),
+				Attributes:                ctyObjectToObjectAttributes(typ),
+				AllowInterpolatedAttrName: true,
 			},
 		}
 		return obj.ReferenceOrigins(ctx, allowSelfRefs)

--- a/decoder/expr_any_ref_origins.go
+++ b/decoder/expr_any_ref_origins.go
@@ -105,8 +105,8 @@ func (a Any) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference
 			expr:    a.expr,
 			pathCtx: a.pathCtx,
 			cons: schema.Object{
-				Attributes:                ctyObjectToObjectAttributes(typ),
-				AllowInterpolatedAttrName: true,
+				Attributes:            ctyObjectToObjectAttributes(typ),
+				AllowInterpolatedKeys: true,
 			},
 		}
 		return obj.ReferenceOrigins(ctx, allowSelfRefs)

--- a/decoder/expr_any_ref_origins.go
+++ b/decoder/expr_any_ref_origins.go
@@ -89,6 +89,7 @@ func (a Any) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference
 				Elem: schema.AnyExpression{
 					OfType: typ.ElementType(),
 				},
+				AllowInterpolatedKeys: true,
 			},
 		}
 		return m.ReferenceOrigins(ctx, allowSelfRefs)

--- a/decoder/expr_any_ref_origins_test.go
+++ b/decoder/expr_any_ref_origins_test.go
@@ -954,6 +954,40 @@ func TestCollectRefOrigins_exprAny_parenthesis_hcl(t *testing.T) {
 				},
 			},
 		},
+		{
+			"reference as object attribute name",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Object(map[string]cty.Type{
+							"bar": cty.String,
+						}),
+					},
+				},
+			},
+			`attr = {
+  (var.foo) = "foo"
+}
+`,
+			reference.Origins{
+				reference.LocalOrigin{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "foo"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 4, Byte: 12},
+						End:      hcl.Pos{Line: 2, Column: 11, Byte: 19},
+					},
+					Constraints: reference.OriginConstraints{
+						{
+							OfType: cty.String,
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for i, tc := range testCases {

--- a/decoder/expr_any_ref_origins_test.go
+++ b/decoder/expr_any_ref_origins_test.go
@@ -922,6 +922,38 @@ func TestCollectRefOrigins_exprAny_parenthesis_hcl(t *testing.T) {
 				},
 			},
 		},
+		{
+			"reference as map key",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Map(cty.String),
+					},
+				},
+			},
+			`attr = {
+  (var.foo) = "foo"
+}
+`,
+			reference.Origins{
+				reference.LocalOrigin{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "foo"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 4, Byte: 12},
+						End:      hcl.Pos{Line: 2, Column: 11, Byte: 19},
+					},
+					Constraints: reference.OriginConstraints{
+						{
+							OfType: cty.String,
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for i, tc := range testCases {

--- a/decoder/expr_any_semtok.go
+++ b/decoder/expr_any_semtok.go
@@ -73,6 +73,7 @@ func (a Any) SemanticTokens(ctx context.Context) []lang.SemanticToken {
 			Elem: schema.AnyExpression{
 				OfType: typ.ElementType(),
 			},
+			AllowInterpolatedKeys: true,
 		}
 		return newExpression(a.pathCtx, expr, cons).SemanticTokens(ctx)
 	}

--- a/decoder/expr_any_semtok.go
+++ b/decoder/expr_any_semtok.go
@@ -85,8 +85,8 @@ func (a Any) SemanticTokens(ctx context.Context) []lang.SemanticToken {
 		}
 
 		cons := schema.Object{
-			Attributes:                ctyObjectToObjectAttributes(typ),
-			AllowInterpolatedAttrName: true,
+			Attributes:            ctyObjectToObjectAttributes(typ),
+			AllowInterpolatedKeys: true,
 		}
 		return newExpression(a.pathCtx, expr, cons).SemanticTokens(ctx)
 	}

--- a/decoder/expr_any_semtok.go
+++ b/decoder/expr_any_semtok.go
@@ -85,7 +85,8 @@ func (a Any) SemanticTokens(ctx context.Context) []lang.SemanticToken {
 		}
 
 		cons := schema.Object{
-			Attributes: ctyObjectToObjectAttributes(typ),
+			Attributes:                ctyObjectToObjectAttributes(typ),
+			AllowInterpolatedAttrName: true,
 		}
 		return newExpression(a.pathCtx, expr, cons).SemanticTokens(ctx)
 	}

--- a/decoder/expr_any_semtok_test.go
+++ b/decoder/expr_any_semtok_test.go
@@ -2878,6 +2878,81 @@ func TestSemanticTokens_exprAny_parenthesis(t *testing.T) {
 				},
 			},
 		},
+		{
+			"reference as object attribute name",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.Object(map[string]cty.Type{
+							"bar": cty.String,
+						}),
+					},
+				},
+			},
+			reference.Origins{
+				reference.LocalOrigin{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "foo"},
+					},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 4, Byte: 12},
+						End:      hcl.Pos{Line: 2, Column: 11, Byte: 19},
+					},
+					Constraints: reference.OriginConstraints{
+						{OfType: cty.String},
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "var"},
+						lang.AttrStep{Name: "foo"},
+					},
+					Type: cty.String,
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 3, Column: 1, Byte: 31},
+						End:      hcl.Pos{Line: 3, Column: 2, Byte: 32},
+					},
+				},
+			},
+			`attr = {
+  (var.foo) = "foo"
+}
+`,
+			[]lang.SemanticToken{
+				{
+					Type:      lang.TokenAttrName,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+				},
+				{
+					Type:      lang.TokenReferenceStep,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 4, Byte: 12},
+						End:      hcl.Pos{Line: 2, Column: 7, Byte: 15},
+					},
+				},
+				{
+					Type:      lang.TokenReferenceStep,
+					Modifiers: lang.SemanticTokenModifiers{},
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 8, Byte: 16},
+						End:      hcl.Pos{Line: 2, Column: 11, Byte: 19},
+					},
+				},
+			},
+		},
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {

--- a/decoder/expr_object_completion.go
+++ b/decoder/expr_object_completion.go
@@ -107,7 +107,7 @@ func (obj Object) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candi
 		if item.KeyExpr.Range().ContainsPos(pos) {
 			// handle any interpolation if it is allowed
 			keyExpr, ok := item.KeyExpr.(*hclsyntax.ObjectConsKeyExpr)
-			if ok && obj.cons.AllowInterpolatedAttrName {
+			if ok && obj.cons.AllowInterpolatedKeys {
 				parensExpr, ok := keyExpr.Wrapped.(*hclsyntax.ParenthesesExpr)
 				if ok {
 					keyCons := schema.AnyExpression{
@@ -184,7 +184,7 @@ func (obj Object) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candi
 	})
 
 	// parenthesis implies interpolated attribute name
-	if trimmedBytes[len(trimmedBytes)-1] == '(' && obj.cons.AllowInterpolatedAttrName {
+	if trimmedBytes[len(trimmedBytes)-1] == '(' && obj.cons.AllowInterpolatedKeys {
 		emptyExpr := newEmptyExpressionAtPos(eType.Range().Filename, pos)
 		attrNameCons := schema.AnyExpression{
 			OfType: cty.String,

--- a/decoder/expr_object_hover.go
+++ b/decoder/expr_object_hover.go
@@ -32,7 +32,7 @@ func (obj Object) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverData {
 		if item.KeyExpr.Range().ContainsPos(pos) {
 			// handle any interpolation if it is allowed
 			keyExpr, ok := item.KeyExpr.(*hclsyntax.ObjectConsKeyExpr)
-			if ok && obj.cons.AllowInterpolatedAttrName {
+			if ok && obj.cons.AllowInterpolatedKeys {
 				parensExpr, ok := keyExpr.Wrapped.(*hclsyntax.ParenthesesExpr)
 				if ok {
 					keyCons := schema.AnyExpression{

--- a/decoder/expr_object_semtok.go
+++ b/decoder/expr_object_semtok.go
@@ -52,12 +52,9 @@ func (obj Object) SemanticTokens(ctx context.Context) []lang.SemanticToken {
 				// TODO: Consider not reporting the quotes?
 				Range: item.KeyExpr.Range(),
 			})
-		}
 
-		if isKnownAttr {
 			expr := newExpression(obj.pathCtx, item.ValueExpr, aSchema.Constraint)
 			tokens = append(tokens, expr.SemanticTokens(ctx)...)
-			continue
 		}
 	}
 

--- a/decoder/expr_object_semtok.go
+++ b/decoder/expr_object_semtok.go
@@ -34,7 +34,7 @@ func (obj Object) SemanticTokens(ctx context.Context) []lang.SemanticToken {
 		}
 
 		keyExpr, ok := item.KeyExpr.(*hclsyntax.ObjectConsKeyExpr)
-		if ok && obj.cons.AllowInterpolatedAttrName {
+		if ok && obj.cons.AllowInterpolatedKeys {
 			parensExpr, ok := keyExpr.Wrapped.(*hclsyntax.ParenthesesExpr)
 			if ok {
 				keyCons := schema.AnyExpression{

--- a/decoder/expression.go
+++ b/decoder/expression.go
@@ -127,8 +127,9 @@ func newExpression(pathContext *PathContext, expr hcl.Expression, cons schema.Co
 		}
 	case schema.LiteralValue:
 		return LiteralValue{
-			expr: expr,
-			cons: c,
+			expr:    expr,
+			cons:    c,
+			pathCtx: pathContext,
 		}
 	case schema.TypeDeclaration:
 		return TypeDeclaration{

--- a/schema/constraint_map.go
+++ b/schema/constraint_map.go
@@ -30,6 +30,10 @@ type Map struct {
 
 	// MaxItems defines maximum number of items (affects completion)
 	MaxItems uint64
+
+	// AllowInterpolatedKeys determines whether the key names can be
+	// interpolated (true) or static (literal strings only).
+	AllowInterpolatedKeys bool
 }
 
 func (Map) isConstraintImpl() constraintSigil {
@@ -52,11 +56,12 @@ func (m Map) Copy() Constraint {
 		elem = m.Elem.Copy()
 	}
 	return Map{
-		Elem:        elem,
-		Name:        m.Name,
-		Description: m.Description,
-		MinItems:    m.MinItems,
-		MaxItems:    m.MaxItems,
+		Elem:                  elem,
+		Name:                  m.Name,
+		Description:           m.Description,
+		MinItems:              m.MinItems,
+		MaxItems:              m.MaxItems,
+		AllowInterpolatedKeys: m.AllowInterpolatedKeys,
 	}
 }
 

--- a/schema/constraint_object.go
+++ b/schema/constraint_object.go
@@ -26,9 +26,9 @@ type Object struct {
 	// Description defines description of the whole object (affects hover)
 	Description lang.MarkupContent
 
-	// AllowInterpolatedAttrName determines whether the attribute names can be
+	// AllowInterpolatedKeys determines whether the attribute names can be
 	// interpolated (true) or static (literal strings only).
-	AllowInterpolatedAttrName bool
+	AllowInterpolatedKeys bool
 }
 
 type ObjectAttributes map[string]*AttributeSchema
@@ -46,10 +46,10 @@ func (o Object) FriendlyName() string {
 
 func (o Object) Copy() Constraint {
 	return Object{
-		Attributes:                o.Attributes.Copy(),
-		Name:                      o.Name,
-		Description:               o.Description,
-		AllowInterpolatedAttrName: o.AllowInterpolatedAttrName,
+		Attributes:            o.Attributes.Copy(),
+		Name:                  o.Name,
+		Description:           o.Description,
+		AllowInterpolatedKeys: o.AllowInterpolatedKeys,
 	}
 }
 

--- a/schema/constraint_object.go
+++ b/schema/constraint_object.go
@@ -25,6 +25,10 @@ type Object struct {
 
 	// Description defines description of the whole object (affects hover)
 	Description lang.MarkupContent
+
+	// AllowInterpolatedAttrName determines whether the attribute names can be
+	// interpolated (true) or static (literal strings only).
+	AllowInterpolatedAttrName bool
 }
 
 type ObjectAttributes map[string]*AttributeSchema
@@ -42,9 +46,10 @@ func (o Object) FriendlyName() string {
 
 func (o Object) Copy() Constraint {
 	return Object{
-		Attributes:  o.Attributes.Copy(),
-		Name:        o.Name,
-		Description: o.Description,
+		Attributes:                o.Attributes.Copy(),
+		Name:                      o.Name,
+		Description:               o.Description,
+		AllowInterpolatedAttrName: o.AllowInterpolatedAttrName,
 	}
 }
 


### PR DESCRIPTION
Depends on:

 - https://github.com/hashicorp/hcl-lang/pull/366

--- 

This enables support for interpolated map keys and object attribute names,. Since this is enabled by parenthesis it is closely related to that linked PR which adds support for that expression type.

In other words this enables parenthesis support on the LHS (left hand side).

Example:

```hcl
map_attr = {
  (var.keyname) = "foo"
}
```

## Implementation Notes

This does _not_ enable equivalent support inside of inferred maps/objects, such as in the context of Terraform's `locals`. This is currently tracked under https://github.com/hashicorp/terraform-ls/issues/1586 

It originally started out as "hidden implementation detail" of `decoder` (the decision whether interpolation is allowed was originally just implied by `AnyExpression{}` until I realised that we still use `schema.Map{}` and `schema.Object{}` in contexts where we expect interpolation, including interpolated keys, so I had to walk it back and make it a more 1st class feature of the schema, for better or worse.

For that reason, this will also require some changes downstream:

 - https://github.com/hashicorp/terraform-schema/pull/316

## UX Examples

### Completion

![Screenshot 2024-01-18 at 20 47 21](https://github.com/hashicorp/hcl-lang/assets/287584/b84cee60-2165-4fbb-8e3a-49c408ced828)

### Hover

![Screenshot 2024-01-18 at 20 49 08](https://github.com/hashicorp/hcl-lang/assets/287584/66b933dd-584f-449c-8d5a-9e6a271dd73a)

### Semantic Tokens

![Screenshot 2024-01-18 at 20 49 28](https://github.com/hashicorp/hcl-lang/assets/287584/75c9f8d6-875e-4b74-8726-3366c14008a2)

### Reference Origins

![2024-01-18 20 50 14](https://github.com/hashicorp/hcl-lang/assets/287584/1509e531-e7f9-432b-8f51-5be557908be8)
