### PR TITLE
(TFECO-8260) Add Heimdall metadata

### DIFF
--- a/META.d/_summary.yml
+++ b/META.d/_summary.yml
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 schema: 1.1
 partition: tf-ecosystem
 category: library

--- a/META.d/_summary.yml
+++ b/META.d/_summary.yml
@@ -1,0 +1,8 @@
+schema: 1.1
+partition: tf-ecosystem
+category: library
+
+summary:
+  owner: team-tf-editor-experience
+  description: HCL Language parsing and validation library
+  visibility: external

--- a/META.d/data.yml
+++ b/META.d/data.yml
@@ -1,0 +1,3 @@
+data_summary:
+  gdpr:
+    exempt: true

--- a/META.d/data.yml
+++ b/META.d/data.yml
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 data_summary:
   gdpr:
     exempt: true


### PR DESCRIPTION
This change adds the metadata for the internal Heimdall service to the repository.
