### PR TITLE
Avoid copying constraints for attribute schemas

### DIFF
--- a/schema/attribute_schema.go
+++ b/schema/attribute_schema.go
@@ -21,6 +21,10 @@ type AttributeSchema struct {
 
 	// Constraint represents expression constraint e.g. what types of
 	// expressions are expected for the attribute
+	//
+	// Constraints are immutable after construction by convention. It is
+	// particularly important not to mutate a constraint after it has been
+	// added to an AttributeSchema.
 	Constraint Constraint
 
 	// DefaultValue represents default value which applies
@@ -142,7 +146,8 @@ func (as *AttributeSchema) Copy() *AttributeSchema {
 		OriginForTarget:        as.OriginForTarget.Copy(),
 		SemanticTokenModifiers: as.SemanticTokenModifiers.Copy(),
 		CompletionHooks:        as.CompletionHooks.Copy(),
-		Constraint:             as.Constraint.Copy(),
+		// We do not copy Constraint as it should be immutable
+		Constraint: as.Constraint,
 	}
 
 	return newAs


### PR DESCRIPTION
Constraints are immutable after construction by convention, so we can achieve performance improvements by avoiding creating an extra copy each time.

## Impact

On deeply nested attribute schemas, we're seeing a lot of extra copy operations
![CleanShot 2024-11-13 at 14 16 00@2x](https://github.com/user-attachments/assets/4db61d69-8760-4af9-b771-1b29eb74c021)

By avoiding copying the constraints, we can cut off the tail
![CleanShot 2024-11-14 at 12 11 58@2x](https://github.com/user-attachments/assets/e131d954-a074-49a2-9eb4-2678f7895012)
