### PR TITLE
schema: allow optional `LabelStep`

### DIFF
--- a/decoder/reference_targets.go
+++ b/decoder/reference_targets.go
@@ -770,6 +770,9 @@ func resolveBlockAddress(block *hcl.Block, blockSchema *schema.BlockSchema) (lan
 		case schema.LabelStep:
 			if len(block.Labels)-1 < int(step.Index) {
 				// label not present
+				if step.IsOptional {
+					continue
+				}
 				return lang.Address{}, false
 			}
 			stepName = block.Labels[step.Index]

--- a/schema/address_step.go
+++ b/schema/address_step.go
@@ -18,7 +18,8 @@ func (StaticStep) isAddrStepImpl() addrStepImplSigil {
 }
 
 type LabelStep struct {
-	Index uint
+	Index      uint
+	IsOptional bool
 }
 
 func (LabelStep) isAddrStepImpl() addrStepImplSigil {


### PR DESCRIPTION
This is helpful in case of [AtlasHCL](https://atlasgo.io/atlas-schema/hcl#table-qualification), which has an optional schema qualifier before each table resource

```hcl
table "public" "t1" {
  column "c1" {
    type = int
  }
}
```

`"public"` is the optional label, in this case, hover. When collecting block addresses, the last label should be optional. Then the block's address will be resolved as `table.public.t1` or `table.t1`