### PR TITLE
Reenable Dependabot for internal GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,10 @@ updates:
     schedule:
       interval: "daily"
     labels: ["dependencies"]
+  # Dependabot only updates hashicorp GHAs, external GHAs are managed by internal tooling (tsccr)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "hashicorp/*"


### PR DESCRIPTION
When TSCCR was first introduced, it was not clear that the tool would only update external GitHub actions. This adds the configuration to enable `hashicorp/*` action updates.