### PR TITLE
decoder: refactor `SelfRefs` use context

### DIFF
--- a/decoder/expr_any_conditional.go
+++ b/decoder/expr_any_conditional.go
@@ -70,7 +70,7 @@ func (a Any) hoverConditionalExprAtPos(ctx context.Context, pos hcl.Pos) (*lang.
 	return nil, false
 }
 
-func (a Any) refOriginsForConditionalExpr(ctx context.Context, allowSelfRefs bool) (reference.Origins, bool) {
+func (a Any) refOriginsForConditionalExpr(ctx context.Context) (reference.Origins, bool) {
 	origins := make(reference.Origins, 0)
 
 	// There is currently no way of decoding conditional expressions in JSON
@@ -84,7 +84,7 @@ func (a Any) refOriginsForConditionalExpr(ctx context.Context, allowSelfRefs boo
 			OfType: cty.Bool,
 		})
 		if expr, ok := condExpr.(ReferenceOriginsExpression); ok {
-			origins = append(origins, expr.ReferenceOrigins(ctx, allowSelfRefs)...)
+			origins = append(origins, expr.ReferenceOrigins(ctx)...)
 		}
 
 		trueExpr := newExpression(a.pathCtx, eType.TrueResult, schema.AnyExpression{
@@ -92,7 +92,7 @@ func (a Any) refOriginsForConditionalExpr(ctx context.Context, allowSelfRefs boo
 			SkipLiteralComplexTypes: a.cons.SkipLiteralComplexTypes,
 		})
 		if expr, ok := trueExpr.(ReferenceOriginsExpression); ok {
-			origins = append(origins, expr.ReferenceOrigins(ctx, allowSelfRefs)...)
+			origins = append(origins, expr.ReferenceOrigins(ctx)...)
 		}
 
 		falseExpr := newExpression(a.pathCtx, eType.FalseResult, schema.AnyExpression{
@@ -100,7 +100,7 @@ func (a Any) refOriginsForConditionalExpr(ctx context.Context, allowSelfRefs boo
 			SkipLiteralComplexTypes: a.cons.SkipLiteralComplexTypes,
 		})
 		if expr, ok := falseExpr.(ReferenceOriginsExpression); ok {
-			origins = append(origins, expr.ReferenceOrigins(ctx, allowSelfRefs)...)
+			origins = append(origins, expr.ReferenceOrigins(ctx)...)
 		}
 
 		return origins, true

--- a/decoder/expr_any_for.go
+++ b/decoder/expr_any_for.go
@@ -158,7 +158,7 @@ func (a Any) semanticTokensForForExpr(ctx context.Context) ([]lang.SemanticToken
 	return tokens, false
 }
 
-func (a Any) refOriginsForForExpr(ctx context.Context, allowSelfRefs bool) (reference.Origins, bool) {
+func (a Any) refOriginsForForExpr(ctx context.Context) (reference.Origins, bool) {
 	origins := make(reference.Origins, 0)
 
 	// There is currently no way of decoding for expressions in JSON
@@ -184,7 +184,7 @@ func (a Any) refOriginsForForExpr(ctx context.Context, allowSelfRefs bool) (refe
 			schema.AnyExpression{OfType: cty.EmptyObject},
 		}
 		if collExpr, ok := newExpression(a.pathCtx, eType.CollExpr, collCons).(ReferenceOriginsExpression); ok {
-			origins = append(origins, collExpr.ReferenceOrigins(ctx, allowSelfRefs)...)
+			origins = append(origins, collExpr.ReferenceOrigins(ctx)...)
 		}
 
 		if eType.KeyExpr != nil {
@@ -196,7 +196,7 @@ func (a Any) refOriginsForForExpr(ctx context.Context, allowSelfRefs bool) (refe
 				OfType: typ,
 			}
 			if keyExpr, ok := newExpression(a.pathCtx, eType.KeyExpr, cons).(ReferenceOriginsExpression); ok {
-				origins = append(origins, keyExpr.ReferenceOrigins(ctx, allowSelfRefs)...)
+				origins = append(origins, keyExpr.ReferenceOrigins(ctx)...)
 			}
 		}
 
@@ -208,7 +208,7 @@ func (a Any) refOriginsForForExpr(ctx context.Context, allowSelfRefs bool) (refe
 			OfType: typ,
 		}
 		if valExpr, ok := newExpression(a.pathCtx, eType.ValExpr, cons).(ReferenceOriginsExpression); ok {
-			origins = append(origins, valExpr.ReferenceOrigins(ctx, allowSelfRefs)...)
+			origins = append(origins, valExpr.ReferenceOrigins(ctx)...)
 		}
 
 		if eType.CondExpr != nil {
@@ -217,7 +217,7 @@ func (a Any) refOriginsForForExpr(ctx context.Context, allowSelfRefs bool) (refe
 			}
 
 			if condExpr, ok := newExpression(a.pathCtx, eType.CondExpr, cons).(ReferenceOriginsExpression); ok {
-				origins = append(origins, condExpr.ReferenceOrigins(ctx, allowSelfRefs)...)
+				origins = append(origins, condExpr.ReferenceOrigins(ctx)...)
 			}
 		}
 

--- a/decoder/expr_any_operator.go
+++ b/decoder/expr_any_operator.go
@@ -159,7 +159,7 @@ func (a Any) hoverOperatorExprAtPos(ctx context.Context, pos hcl.Pos) (*lang.Hov
 	return nil, false
 }
 
-func (a Any) refOriginsForOperatorExpr(ctx context.Context, allowSelfRefs bool) (reference.Origins, bool) {
+func (a Any) refOriginsForOperatorExpr(ctx context.Context) (reference.Origins, bool) {
 	origins := make(reference.Origins, 0)
 
 	// There is currently no way of decoding operator expressions in JSON
@@ -186,14 +186,14 @@ func (a Any) refOriginsForOperatorExpr(ctx context.Context, allowSelfRefs bool) 
 			OfType: opFuncParams[0].Type,
 		})
 		if expr, ok := leftExpr.(ReferenceOriginsExpression); ok {
-			origins = append(origins, expr.ReferenceOrigins(ctx, allowSelfRefs)...)
+			origins = append(origins, expr.ReferenceOrigins(ctx)...)
 		}
 
 		rightExpr := newExpression(a.pathCtx, eType.RHS, schema.AnyExpression{
 			OfType: opFuncParams[1].Type,
 		})
 		if expr, ok := rightExpr.(ReferenceOriginsExpression); ok {
-			origins = append(origins, expr.ReferenceOrigins(ctx, allowSelfRefs)...)
+			origins = append(origins, expr.ReferenceOrigins(ctx)...)
 		}
 
 		return origins, true
@@ -216,14 +216,14 @@ func (a Any) refOriginsForOperatorExpr(ctx context.Context, allowSelfRefs bool) 
 			OfType: opFuncParams[0].Type,
 		})
 		if expr, ok := expr.(ReferenceOriginsExpression); ok {
-			origins = append(origins, expr.ReferenceOrigins(ctx, allowSelfRefs)...)
+			origins = append(origins, expr.ReferenceOrigins(ctx)...)
 		}
 
 		return origins, true
 	case *hclsyntax.ParenthesesExpr:
 		expr := newExpression(a.pathCtx, eType.Expression, a.cons)
 		if expr, ok := expr.(ReferenceOriginsExpression); ok {
-			origins = append(origins, expr.ReferenceOrigins(ctx, allowSelfRefs)...)
+			origins = append(origins, expr.ReferenceOrigins(ctx)...)
 		}
 
 		return origins, true

--- a/decoder/expr_any_template.go
+++ b/decoder/expr_any_template.go
@@ -113,7 +113,7 @@ func (a Any) hoverTemplateExprAtPos(ctx context.Context, pos hcl.Pos) (*lang.Hov
 	return nil, false
 }
 
-func (a Any) refOriginsForTemplateExpr(ctx context.Context, allowSelfRefs bool) (reference.Origins, bool) {
+func (a Any) refOriginsForTemplateExpr(ctx context.Context) (reference.Origins, bool) {
 	origins := make(reference.Origins, 0)
 
 	switch eType := a.expr.(type) {
@@ -129,7 +129,7 @@ func (a Any) refOriginsForTemplateExpr(ctx context.Context, allowSelfRefs bool) 
 			expr := newExpression(a.pathCtx, partExpr, cons)
 
 			if e, ok := expr.(ReferenceOriginsExpression); ok {
-				origins = append(origins, e.ReferenceOrigins(ctx, allowSelfRefs)...)
+				origins = append(origins, e.ReferenceOrigins(ctx)...)
 			}
 		}
 
@@ -141,7 +141,7 @@ func (a Any) refOriginsForTemplateExpr(ctx context.Context, allowSelfRefs bool) 
 		expr := newExpression(a.pathCtx, eType.Wrapped, cons)
 
 		if e, ok := expr.(ReferenceOriginsExpression); ok {
-			origins = append(origins, e.ReferenceOrigins(ctx, allowSelfRefs)...)
+			origins = append(origins, e.ReferenceOrigins(ctx)...)
 		}
 
 		return origins, true

--- a/decoder/expr_function.go
+++ b/decoder/expr_function.go
@@ -274,7 +274,7 @@ func (fe functionExpr) SemanticTokens(ctx context.Context) []lang.SemanticToken 
 	return tokens
 }
 
-func (fe functionExpr) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {
+func (fe functionExpr) ReferenceOrigins(ctx context.Context) reference.Origins {
 	funcExpr, diags := hcl.ExprCall(fe.expr)
 	if diags.HasErrors() {
 		return reference.Origins{}
@@ -309,7 +309,7 @@ func (fe functionExpr) ReferenceOrigins(ctx context.Context, allowSelfRefs bool)
 				OfType: param.Type,
 			},
 		}
-		origins = append(origins, expr.ReferenceOrigins(ctx, allowSelfRefs)...)
+		origins = append(origins, expr.ReferenceOrigins(ctx)...)
 	}
 
 	return origins

--- a/decoder/expr_list_ref_origins.go
+++ b/decoder/expr_list_ref_origins.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 )
 
-func (list List) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {
+func (list List) ReferenceOrigins(ctx context.Context) reference.Origins {
 	elems, diags := hcl.ExprList(list.expr)
 	if diags.HasErrors() {
 		return reference.Origins{}
@@ -25,7 +25,7 @@ func (list List) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) refer
 	for _, elemExpr := range elems {
 		expr := newExpression(list.pathCtx, elemExpr, list.cons.Elem)
 		if e, ok := expr.(ReferenceOriginsExpression); ok {
-			origins = append(origins, e.ReferenceOrigins(ctx, allowSelfRefs)...)
+			origins = append(origins, e.ReferenceOrigins(ctx)...)
 		}
 	}
 

--- a/decoder/expr_map_ref_origins.go
+++ b/decoder/expr_map_ref_origins.go
@@ -13,7 +13,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-func (m Map) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {
+func (m Map) ReferenceOrigins(ctx context.Context) reference.Origins {
 	items, diags := hcl.ExprMap(m.expr)
 	if diags.HasErrors() {
 		return reference.Origins{}
@@ -35,14 +35,14 @@ func (m Map) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference
 				}
 				kExpr := newExpression(m.pathCtx, parensExpr, keyCons)
 				if expr, ok := kExpr.(ReferenceOriginsExpression); ok {
-					origins = append(origins, expr.ReferenceOrigins(ctx, allowSelfRefs)...)
+					origins = append(origins, expr.ReferenceOrigins(ctx)...)
 				}
 			}
 		}
 
 		valExpr := newExpression(m.pathCtx, item.Value, m.cons.Elem)
 		if expr, ok := valExpr.(ReferenceOriginsExpression); ok {
-			origins = append(origins, expr.ReferenceOrigins(ctx, allowSelfRefs)...)
+			origins = append(origins, expr.ReferenceOrigins(ctx)...)
 		}
 	}
 

--- a/decoder/expr_object_ref_origins.go
+++ b/decoder/expr_object_ref_origins.go
@@ -14,7 +14,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-func (obj Object) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {
+func (obj Object) ReferenceOrigins(ctx context.Context) reference.Origins {
 	items, diags := hcl.ExprMap(obj.expr)
 	if diags.HasErrors() {
 		return reference.Origins{}
@@ -44,7 +44,7 @@ func (obj Object) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) refe
 				}
 				kExpr := newExpression(obj.pathCtx, parensExpr, keyCons)
 				if expr, ok := kExpr.(ReferenceOriginsExpression); ok {
-					origins = append(origins, expr.ReferenceOrigins(ctx, allowSelfRefs)...)
+					origins = append(origins, expr.ReferenceOrigins(ctx)...)
 				}
 			}
 		}
@@ -52,7 +52,7 @@ func (obj Object) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) refe
 		if isKnownAttr {
 			expr := newExpression(obj.pathCtx, item.Value, aSchema.Constraint)
 			if elemExpr, ok := expr.(ReferenceOriginsExpression); ok {
-				origins = append(origins, elemExpr.ReferenceOrigins(ctx, allowSelfRefs)...)
+				origins = append(origins, elemExpr.ReferenceOrigins(ctx)...)
 			}
 		}
 

--- a/decoder/expr_one_of_ref_origins.go
+++ b/decoder/expr_one_of_ref_origins.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/hcl-lang/reference"
 )
 
-func (oo OneOf) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {
+func (oo OneOf) ReferenceOrigins(ctx context.Context) reference.Origins {
 	origins := make(reference.Origins, 0)
 
 	for _, con := range oo.cons {
@@ -19,7 +19,7 @@ func (oo OneOf) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) refere
 			continue
 		}
 
-		origins = appendOrigins(origins, e.ReferenceOrigins(ctx, allowSelfRefs))
+		origins = appendOrigins(origins, e.ReferenceOrigins(ctx))
 	}
 
 	return origins

--- a/decoder/expr_reference_ref_origins.go
+++ b/decoder/expr_reference_ref_origins.go
@@ -14,7 +14,8 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-func (ref Reference) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {
+func (ref Reference) ReferenceOrigins(ctx context.Context) reference.Origins {
+	allowSelfRefs := schema.ActiveSelfRefsFromContext(ctx)
 	// deal with native HCL syntax first
 	te, ok := ref.expr.(*hclsyntax.ScopeTraversalExpr)
 	if ok {

--- a/decoder/expr_set_ref_origins.go
+++ b/decoder/expr_set_ref_origins.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 )
 
-func (set Set) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {
+func (set Set) ReferenceOrigins(ctx context.Context) reference.Origins {
 	elems, diags := hcl.ExprList(set.expr)
 	if diags.HasErrors() {
 		return reference.Origins{}
@@ -25,7 +25,7 @@ func (set Set) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) referen
 	for _, elemExpr := range elems {
 		expr := newExpression(set.pathCtx, elemExpr, set.cons.Elem)
 		if e, ok := expr.(ReferenceOriginsExpression); ok {
-			origins = append(origins, e.ReferenceOrigins(ctx, allowSelfRefs)...)
+			origins = append(origins, e.ReferenceOrigins(ctx)...)
 		}
 	}
 

--- a/decoder/expr_tuple_ref_origins.go
+++ b/decoder/expr_tuple_ref_origins.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 )
 
-func (tuple Tuple) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins {
+func (tuple Tuple) ReferenceOrigins(ctx context.Context) reference.Origins {
 	elems, diags := hcl.ExprList(tuple.expr)
 	if diags.HasErrors() {
 		return reference.Origins{}
@@ -29,7 +29,7 @@ func (tuple Tuple) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) ref
 
 		expr := newExpression(tuple.pathCtx, elemExpr, tuple.cons.Elems[i])
 		if e, ok := expr.(ReferenceOriginsExpression); ok {
-			origins = append(origins, e.ReferenceOrigins(ctx, allowSelfRefs)...)
+			origins = append(origins, e.ReferenceOrigins(ctx)...)
 		}
 	}
 

--- a/decoder/expression.go
+++ b/decoder/expression.go
@@ -26,7 +26,7 @@ type Expression interface {
 }
 
 type ReferenceOriginsExpression interface {
-	ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins
+	ReferenceOrigins(ctx context.Context) reference.Origins
 }
 
 type ReferenceTargetsExpression interface {

--- a/decoder/reference_origins.go
+++ b/decoder/reference_origins.go
@@ -169,13 +169,12 @@ func (d *PathDecoder) referenceOriginsInBody(body hcl.Body, bodySchema *schema.B
 			})
 		}
 
-		allowSelfRefs := false
 		if bodySchema.Extensions != nil && bodySchema.Extensions.SelfRefs {
-			allowSelfRefs = true
+			ctx = schema.WithActiveSelfRefs(ctx)
 		}
 		expr := d.newExpression(attr.Expr, aSchema.Constraint)
 		if eType, ok := expr.(ReferenceOriginsExpression); ok {
-			origins = append(origins, eType.ReferenceOrigins(ctx, allowSelfRefs)...)
+			origins = append(origins, eType.ReferenceOrigins(ctx)...)
 		}
 	}
 


### PR DESCRIPTION
This PR refactors a mess in the codebase with `allowSelfRefs` passing around until it reaches the place it was used for.

The helper `schema.WithActiveSelfRefs(ctx)` is already defined by the author, so I just use it for this suppose; and remove the `allowSelfRefs` variable from the method.

Before:
```go
type ReferenceOriginsExpression interface {
	ReferenceOrigins(ctx context.Context, allowSelfRefs bool) reference.Origins
}
```

After:
```go
type ReferenceOriginsExpression interface {
	ReferenceOrigins(ctx context.Context) reference.Origins
}
```