### PR TITLE
test: add test case for panics for invalid namespaced function expressions

### DIFF
--- a/decoder/candidates_test.go
+++ b/decoder/candidates_test.go
@@ -1325,6 +1325,39 @@ resource "random_resource" "test" {
 	}
 }
 
+func TestDecoder_CompletionAtPos_nil_expr(t *testing.T) {
+	ctx := context.Background()
+
+	// provider:: is not a traversal expression, so hcl will return a ExprSyntaxError which needs to be handled
+	f, _ := hclsyntax.ParseConfig([]byte(`attr = provider::`), "test.tf", hcl.InitialPos)
+
+	d := testPathDecoder(t, &PathContext{
+		Schema: &schema.BodySchema{
+			Attributes: map[string]*schema.AttributeSchema{
+				"attr": {Constraint: schema.AnyExpression{OfType: cty.DynamicPseudoType}},
+			},
+		},
+		Files: map[string]*hcl.File{
+			"test.tf": f,
+		},
+	})
+
+	pos := hcl.Pos{Line: 1, Column: 18, Byte: 17}
+
+	candidates, err := d.CompletionAtPos(ctx, "test.tf", pos)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedCandidates := lang.CompleteCandidates([]lang.Candidate{})
+
+	diff := cmp.Diff(expectedCandidates, candidates, ctydebug.CmpOptions)
+	if diff != "" {
+		t.Fatalf("unexpected schema for %s: %s", stringPos(pos), diff)
+	}
+
+}
+
 func TestDecoder_CompletionAtPos_AnyAttribute(t *testing.T) {
 	ctx := context.Background()
 	providersSchema := &schema.BlockSchema{

--- a/decoder/hover_test.go
+++ b/decoder/hover_test.go
@@ -677,15 +677,14 @@ func TestDecoder_HoverAtPos_nil_expr(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	_, err := d.HoverAtPos(ctx, "test.tf", hcl.Pos{Line: 1, Column: 16, Byte: 15})
+	hoverData, err := d.HoverAtPos(ctx, "test.tf", hcl.Pos{Line: 1, Column: 16, Byte: 15})
 
-	if err == nil {
-		t.Fatal("expected error")
+	if err != nil {
+		t.Fatal(err)
 	}
 
-	positionalErr := &PositionalError{}
-	if !errors.As(err, &positionalErr) {
-		t.Fatal("expected PositionalError for invalid expression")
+	if hoverData != nil {
+		t.Fatalf("expected nil hover data, got: %v", hoverData)
 	}
 }
 

--- a/decoder/reference_origins_test.go
+++ b/decoder/reference_origins_test.go
@@ -11,7 +11,9 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/reference"
+	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/zclconf/go-cty-debug/ctydebug"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -761,5 +763,30 @@ func TestReferenceOriginsTargetingPos(t *testing.T) {
 				t.Fatalf("mismatch of reference origins: %s", diff)
 			}
 		})
+	}
+}
+
+func TestCollectReferenceOrigins_nil_expr(t *testing.T) {
+	// provider:: is not a traversal expression, so hcl will return a ExprSyntaxError which needs to be handled
+	f, _ := hclsyntax.ParseConfig([]byte(`attr = provider::`), "test.tf", hcl.InitialPos)
+
+	d := testPathDecoder(t, &PathContext{
+		Schema: &schema.BodySchema{
+			Attributes: map[string]*schema.AttributeSchema{
+				"attr": {Constraint: schema.AnyExpression{OfType: cty.DynamicPseudoType}},
+			},
+		},
+		Files: map[string]*hcl.File{
+			"test.tf": f,
+		},
+	})
+
+	targets, err := d.CollectReferenceOrigins()
+	if err != nil {
+		t.Fatal("unexpected error when collecting reference origins while there was no expr in one of them")
+	}
+
+	if len(targets) != 0 {
+		t.Fatalf("expected no targets, got %d", len(targets))
 	}
 }

--- a/decoder/reference_targets_test.go
+++ b/decoder/reference_targets_test.go
@@ -12,7 +12,9 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/reference"
+	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/zclconf/go-cty-debug/ctydebug"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -350,5 +352,29 @@ func TestReferenceTargetForOriginAtPos(t *testing.T) {
 				t.Fatalf("mismatch of reference targets: %s", diff)
 			}
 		})
+	}
+}
+
+func TestCollectReferenceTargets_nil_expr(t *testing.T) {
+	// provider:: is not a traversal expression, so hcl will return a ExprSyntaxError which needs to be handled
+	f, _ := hclsyntax.ParseConfig([]byte(`attr = provider::`), "test.tf", hcl.InitialPos)
+
+	d := testPathDecoder(t, &PathContext{
+		Schema: &schema.BodySchema{
+			Attributes: map[string]*schema.AttributeSchema{
+				"attr": {Constraint: schema.AnyExpression{OfType: cty.DynamicPseudoType}},
+			},
+		},
+		Files: map[string]*hcl.File{
+			"test.tf": f,
+		},
+	})
+	targets, err := d.CollectReferenceTargets()
+	if err != nil {
+		t.Fatal("unexpected error when collecting reference targets while there was no expr in one of them")
+	}
+
+	if len(targets) != 0 {
+		t.Fatalf("expected no targets, got %d", len(targets))
 	}
 }


### PR DESCRIPTION
This PR adds only the tests but not the fixes from #376 to show that https://github.com/hashicorp/hcl/pull/668 solves the panics as well.

(the bumped hcl version is the current head of https://github.com/hashicorp/hcl/pull/668)