### PR TITLE
 fix: fix data race in schema merging logic by creating a copy instead of modifying the original struct instance

### DIFF
--- a/decoder/internal/schemahelper/block_schema.go
+++ b/decoder/internal/schemahelper/block_schema.go
@@ -38,15 +38,16 @@ func MergeBlockBodySchemas(block *hcl.Block, blockSchema *schema.BlockSchema) (*
 		}
 		for bType, block := range depSchema.Blocks {
 			if _, exists := mergedSchema.Blocks[bType]; !exists {
+				copiedBlock := block.Copy()
 				// propagate DynamicBlocks extension to any nested blocks
 				if mergedSchema.Extensions != nil && mergedSchema.Extensions.DynamicBlocks {
-					if block.Body.Extensions == nil {
-						block.Body.Extensions = &schema.BodyExtensions{}
+					if copiedBlock.Body.Extensions == nil {
+						copiedBlock.Body.Extensions = &schema.BodyExtensions{}
 					}
-					block.Body.Extensions.DynamicBlocks = true
+					copiedBlock.Body.Extensions.DynamicBlocks = true
 				}
 
-				mergedSchema.Blocks[bType] = block
+				mergedSchema.Blocks[bType] = copiedBlock
 			} else {
 				// Skip duplicate block type
 				continue
@@ -54,7 +55,7 @@ func MergeBlockBodySchemas(block *hcl.Block, blockSchema *schema.BlockSchema) (*
 		}
 
 		if mergedSchema.Extensions != nil && mergedSchema.Extensions.DynamicBlocks && len(depSchema.Blocks) > 0 {
-			mergedSchema.Blocks["dynamic"] = buildDynamicBlockSchema(depSchema)
+			mergedSchema.Blocks["dynamic"] = buildDynamicBlockSchema(depSchema, mergedSchema)
 		}
 
 		mergedSchema.TargetableAs = append(mergedSchema.TargetableAs, depSchema.TargetableAs...)
@@ -87,7 +88,7 @@ func MergeBlockBodySchemas(block *hcl.Block, blockSchema *schema.BlockSchema) (*
 			}
 		}
 
-		mergedSchema.Blocks["dynamic"] = buildDynamicBlockSchema(mergedSchema)
+		mergedSchema.Blocks["dynamic"] = buildDynamicBlockSchema(mergedSchema, mergedSchema)
 	}
 
 	return mergedSchema, result

--- a/decoder/internal/schemahelper/dynamic_block.go
+++ b/decoder/internal/schemahelper/dynamic_block.go
@@ -9,9 +9,15 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-func buildDynamicBlockSchema(inputSchema *schema.BodySchema) *schema.BlockSchema {
+// buildDynamicBlockSchema creates the schema for dynamic blocks based on the available blocks in the body schema (inputSchema).
+//
+// inputSchema - schema used to figure out which blocks can be dynamic (commonly the dependent schema in order to NOT include static blocks like e.g. lifecycle)
+// sourceSchema - schema used to copy the body of the block (commonly the merged schema in order to include changes that were made to the schema)
+func buildDynamicBlockSchema(inputSchema *schema.BodySchema, sourceSchema *schema.BodySchema) *schema.BlockSchema {
 	dependentBody := make(map[schema.SchemaKey]*schema.BodySchema)
-	for blockName, block := range inputSchema.Blocks {
+	for blockName := range inputSchema.Blocks {
+		block := sourceSchema.Blocks[blockName]
+
 		dependentBody[schema.NewSchemaKey(schema.DependencyKeys{
 			Labels: []schema.LabelDependent{
 				{Index: 0, Value: blockName},


### PR DESCRIPTION
Different jobs in terraform-ls use the same `hcl.Block` instance simultaneously and the schema merger modified it in the past.
We fixed this by creating a copy first which uncovered another bug: The `buildDynamicBlockSchema` function implicitly read that change from the dependent schema, which we fixed by reading from the `mergedSchema` instead. This in turn required us to also pass the dependent schema into the function as the `mergedSchema` also contains the static `lifecycle` block which can't be set via a dynamic block. This means we now iterate over all blocks in the dependent schema but copy their bodies from the `mergedSchema`.

Fixes #395