### PR TITLE
Fix `for` expression collection constraints 

### DIFF
--- a/decoder/expr_any_for.go
+++ b/decoder/expr_any_for.go
@@ -175,7 +175,15 @@ func (a Any) refOriginsForForExpr(ctx context.Context, allowSelfRefs bool) (refe
 		// TODO: eType.KeyVarExpr.Range() to collect key as origin
 		// TODO: eType.ValVarExpr.Range() to collect value as origin
 
-		if collExpr, ok := newExpression(a.pathCtx, eType.CollExpr, a.cons).(ReferenceOriginsExpression); ok {
+		// A for expression's input can be a list, a set, a tuple, a map, or an object
+		collCons := schema.OneOf{
+			schema.AnyExpression{OfType: cty.List(cty.DynamicPseudoType)},
+			schema.AnyExpression{OfType: cty.Set(cty.DynamicPseudoType)},
+			schema.AnyExpression{OfType: cty.EmptyTuple},
+			schema.AnyExpression{OfType: cty.Map(cty.DynamicPseudoType)},
+			schema.AnyExpression{OfType: cty.EmptyObject},
+		}
+		if collExpr, ok := newExpression(a.pathCtx, eType.CollExpr, collCons).(ReferenceOriginsExpression); ok {
 			origins = append(origins, collExpr.ReferenceOrigins(ctx, allowSelfRefs)...)
 		}
 

--- a/decoder/expr_any_ref_origins_test.go
+++ b/decoder/expr_any_ref_origins_test.go
@@ -1049,7 +1049,11 @@ func TestCollectRefOrigins_exprAny_forExpr_hcl(t *testing.T) {
 						End:      hcl.Pos{Line: 1, Column: 33, Byte: 32},
 					},
 					Constraints: reference.OriginConstraints{
-						{OfType: cty.List(cty.String)},
+						{OfType: cty.List(cty.DynamicPseudoType)},
+						{OfType: cty.Set(cty.DynamicPseudoType)},
+						{OfType: cty.EmptyTuple},
+						{OfType: cty.Map(cty.DynamicPseudoType)},
+						{OfType: cty.EmptyObject},
 					},
 				},
 				reference.LocalOrigin{
@@ -1090,7 +1094,11 @@ func TestCollectRefOrigins_exprAny_forExpr_hcl(t *testing.T) {
 						End:      hcl.Pos{Line: 1, Column: 33, Byte: 32},
 					},
 					Constraints: reference.OriginConstraints{
-						{OfType: cty.Set(cty.String)},
+						{OfType: cty.List(cty.DynamicPseudoType)},
+						{OfType: cty.Set(cty.DynamicPseudoType)},
+						{OfType: cty.EmptyTuple},
+						{OfType: cty.Map(cty.DynamicPseudoType)},
+						{OfType: cty.EmptyObject},
 					},
 				},
 				reference.LocalOrigin{
@@ -1131,7 +1139,11 @@ func TestCollectRefOrigins_exprAny_forExpr_hcl(t *testing.T) {
 						End:      hcl.Pos{Line: 1, Column: 33, Byte: 32},
 					},
 					Constraints: reference.OriginConstraints{
+						{OfType: cty.List(cty.DynamicPseudoType)},
+						{OfType: cty.Set(cty.DynamicPseudoType)},
 						{OfType: cty.EmptyTuple},
+						{OfType: cty.Map(cty.DynamicPseudoType)},
+						{OfType: cty.EmptyObject},
 					},
 				},
 				reference.LocalOrigin{
@@ -1172,7 +1184,11 @@ func TestCollectRefOrigins_exprAny_forExpr_hcl(t *testing.T) {
 						End:      hcl.Pos{Line: 1, Column: 33, Byte: 32},
 					},
 					Constraints: reference.OriginConstraints{
-						{OfType: cty.Map(cty.String)},
+						{OfType: cty.List(cty.DynamicPseudoType)},
+						{OfType: cty.Set(cty.DynamicPseudoType)},
+						{OfType: cty.EmptyTuple},
+						{OfType: cty.Map(cty.DynamicPseudoType)},
+						{OfType: cty.EmptyObject},
 					},
 				},
 				reference.LocalOrigin{
@@ -1226,6 +1242,10 @@ func TestCollectRefOrigins_exprAny_forExpr_hcl(t *testing.T) {
 						End:      hcl.Pos{Line: 1, Column: 33, Byte: 32},
 					},
 					Constraints: reference.OriginConstraints{
+						{OfType: cty.List(cty.DynamicPseudoType)},
+						{OfType: cty.Set(cty.DynamicPseudoType)},
+						{OfType: cty.EmptyTuple},
+						{OfType: cty.Map(cty.DynamicPseudoType)},
 						{OfType: cty.EmptyObject},
 					},
 				},

--- a/decoder/expr_one_of_ref_origins.go
+++ b/decoder/expr_one_of_ref_origins.go
@@ -44,7 +44,7 @@ func appendOrigins(origins, newOrigins reference.Origins) reference.Origins {
 			if ok &&
 				existingOrigin.Address().Equals(newMatchableOrigin.Address()) &&
 				rangesEqual(existingOrigin.OriginRange(), newMatchableOrigin.OriginRange()) {
-
+				// TODO? deduplicate constraints
 				origins[i] = existingOrigin.AppendConstraints(newMatchableOrigin.OriginConstraints())
 				foundMatch = true
 				break


### PR DESCRIPTION
#368 added support for `for`-`in`-`if` expressions. Instead of collecting the reference origins inside `for` expressions with the [allowed input constraints](https://developer.hashicorp.com/terraform/language/expressions/for#input-types), we used the constraints of the attribute. This PR fixes that subtle bug.

Fixes https://github.com/hashicorp/vscode-terraform/issues/1693

### UX Before
<img width="715" alt="CleanShot 2024-02-19 at 17 12 01@2x" src="https://github.com/hashicorp/hcl-lang/assets/45985/bb8fe57f-09fe-4218-bbcc-46842a316400">

### UX After
<img width="538" alt="CleanShot 2024-02-19 at 17 13 05@2x" src="https://github.com/hashicorp/hcl-lang/assets/45985/e1d5c8cb-7297-4d60-aa6f-da9f2ff2bfa8">

