### PR TITLE
f recover namespaced fn completion

### DIFF
--- a/decoder/candidates.go
+++ b/decoder/candidates.go
@@ -55,7 +55,10 @@ func (d *PathDecoder) completionAtPos(ctx context.Context, body *hclsyntax.Body,
 	filename := body.Range().Filename
 
 	for _, attr := range body.Attributes {
-		if d.isPosInsideAttrExpr(attr, pos) {
+		// TODO: handle nil Expr in all nested calls instead which allows us
+		// to recover incomplete calls to provider defined functions (which have no expression
+		// as they are deemed invalid by hcl while they are not completed yet)
+		if attr.Expr != nil && d.isPosInsideAttrExpr(attr, pos) {
 			if bodySchema.Extensions != nil && bodySchema.Extensions.SelfRefs {
 				ctx = schema.WithActiveSelfRefs(ctx)
 			}

--- a/decoder/expr_any_completion.go
+++ b/decoder/expr_any_completion.go
@@ -15,6 +15,10 @@ import (
 func (a Any) CompletionAtPos(ctx context.Context, pos hcl.Pos) []lang.Candidate {
 	typ := a.cons.OfType
 
+	if a.expr == nil {
+		return []lang.Candidate{}
+	}
+
 	if !a.cons.SkipLiteralComplexTypes && typ.IsListType() {
 		expr, ok := a.expr.(*hclsyntax.TupleConsExpr)
 		if !ok {

--- a/decoder/expr_any_completion_test.go
+++ b/decoder/expr_any_completion_test.go
@@ -116,6 +116,21 @@ func TestCompletionAtPos_exprAny_functions(t *testing.T) {
 						},
 					},
 				},
+				{
+					Label:       "provider::framework::example",
+					Detail:      "provider::framework::example(input string) string",
+					Description: lang.Markdown("Echoes given argument as result"),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "provider::framework::example()",
+						Snippet: "provider::framework::example(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+					},
+				},
 			}),
 		},
 		{
@@ -200,6 +215,21 @@ func TestCompletionAtPos_exprAny_functions(t *testing.T) {
 					TextEdit: lang.TextEdit{
 						NewText: "lower()",
 						Snippet: "lower(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+					},
+				},
+				{
+					Label:       "provider::framework::example",
+					Detail:      "provider::framework::example(input string) string",
+					Description: lang.Markdown("Echoes given argument as result"),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "provider::framework::example()",
+						Snippet: "provider::framework::example(${0})",
 						Range: hcl.Range{
 							Filename: "test.tf",
 							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
@@ -364,6 +394,21 @@ func TestCompletionAtPos_exprAny_functions(t *testing.T) {
 					TextEdit: lang.TextEdit{
 						NewText: "lower()",
 						Snippet: "lower(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 14, Byte: 15},
+							End:      hcl.Pos{Line: 1, Column: 14, Byte: 15},
+						},
+					},
+				},
+				{
+					Label:       "provider::framework::example",
+					Detail:      "provider::framework::example(input string) string",
+					Description: lang.Markdown("Echoes given argument as result"),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "provider::framework::example()",
+						Snippet: "provider::framework::example(${0})",
 						Range: hcl.Range{
 							Filename: "test.tf",
 							Start:    hcl.Pos{Line: 1, Column: 14, Byte: 15},
@@ -649,6 +694,21 @@ func TestCompletionAtPos_exprAny_functions(t *testing.T) {
 						},
 					},
 				},
+				{
+					Label:       "provider::framework::example",
+					Detail:      "provider::framework::example(input string) string",
+					Description: lang.Markdown("Echoes given argument as result"),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "provider::framework::example()",
+						Snippet: "provider::framework::example(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 22, Byte: 21},
+							End:      hcl.Pos{Line: 1, Column: 22, Byte: 21},
+						},
+					},
+				},
 			}),
 		},
 		{
@@ -785,6 +845,21 @@ func TestCompletionAtPos_exprAny_functions(t *testing.T) {
 						},
 					},
 				},
+				{
+					Label:       "provider::framework::example",
+					Detail:      "provider::framework::example(input string) string",
+					Description: lang.Markdown("Echoes given argument as result"),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "provider::framework::example()",
+						Snippet: "provider::framework::example(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 28, Byte: 29},
+							End:      hcl.Pos{Line: 1, Column: 28, Byte: 29},
+						},
+					},
+				},
 			}),
 		},
 		{
@@ -869,6 +944,21 @@ func TestCompletionAtPos_exprAny_functions(t *testing.T) {
 					TextEdit: lang.TextEdit{
 						NewText: "lower()",
 						Snippet: "lower(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 22, Byte: 23},
+							End:      hcl.Pos{Line: 1, Column: 22, Byte: 23},
+						},
+					},
+				},
+				{
+					Label:       "provider::framework::example",
+					Detail:      "provider::framework::example(input string) string",
+					Description: lang.Markdown("Echoes given argument as result"),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "provider::framework::example()",
+						Snippet: "provider::framework::example(${0})",
 						Range: hcl.Range{
 							Filename: "test.tf",
 							Start:    hcl.Pos{Line: 1, Column: 22, Byte: 23},
@@ -1046,6 +1136,21 @@ func TestCompletionAtPos_exprAny_combinedExpressions(t *testing.T) {
 					TextEdit: lang.TextEdit{
 						NewText: "lower()",
 						Snippet: "lower(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 8, Byte: 7},
+						},
+					},
+				},
+				{
+					Label:       "provider::framework::example",
+					Detail:      "provider::framework::example(input string) string",
+					Description: lang.Markdown("Echoes given argument as result"),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "provider::framework::example()",
+						Snippet: "provider::framework::example(${0})",
 						Range: hcl.Range{
 							Filename: "test.tf",
 							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
@@ -1304,6 +1409,18 @@ func testFunctionSignatures() map[string]schema.FunctionSignature {
 			},
 			ReturnType:  cty.List(cty.String),
 			Description: "`split` produces a list by dividing a given string at all occurrences of a given separator.",
+		},
+		"provider::framework::example": {
+			Params: []function.Parameter{
+				{
+					Name:        "input",
+					Type:        cty.String,
+					Description: "String to echo",
+				},
+			},
+			ReturnType:  cty.String,
+			Description: "Echoes given argument as result",
+			Detail:      "bflad/framework 0.2.0",
 		},
 	}
 }
@@ -3186,6 +3303,21 @@ func TestCompletionAtPos_exprAny_operators(t *testing.T) {
 					},
 				},
 				{
+					Label:       "provider::framework::example",
+					Detail:      "provider::framework::example(input string) string",
+					Description: lang.Markdown("Echoes given argument as result"),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "provider::framework::example()",
+						Snippet: "provider::framework::example(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+							End:      hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						},
+					},
+				},
+				{
 					Label:  "false",
 					Detail: "bool",
 					Kind:   lang.BoolCandidateKind,
@@ -3475,6 +3607,21 @@ func TestCompletionAtPos_exprAny_operators(t *testing.T) {
 					TextEdit: lang.TextEdit{
 						NewText: "lower()",
 						Snippet: "lower(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 15, Byte: 14},
+							End:      hcl.Pos{Line: 1, Column: 15, Byte: 14},
+						},
+					},
+				},
+				{
+					Label:       "provider::framework::example",
+					Detail:      "provider::framework::example(input string) string",
+					Description: lang.Markdown("Echoes given argument as result"),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "provider::framework::example()",
+						Snippet: "provider::framework::example(${0})",
 						Range: hcl.Range{
 							Filename: "test.tf",
 							Start:    hcl.Pos{Line: 1, Column: 15, Byte: 14},
@@ -4951,6 +5098,21 @@ func TestCompletionAtPos_exprAny_template(t *testing.T) {
 						},
 					},
 				},
+				{
+					Label:       "provider::framework::example",
+					Detail:      "provider::framework::example(input string) string",
+					Description: lang.Markdown("Echoes given argument as result"),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "provider::framework::example()",
+						Snippet: "provider::framework::example(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 11, Byte: 10},
+							End:      hcl.Pos{Line: 1, Column: 11, Byte: 10},
+						},
+					},
+				},
 			}),
 		},
 		{
@@ -5151,6 +5313,21 @@ EOT
 					TextEdit: lang.TextEdit{
 						NewText: "lower()",
 						Snippet: "lower(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 3, Column: 10, Byte: 38},
+							End:      hcl.Pos{Line: 3, Column: 10, Byte: 38},
+						},
+					},
+				},
+				{
+					Label:       "provider::framework::example",
+					Detail:      "provider::framework::example(input string) string",
+					Description: lang.Markdown("Echoes given argument as result"),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "provider::framework::example()",
+						Snippet: "provider::framework::example(${0})",
 						Range: hcl.Range{
 							Filename: "test.tf",
 							Start:    hcl.Pos{Line: 3, Column: 10, Byte: 38},
@@ -5365,6 +5542,21 @@ EOT
 						},
 					},
 				},
+				{
+					Label:       "provider::framework::example",
+					Detail:      "provider::framework::example(input string) string",
+					Description: lang.Markdown("Echoes given argument as result"),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "provider::framework::example()",
+						Snippet: "provider::framework::example(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 28, Byte: 27},
+							End:      hcl.Pos{Line: 1, Column: 28, Byte: 27},
+						},
+					},
+				},
 			}),
 		},
 		{
@@ -5569,6 +5761,21 @@ EOT
 						},
 					},
 				},
+				{
+					Label:       "provider::framework::example",
+					Detail:      "provider::framework::example(input string) string",
+					Description: lang.Markdown("Echoes given argument as result"),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "provider::framework::example()",
+						Snippet: "provider::framework::example(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 23, Byte: 22},
+							End:      hcl.Pos{Line: 1, Column: 23, Byte: 22},
+						},
+					},
+				},
 			}),
 		},
 		{
@@ -5680,6 +5887,21 @@ EOT
 					TextEdit: lang.TextEdit{
 						NewText: "lower()",
 						Snippet: "lower(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 23, Byte: 22},
+							End:      hcl.Pos{Line: 1, Column: 23, Byte: 22},
+						},
+					},
+				},
+				{
+					Label:       "provider::framework::example",
+					Detail:      "provider::framework::example(input string) string",
+					Description: lang.Markdown("Echoes given argument as result"),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "provider::framework::example()",
+						Snippet: "provider::framework::example(${0})",
 						Range: hcl.Range{
 							Filename: "test.tf",
 							Start:    hcl.Pos{Line: 1, Column: 23, Byte: 22},
@@ -5801,6 +6023,21 @@ EOT
 					TextEdit: lang.TextEdit{
 						NewText: "lower()",
 						Snippet: "lower(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 23, Byte: 22},
+							End:      hcl.Pos{Line: 1, Column: 23, Byte: 22},
+						},
+					},
+				},
+				{
+					Label:       "provider::framework::example",
+					Detail:      "provider::framework::example(input string) string",
+					Description: lang.Markdown("Echoes given argument as result"),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "provider::framework::example()",
+						Snippet: "provider::framework::example(${0})",
 						Range: hcl.Range{
 							Filename: "test.tf",
 							Start:    hcl.Pos{Line: 1, Column: 23, Byte: 22},

--- a/decoder/expr_any_hover_test.go
+++ b/decoder/expr_any_hover_test.go
@@ -139,6 +139,30 @@ func TestHoverAtPos_exprAny_functions(t *testing.T) {
 			hcl.Pos{Line: 1, Column: 17, Byte: 16},
 			nil,
 		},
+		{
+			"over namespaced function",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.AnyExpression{
+						OfType: cty.String,
+					},
+				},
+			},
+			`attr = provider::framework::example("FOO")
+`,
+			hcl.Pos{Line: 1, Column: 11, Byte: 10},
+			&lang.HoverData{
+				Content: lang.MarkupContent{
+					Value: "```terraform\nprovider::framework::example(input string) string\n```\n\nEchoes given argument as result\n\nbflad/framework 0.2.0",
+					Kind:  lang.MarkdownKind,
+				},
+				Range: hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+					End:      hcl.Pos{Line: 1, Column: 43, Byte: 42},
+				},
+			},
+		},
 	}
 
 	for i, tc := range testCases {

--- a/decoder/expr_function.go
+++ b/decoder/expr_function.go
@@ -151,9 +151,8 @@ func (fe functionExpr) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverD
 
 	if funcExpr.NameRange.ContainsPos(pos) {
 		return &lang.HoverData{
-			Content: lang.Markdown(fmt.Sprintf("```terraform\n%s(%s) %s\n```\n\n%s",
-				funcExpr.Name, parameterNamesAsString(funcSig), funcSig.ReturnType.FriendlyName(), funcSig.Description)),
-			Range: fe.expr.Range(),
+			Content: hoverContentForFunction(funcSig, funcExpr),
+			Range:   fe.expr.Range(),
 		}
 	}
 
@@ -296,4 +295,9 @@ func (fe functionExpr) matchingFunctions(prefix string, editRange hcl.Range) []l
 	})
 
 	return candidates
+}
+
+func hoverContentForFunction(funcSig schema.FunctionSignature, funcExpr *hclsyntax.FunctionCallExpr) lang.MarkupContent {
+	return lang.Markdown(fmt.Sprintf("```terraform\n%s(%s) %s\n```\n\n%s\n\n%s",
+		funcExpr.Name, parameterNamesAsString(funcSig), funcSig.ReturnType.FriendlyName(), funcSig.Description, funcSig.Detail))
 }

--- a/decoder/expr_function.go
+++ b/decoder/expr_function.go
@@ -298,6 +298,12 @@ func (fe functionExpr) matchingFunctions(prefix string, editRange hcl.Range) []l
 }
 
 func hoverContentForFunction(funcSig schema.FunctionSignature, funcExpr *hclsyntax.FunctionCallExpr) lang.MarkupContent {
-	return lang.Markdown(fmt.Sprintf("```terraform\n%s(%s) %s\n```\n\n%s\n\n%s",
-		funcExpr.Name, parameterNamesAsString(funcSig), funcSig.ReturnType.FriendlyName(), funcSig.Description, funcSig.Detail))
+	rawMd := fmt.Sprintf("```terraform\n%s(%s) %s\n```\n\n%s",
+		funcExpr.Name, parameterNamesAsString(funcSig), funcSig.ReturnType.FriendlyName(), funcSig.Description)
+
+	if funcSig.Detail != "" {
+		rawMd += fmt.Sprintf("\n\n%s", funcSig.Detail)
+	}
+
+	return lang.Markdown(rawMd)
 }

--- a/decoder/expr_function.go
+++ b/decoder/expr_function.go
@@ -151,7 +151,7 @@ func (fe functionExpr) HoverAtPos(ctx context.Context, pos hcl.Pos) *lang.HoverD
 
 	if funcExpr.NameRange.ContainsPos(pos) {
 		return &lang.HoverData{
-			Content: hoverContentForFunction(funcSig, funcExpr),
+			Content: hoverContentForFunction(funcExpr.Name, funcSig),
 			Range:   fe.expr.Range(),
 		}
 	}
@@ -297,9 +297,9 @@ func (fe functionExpr) matchingFunctions(prefix string, editRange hcl.Range) []l
 	return candidates
 }
 
-func hoverContentForFunction(funcSig schema.FunctionSignature, funcExpr *hclsyntax.FunctionCallExpr) lang.MarkupContent {
+func hoverContentForFunction(name string, funcSig schema.FunctionSignature) lang.MarkupContent {
 	rawMd := fmt.Sprintf("```terraform\n%s(%s) %s\n```\n\n%s",
-		funcExpr.Name, parameterNamesAsString(funcSig), funcSig.ReturnType.FriendlyName(), funcSig.Description)
+		name, parameterNamesAsString(funcSig), funcSig.ReturnType.FriendlyName(), funcSig.Description)
 
 	if funcSig.Detail != "" {
 		rawMd += fmt.Sprintf("\n\n%s", funcSig.Detail)

--- a/decoder/hover.go
+++ b/decoder/hover.go
@@ -80,7 +80,7 @@ func (d *PathDecoder) hoverAtPos(ctx context.Context, body *hclsyntax.Body, body
 				}, nil
 			}
 
-			if attr.Expr.Range().ContainsPos(pos) {
+			if attr.Expr != nil && attr.Expr.Range().ContainsPos(pos) {
 				return d.newExpression(attr.Expr, aSchema.Constraint).HoverAtPos(ctx, pos), nil
 			}
 		}

--- a/decoder/hover_test.go
+++ b/decoder/hover_test.go
@@ -661,6 +661,35 @@ func TestDecoder_HoverAtPos_basic(t *testing.T) {
 	}
 }
 
+func TestDecoder_HoverAtPos_nil_expr(t *testing.T) {
+	// provider:: is not a traversal expression, so hcl will return a nil expression which needs to be
+	// handled gracefully
+	f, _ := hclsyntax.ParseConfig([]byte(`attr = provider::`), "test.tf", hcl.InitialPos)
+
+	d := testPathDecoder(t, &PathContext{
+		Schema: &schema.BodySchema{
+			Attributes: map[string]*schema.AttributeSchema{
+				"attr": {Constraint: schema.AnyExpression{OfType: cty.DynamicPseudoType}},
+			},
+		},
+		Files: map[string]*hcl.File{
+			"test.tf": f,
+		},
+	})
+
+	ctx := context.Background()
+	_, err := d.HoverAtPos(ctx, "test.tf", hcl.Pos{Line: 1, Column: 16, Byte: 15})
+
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	positionalErr := &PositionalError{}
+	if !errors.As(err, &positionalErr) {
+		t.Fatal("expected PositionalError for invalid expression")
+	}
+}
+
 func TestDecoder_HoverAtPos_URL(t *testing.T) {
 	resourceLabelSchema := []*schema.LabelSchema{
 		{Name: "type", IsDepKey: true},

--- a/decoder/reference_origins.go
+++ b/decoder/reference_origins.go
@@ -161,6 +161,11 @@ func (d *PathDecoder) referenceOriginsInBody(body hcl.Body, bodySchema *schema.B
 			}
 		}
 
+		// skip if the attribute Expr is nil as all following origins are based on the expression
+		if attr.Expr == nil {
+			continue
+		}
+
 		if aSchema.IsDepKey && bodySchema.Targets != nil {
 			origins = append(origins, reference.DirectOrigin{
 				Range:       attr.Expr.Range(),

--- a/decoder/reference_targets.go
+++ b/decoder/reference_targets.go
@@ -275,6 +275,11 @@ func (d *PathDecoder) decodeReferenceTargetsForAttribute(attr *hcl.Attribute, at
 
 	ctx := context.Background()
 
+	// Early return as we don't attempt to recover reference targets for invalid expressions
+	if attr.Expr == nil {
+		return refs
+	}
+
 	expr := d.newExpression(attr.Expr, attrSchema.Constraint)
 	if eType, ok := expr.(ReferenceTargetsExpression); ok {
 		var targetCtx *TargetContext

--- a/decoder/reference_targets_test.go
+++ b/decoder/reference_targets_test.go
@@ -12,7 +12,9 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/reference"
+	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/zclconf/go-cty-debug/ctydebug"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -350,5 +352,30 @@ func TestReferenceTargetForOriginAtPos(t *testing.T) {
 				t.Fatalf("mismatch of reference targets: %s", diff)
 			}
 		})
+	}
+}
+
+func TestCollectReferenceTargets_nil_expr(t *testing.T) {
+	// provider:: is not a traversal expression, so hcl will return a nil expression which needs to be
+	// handled gracefully
+	f, _ := hclsyntax.ParseConfig([]byte(`attr = provider::`), "test.tf", hcl.InitialPos)
+
+	d := testPathDecoder(t, &PathContext{
+		Schema: &schema.BodySchema{
+			Attributes: map[string]*schema.AttributeSchema{
+				"attr": {Constraint: schema.AnyExpression{OfType: cty.DynamicPseudoType}},
+			},
+		},
+		Files: map[string]*hcl.File{
+			"test.tf": f,
+		},
+	})
+	targets, err := d.CollectReferenceTargets()
+	if err != nil {
+		t.Fatal("unexpected error when collecting reference targets while there was no expr in one of them")
+	}
+
+	if len(targets) != 0 {
+		t.Fatalf("expected no targets, got %d", len(targets))
 	}
 }

--- a/decoder/semantic_tokens.go
+++ b/decoder/semantic_tokens.go
@@ -79,7 +79,10 @@ func (d *PathDecoder) tokensForBody(ctx context.Context, body *hclsyntax.Body, b
 			Range:     attr.NameRange,
 		})
 
-		tokens = append(tokens, d.newExpression(attr.Expr, attrSchema.Constraint).SemanticTokens(ctx)...)
+		// Invalid expressions may be nil, and we don't want to panic further down the line
+		if attr.Expr != nil {
+			tokens = append(tokens, d.newExpression(attr.Expr, attrSchema.Constraint).SemanticTokens(ctx)...)
+		}
 	}
 
 	for _, block := range body.Blocks {

--- a/decoder/semantic_tokens_test.go
+++ b/decoder/semantic_tokens_test.go
@@ -320,6 +320,55 @@ resource "vault_auth_backend" "blah" {
 	}
 }
 
+func TestDecoder_SemanticTokensInFile_nil_expr(t *testing.T) {
+	// provider:: is not a traversal expression, so hcl will return a nil expression which needs to be
+	// handled gracefully
+	f, _ := hclsyntax.ParseConfig([]byte(`attr = provider::`), "test.tf", hcl.InitialPos)
+
+	d := testPathDecoder(t, &PathContext{
+		Schema: &schema.BodySchema{
+			Attributes: map[string]*schema.AttributeSchema{
+				"attr": {Constraint: schema.AnyExpression{OfType: cty.DynamicPseudoType}},
+			},
+		},
+		Files: map[string]*hcl.File{
+			"test.tf": f,
+		},
+	})
+
+	ctx := context.Background()
+
+	tokens, err := d.SemanticTokensInFile(ctx, "test.tf")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedTokens := []lang.SemanticToken{
+		{
+			Type:      "hcl-attrName",
+			Modifiers: lang.SemanticTokenModifiers{},
+			Range: hcl.Range{
+				Filename: "test.tf",
+				Start: hcl.Pos{
+					Line:   1,
+					Column: 1,
+					Byte:   0,
+				},
+				End: hcl.Pos{
+					Line:   1,
+					Column: 5,
+					Byte:   4,
+				},
+			},
+		},
+	}
+
+	diff := cmp.Diff(expectedTokens, tokens)
+	if diff != "" {
+		t.Fatalf("unexpected tokens: %s", diff)
+	}
+}
+
 func TestDecoder_SemanticTokensInFile_dependentSchema(t *testing.T) {
 	bodySchema := &schema.BodySchema{
 		Blocks: map[string]*schema.BlockSchema{

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21.0
 require (
 	github.com/google/go-cmp v0.6.0
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/hashicorp/hcl/v2 v2.19.1
+	github.com/hashicorp/hcl/v2 v2.19.2-0.20240209134327-1e1a6b858a91
 	github.com/mh-cbon/go-fmt-fail v0.0.0-20160815164508-67765b3fbcb5
 	github.com/zclconf/go-cty v1.14.2
 	github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,8 @@ github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/U
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
-github.com/hashicorp/hcl/v2 v2.19.1 h1://i05Jqznmb2EXqa39Nsvyan2o5XyMowW5fnCKW5RPI=
-github.com/hashicorp/hcl/v2 v2.19.1/go.mod h1:ThLC89FV4p9MPW804KVbe/cEXoQ8NZEh+JtMeeGErHE=
+github.com/hashicorp/hcl/v2 v2.19.2-0.20240209134327-1e1a6b858a91 h1:xeOnbTJeAFr29IjGNXu2YbGofssS/8+C20aQme2Zwh8=
+github.com/hashicorp/hcl/v2 v2.19.2-0.20240209134327-1e1a6b858a91/go.mod h1:ThLC89FV4p9MPW804KVbe/cEXoQ8NZEh+JtMeeGErHE=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/schema/signature.go
+++ b/schema/signature.go
@@ -35,6 +35,7 @@ func (fs *FunctionSignature) Copy() *FunctionSignature {
 		ReturnType:  fs.ReturnType,
 	}
 
+	newFS.Params = make([]function.Parameter, len(fs.Params))
 	copy(newFS.Params, fs.Params)
 
 	if fs.VarParam != nil {

--- a/schema/signature.go
+++ b/schema/signature.go
@@ -32,7 +32,7 @@ func (fs *FunctionSignature) Copy() *FunctionSignature {
 	newFS := &FunctionSignature{
 		Description: fs.Description,
 		Detail:      fs.Detail,
-		ReturnType:  fs.ReturnType, // TODO: deep copy needed?
+		ReturnType:  fs.ReturnType,
 		VarParam:    copyFunctionParameter(fs.VarParam),
 	}
 	newFS.Params = make([]function.Parameter, len(fs.Params))

--- a/schema/signature.go
+++ b/schema/signature.go
@@ -33,28 +33,14 @@ func (fs *FunctionSignature) Copy() *FunctionSignature {
 		Description: fs.Description,
 		Detail:      fs.Detail,
 		ReturnType:  fs.ReturnType,
-		VarParam:    copyFunctionParameter(fs.VarParam),
 	}
-	newFS.Params = make([]function.Parameter, len(fs.Params))
-	for i, p := range fs.Params {
-		newFS.Params[i] = *copyFunctionParameter(&p)
+
+	copy(newFS.Params, fs.Params)
+
+	if fs.VarParam != nil {
+		vpCpy := *fs.VarParam
+		newFS.VarParam = &vpCpy
 	}
 
 	return newFS
-}
-
-func copyFunctionParameter(p *function.Parameter) *function.Parameter {
-	if p == nil {
-		return nil
-	}
-
-	return &function.Parameter{
-		Name:             p.Name,
-		Type:             p.Type,
-		Description:      p.Description,
-		AllowNull:        p.AllowNull,
-		AllowUnknown:     p.AllowUnknown,
-		AllowDynamicType: p.AllowDynamicType,
-		AllowMarked:      p.AllowMarked,
-	}
 }

--- a/schema/signature.go
+++ b/schema/signature.go
@@ -33,9 +33,24 @@ func (fs *FunctionSignature) Copy() *FunctionSignature {
 		Description: fs.Description,
 		Detail:      fs.Detail,
 		ReturnType:  fs.ReturnType, // TODO: deep copy needed?
-		VarParam:    fs.VarParam,   // TODO: deep copy needed?
+		VarParam:    copyFunctionParameter(fs.VarParam),
 	}
 	newFS.Params = make([]function.Parameter, len(fs.Params))
-	copy(newFS.Params, fs.Params) // TODO: deep copy needed?
+	for i, p := range fs.Params {
+		newFS.Params[i] = *copyFunctionParameter(&p)
+	}
+
 	return newFS
+}
+
+func copyFunctionParameter(p *function.Parameter) *function.Parameter {
+	return &function.Parameter{
+		Name:             p.Name,
+		Type:             p.Type,
+		Description:      p.Description,
+		AllowNull:        p.AllowNull,
+		AllowUnknown:     p.AllowUnknown,
+		AllowDynamicType: p.AllowDynamicType,
+		AllowMarked:      p.AllowMarked,
+	}
 }

--- a/schema/signature.go
+++ b/schema/signature.go
@@ -44,6 +44,10 @@ func (fs *FunctionSignature) Copy() *FunctionSignature {
 }
 
 func copyFunctionParameter(p *function.Parameter) *function.Parameter {
+	if p == nil {
+		return nil
+	}
+
 	return &function.Parameter{
 		Name:             p.Name,
 		Type:             p.Type,

--- a/schema/signature.go
+++ b/schema/signature.go
@@ -13,6 +13,8 @@ type FunctionSignature struct {
 	// of the function.
 	Description string
 
+	Detail string
+
 	// ReturnType is the ctyjson representation of the function's
 	// return types based on supplying all parameters using
 	// dynamic types. Functions can have dynamic return types.
@@ -24,4 +26,16 @@ type FunctionSignature struct {
 	// VarParam describes the function's variadic
 	// parameter if it is supported.
 	VarParam *function.Parameter
+}
+
+func (fs *FunctionSignature) Copy() *FunctionSignature {
+	newFS := &FunctionSignature{
+		Description: fs.Description,
+		Detail:      fs.Detail,
+		ReturnType:  fs.ReturnType, // TODO: deep copy needed?
+		VarParam:    fs.VarParam,   // TODO: deep copy needed?
+	}
+	newFS.Params = make([]function.Parameter, len(fs.Params))
+	copy(newFS.Params, fs.Params) // TODO: deep copy needed?
+	return newFS
 }


### PR DESCRIPTION
Based on https://github.com/hashicorp/hcl-lang/pull/372 and https://github.com/hashicorp/hcl-lang/pull/376

(please rebase this PR after they have been merged)

---

This PR tries to recover partially typed provider defined functions after the first colon has been typed for completions.

Resolves https://github.com/hashicorp/vscode-terraform/issues/1697