### PR TITLE
Run CI on PRs that don't target `main`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: ci
 
 on:
   pull_request:
-    branches:
-      - main
   push:
     branches:
       - main


### PR DESCRIPTION
Follow-up to #415. We have never run checks in the CI for any branches that target the `pre-release` branch. I think this is mainly because we rarely make any pre-release changes in hcl-lang.

I think it's still helpful to add this change.