### PR TITLE
Introduce `SupportUnknownNestedRefs` for block addresses

### DIFF
--- a/decoder/reference_targets.go
+++ b/decoder/reference_targets.go
@@ -238,6 +238,16 @@ func (d *PathDecoder) decodeReferenceTargetsForBody(body hcl.Body, parentBlock *
 			}
 		}
 
+		if bSchema.Address.SupportUnknownNestedRefs {
+			refs = append(refs, reference.Target{
+				Addr:        addr,
+				ScopeId:     bSchema.Address.ScopeId,
+				RangePtr:    blk.Range.Ptr(),
+				DefRangePtr: blk.DefRange.Ptr(),
+				Type:        cty.DynamicPseudoType,
+			})
+		}
+
 		sort.Sort(bodyRef.NestedTargets)
 	}
 

--- a/schema/block_schema.go
+++ b/schema/block_schema.go
@@ -93,6 +93,11 @@ type BlockAddrSchema struct {
 	// and their addresses inferred as data
 	InferDependentBody bool
 
+	// SupportUnknownNestedRefs makes it possible to
+	// target the block with references that don't map to
+	// existing attributes
+	SupportUnknownNestedRefs bool
+
 	// DependentBodySelfRef instructs collection of reference
 	// targets with an additional self.* LocalAddr and
 	// makes those targetable by origins within the block body
@@ -137,16 +142,17 @@ func (bas *BlockAddrSchema) Copy() *BlockAddrSchema {
 	}
 
 	newBas := &BlockAddrSchema{
-		FriendlyName:         bas.FriendlyName,
-		ScopeId:              bas.ScopeId,
-		AsReference:          bas.AsReference,
-		AsTypeOf:             bas.AsTypeOf.Copy(),
-		BodyAsData:           bas.BodyAsData,
-		InferBody:            bas.InferBody,
-		DependentBodyAsData:  bas.DependentBodyAsData,
-		InferDependentBody:   bas.InferDependentBody,
-		DependentBodySelfRef: bas.DependentBodySelfRef,
-		Steps:                bas.Steps.Copy(),
+		FriendlyName:             bas.FriendlyName,
+		ScopeId:                  bas.ScopeId,
+		AsReference:              bas.AsReference,
+		AsTypeOf:                 bas.AsTypeOf.Copy(),
+		BodyAsData:               bas.BodyAsData,
+		InferBody:                bas.InferBody,
+		DependentBodyAsData:      bas.DependentBodyAsData,
+		InferDependentBody:       bas.InferDependentBody,
+		DependentBodySelfRef:     bas.DependentBodySelfRef,
+		SupportUnknownNestedRefs: bas.SupportUnknownNestedRefs,
+		Steps:                    bas.Steps.Copy(),
 	}
 
 	return newBas


### PR DESCRIPTION
This will allow references for nested origins that point to a block that doesn't have the referenced attributes and doesn't point to a nested target (like a module).

This is particularly useful for store blocks in the Stack language that can point to a varset defined in HCP Terraform. With the new flag, we can have valid references without knowing the varset entries.

## TODO

- [ ] Tests