### PR TITLE
Fix crash prefix completion with leading space

### DIFF
--- a/decoder/expr_any_completion_test.go
+++ b/decoder/expr_any_completion_test.go
@@ -878,6 +878,36 @@ func TestCompletionAtPos_exprAny_functions(t *testing.T) {
 				},
 			}),
 		},
+		{
+			"in front of prefix (with space)",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			reference.Targets{},
+			`attr = t 
+`,
+			hcl.Pos{Line: 1, Column: 7, Byte: 6},
+			lang.CompleteCandidates([]lang.Candidate{}),
+		},
+		{
+			"in front of non-empty [ ]",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			reference.Targets{},
+			`attr = t [x]
+`,
+			hcl.Pos{Line: 1, Column: 9, Byte: 8},
+			lang.CompleteCandidates([]lang.Candidate{}),
+		},
 	}
 
 	for i, tc := range testCases {

--- a/decoder/expr_function.go
+++ b/decoder/expr_function.go
@@ -49,7 +49,7 @@ func (fe functionExpr) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.
 
 		// There can be a single segment with trailing dot which cannot
 		// be a function anymore as functions cannot contain dots.
-		if prefixLen > len(rootName) {
+		if prefixLen < 0 || prefixLen > len(rootName) {
 			return []lang.Candidate{}
 		}
 

--- a/decoder/expr_keyword_completion.go
+++ b/decoder/expr_keyword_completion.go
@@ -43,7 +43,7 @@ func (kw Keyword) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candi
 	}
 
 	prefixLen := pos.Byte - eType.Traversal.SourceRange().Start.Byte
-	if prefixLen > len(eType.Traversal.RootName()) {
+	if prefixLen < 0 || prefixLen > len(eType.Traversal.RootName()) {
 		// The user has probably typed an extra character, such as a
 		// period, that is not (yet) part of the expression. This prefix
 		// won't match anything, so we'll return early.

--- a/decoder/expr_keyword_completion_test.go
+++ b/decoder/expr_keyword_completion_test.go
@@ -123,7 +123,19 @@ func TestCompletionAtPos_exprKeyword(t *testing.T) {
 			hcl.Pos{Line: 1, Column: 9, Byte: 8},
 			lang.CompleteCandidates([]lang.Candidate{}),
 		},
+		{
+			"in front of prefix (with space)",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Keyword{Keyword: "foobar"},
+				},
+			},
+			`attr = f`,
+			hcl.Pos{Line: 1, Column: 7, Byte: 6},
+			lang.CompleteCandidates([]lang.Candidate{}),
+		},
 	}
+
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {
 			bodySchema := &schema.BodySchema{

--- a/decoder/expr_literal_type_completion.go
+++ b/decoder/expr_literal_type_completion.go
@@ -140,7 +140,7 @@ func (lt LiteralType) completeBoolAtPos(ctx context.Context, pos hcl.Pos) []lang
 
 	case *hclsyntax.ScopeTraversalExpr:
 		prefixLen := pos.Byte - eType.Range().Start.Byte
-		if prefixLen > len(eType.Traversal.RootName()) {
+		if prefixLen < 0 || prefixLen > len(eType.Traversal.RootName()) {
 			// The user has probably typed an extra character, such as a
 			// period, that is not (yet) part of the expression. This prefix
 			// won't match anything, so we'll return early.

--- a/decoder/expr_literal_type_completion_test.go
+++ b/decoder/expr_literal_type_completion_test.go
@@ -1190,6 +1190,20 @@ func TestCompletionAtPos_exprLiteralType(t *testing.T) {
 				},
 			}),
 		},
+		{
+			"in front of prefix (with space)",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralType{
+						Type: cty.Bool,
+					},
+				},
+			},
+			`attr = f
+`,
+			hcl.Pos{Line: 1, Column: 7, Byte: 6},
+			lang.CompleteCandidates([]lang.Candidate{}),
+		},
 	}
 
 	for i, tc := range testCases {

--- a/decoder/expr_literal_value_completion.go
+++ b/decoder/expr_literal_value_completion.go
@@ -87,7 +87,7 @@ func (lv LiteralValue) completeBoolAtPos(ctx context.Context, pos hcl.Pos) []lan
 
 	case *hclsyntax.ScopeTraversalExpr:
 		prefixLen := pos.Byte - eType.Range().Start.Byte
-		if prefixLen > len(eType.Traversal.RootName()) {
+		if prefixLen < 0 || prefixLen > len(eType.Traversal.RootName()) {
 			// The user has probably typed an extra character, such as a
 			// period, that is not (yet) part of the expression. This prefix
 			// won't match anything, so we'll return early.

--- a/decoder/expr_literal_value_completion_test.go
+++ b/decoder/expr_literal_value_completion_test.go
@@ -621,6 +621,20 @@ func TestCompletionAtPos_exprLiteralValue(t *testing.T) {
 				},
 			}),
 		},
+		{
+			"in front of prefix (with space)",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.LiteralValue{
+						Value: cty.BoolVal(true),
+					},
+				},
+			},
+			`attr = t
+`,
+			hcl.Pos{Line: 1, Column: 7, Byte: 6},
+			lang.CompleteCandidates([]lang.Candidate{}),
+		},
 	}
 
 	for i, tc := range testCases {

--- a/decoder/expr_type_declaration_completion.go
+++ b/decoder/expr_type_declaration_completion.go
@@ -32,7 +32,7 @@ func (td TypeDeclaration) CompletionAtPos(ctx context.Context, pos hcl.Pos) []la
 		}
 
 		prefixLen := pos.Byte - eType.Range().Start.Byte
-		if prefixLen > len(eType.Traversal.RootName()) {
+		if prefixLen < 0 || prefixLen > len(eType.Traversal.RootName()) {
 			// The user has probably typed an extra character, such as a
 			// period, that is not (yet) part of the expression. This prefix
 			// won't match anything, so we'll return early.

--- a/decoder/expr_type_declaration_completion_test.go
+++ b/decoder/expr_type_declaration_completion_test.go
@@ -125,7 +125,7 @@ func TestCompletionAtPos_exprTypeDeclaration(t *testing.T) {
 			}),
 		},
 		{
-			"partial name with dot",
+			"partial name with dot",
 			map[string]*schema.AttributeSchema{
 				"attr": {
 					Constraint: schema.TypeDeclaration{},
@@ -1012,6 +1012,18 @@ func TestCompletionAtPos_exprTypeDeclaration(t *testing.T) {
   s = 
 })`,
 			hcl.Pos{Line: 2, Column: 4, Byte: 19},
+			lang.CompleteCandidates([]lang.Candidate{}),
+		},
+		{
+			"in front of prefix (with space)",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.TypeDeclaration{},
+				},
+			},
+			`attr = st
+`,
+			hcl.Pos{Line: 1, Column: 7, Byte: 6},
 			lang.CompleteCandidates([]lang.Candidate{}),
 		},
 	}


### PR DESCRIPTION
Radek discovered this crash in the context of a function expression, but it turns out that it affects all expressions that try to infer a prefix.
This PR fixes a crash that occurred when a user tried to use auto-completion in front of a prefix, right after the `=`.

Closes https://github.com/hashicorp/terraform-ls/issues/1606