### PR TITLE
Extend symbols with concrete `*hcl.(Attribute/Block/Expression)`

### DIFF
--- a/decoder/symbol.go
+++ b/decoder/symbol.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 )
 
 type symbolImplSigil struct{}
@@ -27,6 +28,7 @@ type Symbol interface {
 type BlockSymbol struct {
 	Type   string
 	Labels []string
+	Block  *hcl.Block
 
 	path          lang.Path
 	rng           hcl.Range
@@ -71,8 +73,9 @@ func (bs *BlockSymbol) Path() lang.Path {
 
 // AttributeSymbol is Symbol implementation representing an attribute
 type AttributeSymbol struct {
-	AttrName string
-	ExprKind lang.SymbolExprKind
+	AttrName  string
+	ExprKind  lang.SymbolExprKind
+	Attribute *hcl.Attribute
 
 	path          lang.Path
 	rng           hcl.Range
@@ -114,6 +117,11 @@ func (as *AttributeSymbol) Path() lang.Path {
 type ExprSymbol struct {
 	ExprName string
 	ExprKind lang.SymbolExprKind
+
+	// Expr is set if the outter Expression is a *hclsyntax.TupleConsExpr
+	Expr hcl.Expression
+	// Item is set if the outter Expression is a *hclsyntax.ObjectConsExpr
+	Item hclsyntax.ObjectConsItem
 
 	path          lang.Path
 	rng           hcl.Range

--- a/decoder/symbols.go
+++ b/decoder/symbols.go
@@ -104,6 +104,7 @@ func (d *PathDecoder) symbolsForBody(body hcl.Body, bodySchema *schema.BodySchem
 		symbols = append(symbols, &AttributeSymbol{
 			AttrName:      name,
 			ExprKind:      symbolExprKind(attr.Expr),
+			Attribute:     attr,
 			path:          d.path,
 			rng:           attr.Range,
 			nestedSymbols: d.nestedSymbolsForExpr(attr.Expr),
@@ -124,6 +125,7 @@ func (d *PathDecoder) symbolsForBody(body hcl.Body, bodySchema *schema.BodySchem
 		symbols = append(symbols, &BlockSymbol{
 			Type:          block.Type,
 			Labels:        block.Labels,
+			Block:         block.Block,
 			path:          d.path,
 			rng:           block.Range,
 			nestedSymbols: d.symbolsForBody(block.Body, bSchema),
@@ -171,6 +173,7 @@ func (d *PathDecoder) nestedSymbolsForExpr(expr hcl.Expression) []Symbol {
 			symbols = append(symbols, &ExprSymbol{
 				ExprName:      fmt.Sprintf("%d", i),
 				ExprKind:      symbolExprKind(item),
+				Expr:          item,
 				path:          d.path,
 				rng:           item.Range(),
 				nestedSymbols: d.nestedSymbolsForExpr(item),
@@ -187,6 +190,7 @@ func (d *PathDecoder) nestedSymbolsForExpr(expr hcl.Expression) []Symbol {
 			symbols = append(symbols, &ExprSymbol{
 				ExprName:      key.AsString(),
 				ExprKind:      symbolExprKind(item.ValueExpr),
+				Item:          item,
 				path:          d.path,
 				rng:           hcl.RangeBetween(item.KeyExpr.Range(), item.ValueExpr.Range()),
 				nestedSymbols: d.nestedSymbolsForExpr(item.ValueExpr),

--- a/decoder/symbols_hcl_test.go
+++ b/decoder/symbols_hcl_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -81,7 +82,8 @@ provider "google" {
 				"aws_vpc",
 				"main",
 			},
-			path: lang.Path{Path: dirPath},
+			Block: f1.InnermostBlockAtPos(hcl.Pos{Byte: 1}),
+			path:  lang.Path{Path: dirPath},
 			rng: hcl.Range{
 				Filename: "first.tf",
 				Start:    hcl.Pos{Line: 2, Column: 1, Byte: 1},
@@ -89,9 +91,10 @@ provider "google" {
 			},
 			nestedSymbols: []Symbol{
 				&AttributeSymbol{
-					AttrName: "cidr_block",
-					ExprKind: lang.LiteralTypeKind{Type: cty.String},
-					path:     lang.Path{Path: dirPath},
+					AttrName:  "cidr_block",
+					ExprKind:  lang.LiteralTypeKind{Type: cty.String},
+					Attribute: bodyMustJustAttributes(t, f1.InnermostBlockAtPos(hcl.Pos{Byte: 1}).Body)["cidr_block"],
+					path:      lang.Path{Path: dirPath},
 					rng: hcl.Range{
 						Filename: "first.tf",
 						Start:    hcl.Pos{Line: 3, Column: 3, Byte: 31},
@@ -106,7 +109,8 @@ provider "google" {
 			Labels: []string{
 				"google",
 			},
-			path: lang.Path{Path: dirPath},
+			Block: f2.InnermostBlockAtPos(hcl.Pos{Byte: 1}),
+			path:  lang.Path{Path: dirPath},
 			rng: hcl.Range{
 				Filename: "second.tf",
 				Start:    hcl.Pos{Line: 2, Column: 1, Byte: 1},
@@ -114,9 +118,10 @@ provider "google" {
 			},
 			nestedSymbols: []Symbol{
 				&AttributeSymbol{
-					AttrName: "project",
-					ExprKind: lang.LiteralTypeKind{Type: cty.String},
-					path:     lang.Path{Path: dirPath},
+					AttrName:  "project",
+					ExprKind:  lang.LiteralTypeKind{Type: cty.String},
+					Attribute: bodyMustJustAttributes(t, f2.InnermostBlockAtPos(hcl.Pos{Byte: 1}).Body)["project"],
+					path:      lang.Path{Path: dirPath},
 					rng: hcl.Range{
 						Filename: "second.tf",
 						Start:    hcl.Pos{Line: 3, Column: 3, Byte: 23},
@@ -125,9 +130,10 @@ provider "google" {
 					nestedSymbols: []Symbol{},
 				},
 				&AttributeSymbol{
-					AttrName: "region",
-					ExprKind: lang.LiteralTypeKind{Type: cty.String},
-					path:     lang.Path{Path: dirPath},
+					AttrName:  "region",
+					ExprKind:  lang.LiteralTypeKind{Type: cty.String},
+					Attribute: bodyMustJustAttributes(t, f2.InnermostBlockAtPos(hcl.Pos{Byte: 1}).Body)["region"],
+					path:      lang.Path{Path: dirPath},
 					rng: hcl.Range{
 						Filename: "second.tf",
 						Start:    hcl.Pos{Line: 4, Column: 3, Byte: 55},
@@ -139,7 +145,7 @@ provider "google" {
 		},
 	}
 
-	diff := cmp.Diff(expectedSymbols, symbols)
+	diff := cmp.Diff(expectedSymbols, symbols, cmpopts.IgnoreFields(BlockSymbol{}, "Block"))
 	if diff != "" {
 		t.Fatalf("unexpected symbols: %s", diff)
 	}
@@ -189,7 +195,8 @@ resource "aws_instance" "test" {
 				"aws_instance",
 				"test",
 			},
-			path: lang.Path{Path: dirPath},
+			Block: f.InnermostBlockAtPos(hcl.Pos{Byte: 1}),
+			path:  lang.Path{Path: dirPath},
 			rng: hcl.Range{
 				Filename: "test.tf",
 				Start:    hcl.Pos{Line: 2, Column: 1, Byte: 1},
@@ -197,9 +204,10 @@ resource "aws_instance" "test" {
 			},
 			nestedSymbols: []Symbol{
 				&AttributeSymbol{
-					AttrName: "subnet_ids",
-					ExprKind: lang.TupleConsExprKind{},
-					path:     lang.Path{Path: dirPath},
+					AttrName:  "subnet_ids",
+					ExprKind:  lang.TupleConsExprKind{},
+					Attribute: bodyMustJustAttributes(t, f.InnermostBlockAtPos(hcl.Pos{Byte: 1}).Body)["subnet_ids"],
+					path:      lang.Path{Path: dirPath},
 					rng: hcl.Range{
 						Filename: "test.tf",
 						Start: hcl.Pos{
@@ -219,6 +227,7 @@ resource "aws_instance" "test" {
 							ExprKind: lang.LiteralTypeKind{
 								Type: cty.String,
 							},
+							Expr: bodyMustJustAttributes(t, f.InnermostBlockAtPos(hcl.Pos{Byte: 1}).Body)["subnet_ids"].Expr.(*hclsyntax.TupleConsExpr).ExprList()[0],
 							path: lang.Path{Path: dirPath},
 							rng: hcl.Range{
 								Filename: "test.tf",
@@ -240,6 +249,7 @@ resource "aws_instance" "test" {
 							ExprKind: lang.LiteralTypeKind{
 								Type: cty.String,
 							},
+							Expr: bodyMustJustAttributes(t, f.InnermostBlockAtPos(hcl.Pos{Byte: 1}).Body)["subnet_ids"].Expr.(*hclsyntax.TupleConsExpr).ExprList()[1],
 							path: lang.Path{Path: dirPath},
 							rng: hcl.Range{
 								Filename: "test.tf",
@@ -259,9 +269,10 @@ resource "aws_instance" "test" {
 					},
 				},
 				&AttributeSymbol{
-					AttrName: "configuration",
-					ExprKind: lang.ObjectConsExprKind{},
-					path:     lang.Path{Path: dirPath},
+					AttrName:  "configuration",
+					ExprKind:  lang.ObjectConsExprKind{},
+					Attribute: bodyMustJustAttributes(t, f.InnermostBlockAtPos(hcl.Pos{Byte: 1}).Body)["configuration"],
+					path:      lang.Path{Path: dirPath},
 					rng: hcl.Range{
 						Filename: "test.tf",
 						Start: hcl.Pos{
@@ -281,6 +292,7 @@ resource "aws_instance" "test" {
 							ExprKind: lang.LiteralTypeKind{
 								Type: cty.String,
 							},
+							Item: bodyMustJustAttributes(t, f.InnermostBlockAtPos(hcl.Pos{Byte: 1}).Body)["configuration"].Expr.(*hclsyntax.ObjectConsExpr).Items[0],
 							path: lang.Path{Path: dirPath},
 							rng: hcl.Range{
 								Filename: "test.tf",
@@ -302,6 +314,7 @@ resource "aws_instance" "test" {
 							ExprKind: lang.LiteralTypeKind{
 								Type: cty.Number,
 							},
+							Item: bodyMustJustAttributes(t, f.InnermostBlockAtPos(hcl.Pos{Byte: 1}).Body)["configuration"].Expr.(*hclsyntax.ObjectConsExpr).Items[1],
 							path: lang.Path{Path: dirPath},
 							rng: hcl.Range{
 								Filename: "test.tf",
@@ -323,6 +336,7 @@ resource "aws_instance" "test" {
 							ExprKind: lang.LiteralTypeKind{
 								Type: cty.Bool,
 							},
+							Item: bodyMustJustAttributes(t, f.InnermostBlockAtPos(hcl.Pos{Byte: 1}).Body)["configuration"].Expr.(*hclsyntax.ObjectConsExpr).Items[2],
 							path: lang.Path{Path: dirPath},
 							rng: hcl.Range{
 								Filename: "test.tf",
@@ -342,9 +356,10 @@ resource "aws_instance" "test" {
 					},
 				},
 				&AttributeSymbol{
-					AttrName: "random_kw",
-					ExprKind: lang.ReferenceExprKind{},
-					path:     lang.Path{Path: dirPath},
+					AttrName:  "random_kw",
+					ExprKind:  lang.ReferenceExprKind{},
+					Attribute: bodyMustJustAttributes(t, f.InnermostBlockAtPos(hcl.Pos{Byte: 1}).Body)["random_kw"],
+					path:      lang.Path{Path: dirPath},
 					rng: hcl.Range{
 						Filename: "test.tf",
 						Start: hcl.Pos{
@@ -414,7 +429,8 @@ resource "aws_instance" "test" {
 				"aws_instance",
 				"test",
 			},
-			path: lang.Path{Path: dirPath},
+			path:  lang.Path{Path: dirPath},
+			Block: f.InnermostBlockAtPos(hcl.Pos{Byte: 1}),
 			rng: hcl.Range{
 				Filename: "test.tf",
 				Start:    hcl.Pos{Line: 2, Column: 1, Byte: 1},
@@ -422,9 +438,10 @@ resource "aws_instance" "test" {
 			},
 			nestedSymbols: []Symbol{
 				&AttributeSymbol{
-					AttrName: "subnet_ids",
-					ExprKind: lang.TupleConsExprKind{},
-					path:     lang.Path{Path: dirPath},
+					AttrName:  "subnet_ids",
+					ExprKind:  lang.TupleConsExprKind{},
+					Attribute: bodyMustJustAttributes(t, f.InnermostBlockAtPos(hcl.Pos{Byte: 1}).Body)["subnet_ids"],
+					path:      lang.Path{Path: dirPath},
 					rng: hcl.Range{
 						Filename: "test.tf",
 						Start: hcl.Pos{
@@ -442,6 +459,7 @@ resource "aws_instance" "test" {
 						&ExprSymbol{
 							ExprName: "0",
 							ExprKind: lang.ReferenceExprKind{},
+							Expr:     bodyMustJustAttributes(t, f.InnermostBlockAtPos(hcl.Pos{Byte: 1}).Body)["subnet_ids"].Expr.(*hclsyntax.TupleConsExpr).ExprList()[0],
 							path:     lang.Path{Path: dirPath},
 							rng: hcl.Range{
 								Filename: "test.tf",
@@ -463,6 +481,7 @@ resource "aws_instance" "test" {
 							ExprKind: lang.LiteralTypeKind{
 								Type: cty.String,
 							},
+							Expr: bodyMustJustAttributes(t, f.InnermostBlockAtPos(hcl.Pos{Byte: 1}).Body)["subnet_ids"].Expr.(*hclsyntax.TupleConsExpr).ExprList()[1],
 							path: lang.Path{Path: dirPath},
 							rng: hcl.Range{
 								Filename: "test.tf",
@@ -482,9 +501,10 @@ resource "aws_instance" "test" {
 					},
 				},
 				&AttributeSymbol{
-					AttrName: "configuration",
-					ExprKind: lang.ObjectConsExprKind{},
-					path:     lang.Path{Path: dirPath},
+					AttrName:  "configuration",
+					ExprKind:  lang.ObjectConsExprKind{},
+					path:      lang.Path{Path: dirPath},
+					Attribute: bodyMustJustAttributes(t, f.InnermostBlockAtPos(hcl.Pos{Byte: 1}).Body)["configuration"],
 					rng: hcl.Range{
 						Filename: "test.tf",
 						Start: hcl.Pos{
@@ -503,6 +523,7 @@ resource "aws_instance" "test" {
 							ExprName: "num",
 							ExprKind: lang.ReferenceExprKind{},
 							path:     lang.Path{Path: dirPath},
+							Item:     bodyMustJustAttributes(t, f.InnermostBlockAtPos(hcl.Pos{Byte: 1}).Body)["configuration"].Expr.(*hclsyntax.ObjectConsExpr).Items[1],
 							rng: hcl.Range{
 								Filename: "test.tf",
 								Start: hcl.Pos{
@@ -521,9 +542,10 @@ resource "aws_instance" "test" {
 					},
 				},
 				&AttributeSymbol{
-					AttrName: "random_kw",
-					ExprKind: lang.ReferenceExprKind{},
-					path:     lang.Path{Path: dirPath},
+					AttrName:  "random_kw",
+					ExprKind:  lang.ReferenceExprKind{},
+					Attribute: bodyMustJustAttributes(t, f.InnermostBlockAtPos(hcl.Pos{Byte: 1}).Body)["random_kw"],
+					path:      lang.Path{Path: dirPath},
 					rng: hcl.Range{
 						Filename: "test.tf",
 						Start: hcl.Pos{
@@ -593,7 +615,8 @@ provider "google" {
 			Labels: []string{
 				"google",
 			},
-			path: lang.Path{Path: dirPath},
+			Block: f2.InnermostBlockAtPos(hcl.Pos{Byte: 1}),
+			path:  lang.Path{Path: dirPath},
 			rng: hcl.Range{
 				Filename: "second.tf",
 				Start:    hcl.Pos{Line: 2, Column: 1, Byte: 1},
@@ -601,9 +624,10 @@ provider "google" {
 			},
 			nestedSymbols: []Symbol{
 				&AttributeSymbol{
-					AttrName: "project",
-					ExprKind: lang.LiteralTypeKind{Type: cty.String},
-					path:     lang.Path{Path: dirPath},
+					AttrName:  "project",
+					ExprKind:  lang.LiteralTypeKind{Type: cty.String},
+					Attribute: bodyMustJustAttributes(t, f2.InnermostBlockAtPos(hcl.Pos{Byte: 1}).Body)["project"],
+					path:      lang.Path{Path: dirPath},
 					rng: hcl.Range{
 						Filename: "second.tf",
 						Start:    hcl.Pos{Line: 3, Column: 3, Byte: 23},
@@ -612,9 +636,10 @@ provider "google" {
 					nestedSymbols: []Symbol{},
 				},
 				&AttributeSymbol{
-					AttrName: "region",
-					ExprKind: lang.LiteralTypeKind{Type: cty.String},
-					path:     lang.Path{Path: dirPath},
+					AttrName:  "region",
+					ExprKind:  lang.LiteralTypeKind{Type: cty.String},
+					Attribute: bodyMustJustAttributes(t, f2.InnermostBlockAtPos(hcl.Pos{Byte: 1}).Body)["region"],
+					path:      lang.Path{Path: dirPath},
 					rng: hcl.Range{
 						Filename: "second.tf",
 						Start:    hcl.Pos{Line: 4, Column: 3, Byte: 55},
@@ -630,4 +655,20 @@ provider "google" {
 	if diff != "" {
 		t.Fatalf("unexpected symbols: %s", diff)
 	}
+}
+
+func bodyMustJustAttributes(t *testing.T, body hcl.Body) hcl.Attributes {
+	attrs, diags := body.JustAttributes()
+	if diags.HasErrors() {
+		t.Fatalf("failed to call JustAttributes: %v", diags.Error())
+	}
+	return attrs
+}
+
+func bodyMustContent(t *testing.T, body hcl.Body, schema *hcl.BodySchema) *hcl.BodyContent {
+	bc, diags := body.Content(schema)
+	if diags.HasErrors() {
+		t.Fatal(diags.Error())
+	}
+	return bc
 }


### PR DESCRIPTION
I have a use case of this module: I'd like to firstly call the `Decoder.Symbols` to get the target symbols of a query. Then iterate each symbols (recursively visiting its nested symbols). Then check whether those symbols are reference origins/targets, by using `ReferenceOriginsTargetingPos()/ReferenceTargetsForOriginAtPos()`, with passing in the position of the symbols.

The problem is that the symbol's position is larger than what those two functions expected. E.g. Given following HCL:

```hcl
provider "azurerm" {
  features {
    resource_group {
      prevent_deletion_if_contains_resources = false
    }
  }
}

resource "azurerm_resource_group" "src" {
  name     = "my-rg"
  location = "westeurope"
}

resource "azurerm_resource_group" "dst" {
  name     = azurerm_resource_group.src.name
  location = azurerm_resource_group.src.location
  tags = {
    source = azurerm_resource_group.src.id
  }
}
```

The symbol of `azurerm_resource_group.dst`'s attribute `name`, its range spans from column 3 to column 45, which is effectively `name     = azurerm_resource_group.src.name`, which is not recognised by `ReferenceTargetsForOriginAtPos()`. Instead, it wants the pos is within range column 14 to column 45.

Furthermore, we also want to get the exact position of, e.g. for `AttributeSymbol`, the key and value positions. These are missing in the current symbol types.

This PR adds:

- The underlying `*hcl.Attribute` for `AttributeSymbol`
- The underlying `*hcl.Block` for `BlockSymbol`
- For `ExprSymbol`, it is a bit complex:
  - If the parent Expression is a *hclsyntax.TupleConsExpr, adds the `hcl.Expression` to `Expr` field
  - If the parent Expression is a *hclsyntax.ObjectConsExpr, adds the `hclsyntax.ObjectConsItem` to `Item` field