### PR TITLE
Fix whitespace via `go fmt`

### DIFF
--- a/decoder/expr_object_ref_origins.go
+++ b/decoder/expr_object_ref_origins.go
@@ -82,7 +82,7 @@ func (obj Object) ReferenceOrigins(ctx context.Context, allowSelfRefs bool) refe
 func resolveObjectAddress(attrName string, addr schema.Address) (lang.Address, bool) {
 	// This function is a simplified version of the original resolveAttributeAddress
 	// because we don't have an attribute to pass
-	
+
 	address := make(lang.Address, 0)
 
 	if len(addr) == 0 {


### PR DESCRIPTION
CI currently exits early on `main`, because the `go fmt` step fails