### PR TITLE
fix: `nil` `expr` panics

### DIFF
--- a/decoder/candidates.go
+++ b/decoder/candidates.go
@@ -85,6 +85,12 @@ func (d *PathDecoder) completionAtPos(ctx context.Context, body *hclsyntax.Body,
 		if attr.EqualsRange.ContainsPos(pos) {
 			return lang.ZeroCandidates(), nil
 		}
+
+		// There is a partial (aka invalid) namespaced function call in an attribute
+		// We abort here as we don't want to complete body schema candidates
+		if attr.Expr == nil {
+			return lang.ZeroCandidates(), nil
+		}
 	}
 
 	rng := hcl.Range{

--- a/decoder/candidates.go
+++ b/decoder/candidates.go
@@ -55,7 +55,10 @@ func (d *PathDecoder) completionAtPos(ctx context.Context, body *hclsyntax.Body,
 	filename := body.Range().Filename
 
 	for _, attr := range body.Attributes {
-		if d.isPosInsideAttrExpr(attr, pos) {
+		// TODO: handle nil Expr in all nested calls instead which allows us
+		// to recover incomplete calls to provider defined functions (which have no expression
+		// as they are deemed invalid by hcl while they are not completed yet)
+		if attr.Expr != nil && d.isPosInsideAttrExpr(attr, pos) {
 			if bodySchema.Extensions != nil && bodySchema.Extensions.SelfRefs {
 				ctx = schema.WithActiveSelfRefs(ctx)
 			}

--- a/decoder/candidates_test.go
+++ b/decoder/candidates_test.go
@@ -1343,7 +1343,7 @@ func TestDecoder_CompletionAtPos_nil_expr(t *testing.T) {
 		},
 	})
 
-	pos := hcl.Pos{Line: 1, Column: 16, Byte: 15}
+	pos := hcl.Pos{Line: 1, Column: 18, Byte: 17}
 
 	candidates, err := d.CompletionAtPos(ctx, "test.tf", pos)
 	if err != nil {

--- a/decoder/hover.go
+++ b/decoder/hover.go
@@ -80,7 +80,7 @@ func (d *PathDecoder) hoverAtPos(ctx context.Context, body *hclsyntax.Body, body
 				}, nil
 			}
 
-			if attr.Expr.Range().ContainsPos(pos) {
+			if attr.Expr != nil && attr.Expr.Range().ContainsPos(pos) {
 				return d.newExpression(attr.Expr, aSchema.Constraint).HoverAtPos(ctx, pos), nil
 			}
 		}

--- a/decoder/hover_test.go
+++ b/decoder/hover_test.go
@@ -661,6 +661,35 @@ func TestDecoder_HoverAtPos_basic(t *testing.T) {
 	}
 }
 
+func TestDecoder_HoverAtPos_nil_expr(t *testing.T) {
+	// provider:: is not a traversal expression, so hcl will return a nil expression which needs to be
+	// handled gracefully
+	f, _ := hclsyntax.ParseConfig([]byte(`attr = provider::`), "test.tf", hcl.InitialPos)
+
+	d := testPathDecoder(t, &PathContext{
+		Schema: &schema.BodySchema{
+			Attributes: map[string]*schema.AttributeSchema{
+				"attr": {Constraint: schema.AnyExpression{OfType: cty.DynamicPseudoType}},
+			},
+		},
+		Files: map[string]*hcl.File{
+			"test.tf": f,
+		},
+	})
+
+	ctx := context.Background()
+	_, err := d.HoverAtPos(ctx, "test.tf", hcl.Pos{Line: 1, Column: 16, Byte: 15})
+
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	positionalErr := &PositionalError{}
+	if !errors.As(err, &positionalErr) {
+		t.Fatal("expected PositionalError for invalid expression")
+	}
+}
+
 func TestDecoder_HoverAtPos_URL(t *testing.T) {
 	resourceLabelSchema := []*schema.LabelSchema{
 		{Name: "type", IsDepKey: true},

--- a/decoder/reference_origins.go
+++ b/decoder/reference_origins.go
@@ -161,6 +161,11 @@ func (d *PathDecoder) referenceOriginsInBody(body hcl.Body, bodySchema *schema.B
 			}
 		}
 
+		// skip if the attribute Expr is nil as all following origins are based on the expression
+		if attr.Expr == nil {
+			continue
+		}
+
 		if aSchema.IsDepKey && bodySchema.Targets != nil {
 			origins = append(origins, reference.DirectOrigin{
 				Range:       attr.Expr.Range(),

--- a/decoder/reference_targets.go
+++ b/decoder/reference_targets.go
@@ -275,6 +275,11 @@ func (d *PathDecoder) decodeReferenceTargetsForAttribute(attr *hcl.Attribute, at
 
 	ctx := context.Background()
 
+	// Early return as we don't attempt to recover reference targets for invalid expressions
+	if attr.Expr == nil {
+		return refs
+	}
+
 	expr := d.newExpression(attr.Expr, attrSchema.Constraint)
 	if eType, ok := expr.(ReferenceTargetsExpression); ok {
 		var targetCtx *TargetContext

--- a/decoder/reference_targets_test.go
+++ b/decoder/reference_targets_test.go
@@ -12,7 +12,9 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/reference"
+	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/zclconf/go-cty-debug/ctydebug"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -350,5 +352,30 @@ func TestReferenceTargetForOriginAtPos(t *testing.T) {
 				t.Fatalf("mismatch of reference targets: %s", diff)
 			}
 		})
+	}
+}
+
+func TestCollectReferenceTargets_nil_expr(t *testing.T) {
+	// provider:: is not a traversal expression, so hcl will return a nil expression which needs to be
+	// handled gracefully
+	f, _ := hclsyntax.ParseConfig([]byte(`attr = provider::`), "test.tf", hcl.InitialPos)
+
+	d := testPathDecoder(t, &PathContext{
+		Schema: &schema.BodySchema{
+			Attributes: map[string]*schema.AttributeSchema{
+				"attr": {Constraint: schema.AnyExpression{OfType: cty.DynamicPseudoType}},
+			},
+		},
+		Files: map[string]*hcl.File{
+			"test.tf": f,
+		},
+	})
+	targets, err := d.CollectReferenceTargets()
+	if err != nil {
+		t.Fatal("unexpected error when collecting reference targets while there was no expr in one of them")
+	}
+
+	if len(targets) != 0 {
+		t.Fatalf("expected no targets, got %d", len(targets))
 	}
 }

--- a/decoder/semantic_tokens.go
+++ b/decoder/semantic_tokens.go
@@ -79,7 +79,10 @@ func (d *PathDecoder) tokensForBody(ctx context.Context, body *hclsyntax.Body, b
 			Range:     attr.NameRange,
 		})
 
-		tokens = append(tokens, d.newExpression(attr.Expr, attrSchema.Constraint).SemanticTokens(ctx)...)
+		// Invalid expressions may be nil, and we don't want to panic further down the line
+		if attr.Expr != nil {
+			tokens = append(tokens, d.newExpression(attr.Expr, attrSchema.Constraint).SemanticTokens(ctx)...)
+		}
 	}
 
 	for _, block := range body.Blocks {

--- a/decoder/semantic_tokens_test.go
+++ b/decoder/semantic_tokens_test.go
@@ -320,6 +320,55 @@ resource "vault_auth_backend" "blah" {
 	}
 }
 
+func TestDecoder_SemanticTokensInFile_nil_expr(t *testing.T) {
+	// provider:: is not a traversal expression, so hcl will return a nil expression which needs to be
+	// handled gracefully
+	f, _ := hclsyntax.ParseConfig([]byte(`attr = provider::`), "test.tf", hcl.InitialPos)
+
+	d := testPathDecoder(t, &PathContext{
+		Schema: &schema.BodySchema{
+			Attributes: map[string]*schema.AttributeSchema{
+				"attr": {Constraint: schema.AnyExpression{OfType: cty.DynamicPseudoType}},
+			},
+		},
+		Files: map[string]*hcl.File{
+			"test.tf": f,
+		},
+	})
+
+	ctx := context.Background()
+
+	tokens, err := d.SemanticTokensInFile(ctx, "test.tf")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedTokens := []lang.SemanticToken{
+		{
+			Type:      "hcl-attrName",
+			Modifiers: lang.SemanticTokenModifiers{},
+			Range: hcl.Range{
+				Filename: "test.tf",
+				Start: hcl.Pos{
+					Line:   1,
+					Column: 1,
+					Byte:   0,
+				},
+				End: hcl.Pos{
+					Line:   1,
+					Column: 5,
+					Byte:   4,
+				},
+			},
+		},
+	}
+
+	diff := cmp.Diff(expectedTokens, tokens)
+	if diff != "" {
+		t.Fatalf("unexpected tokens: %s", diff)
+	}
+}
+
 func TestDecoder_SemanticTokensInFile_dependentSchema(t *testing.T) {
 	bodySchema := &schema.BodySchema{
 		Blocks: map[string]*schema.BlockSchema{


### PR DESCRIPTION
When Terraform provider defined functions are incomplete (e.g. when completing `provider::`), `hcl` returns a `nil` `Expr` which causes all kinds of panics.

This PR handles such `nil` values for different things.