### PR TITLE
feat: allow overriding existing blocks and attributes for dependent body schemas

### DIFF
--- a/decoder/internal/schemahelper/block_schema.go
+++ b/decoder/internal/schemahelper/block_schema.go
@@ -29,29 +29,18 @@ func MergeBlockBodySchemas(block *hcl.Block, blockSchema *schema.BlockSchema) (*
 	depSchema, _, result := NewBlockSchema(blockSchema).DependentBodySchema(block)
 	if result == LookupSuccessful || result == LookupPartiallySuccessful {
 		for name, attr := range depSchema.Attributes {
-			if _, exists := mergedSchema.Attributes[name]; !exists {
-				mergedSchema.Attributes[name] = attr
-			} else {
-				// Skip duplicate attribute
-				continue
-			}
+			mergedSchema.Attributes[name] = attr
 		}
 		for bType, block := range depSchema.Blocks {
-			if _, exists := mergedSchema.Blocks[bType]; !exists {
-				copiedBlock := block.Copy()
-				// propagate DynamicBlocks extension to any nested blocks
-				if mergedSchema.Extensions != nil && mergedSchema.Extensions.DynamicBlocks {
-					if copiedBlock.Body.Extensions == nil {
-						copiedBlock.Body.Extensions = &schema.BodyExtensions{}
-					}
-					copiedBlock.Body.Extensions.DynamicBlocks = true
+			copiedBlock := block.Copy()
+			// propagate DynamicBlocks extension to any nested blocks
+			if mergedSchema.Extensions != nil && mergedSchema.Extensions.DynamicBlocks {
+				if copiedBlock.Body.Extensions == nil {
+					copiedBlock.Body.Extensions = &schema.BodyExtensions{}
 				}
-
-				mergedSchema.Blocks[bType] = copiedBlock
-			} else {
-				// Skip duplicate block type
-				continue
+				copiedBlock.Body.Extensions.DynamicBlocks = true
 			}
+			mergedSchema.Blocks[bType] = copiedBlock
 		}
 
 		if mergedSchema.Extensions != nil && mergedSchema.Extensions.DynamicBlocks && len(depSchema.Blocks) > 0 {


### PR DESCRIPTION
We couldn't find any cases where the existing tests (and some example codebase) would access the else statement while testing. However, this change could allow e.g. Terraform providers to override for example the lifecycle block if they define such a block in their schema. We have yet to see such cases though :)

### Open
- [x] Add a test case for this new behaviour (since the old didn't have one)