### PR TITLE
Fix empty tuple reference matching

### DIFF
--- a/reference/target.go
+++ b/reference/target.go
@@ -199,6 +199,12 @@ func (target Target) Matches(origin MatchableOrigin) bool {
 			matchesCons = true
 			continue
 		}
+		if cons.OfType.IsTupleType() && cons.OfType.Length() == 0 && target.Type.IsTupleType() {
+			// This is a special case where we match an empty tuple (cty.EmptyTuple)
+			// against any tuple.
+			matchesCons = true
+			continue
+		}
 		if cons.OfType != cty.NilType && target.IsConvertibleToType(cons.OfType) {
 			matchesCons = true
 		}

--- a/reference/targets_test.go
+++ b/reference/targets_test.go
@@ -268,6 +268,43 @@ func TestTargets_Match(t *testing.T) {
 			},
 			true,
 		},
+		{
+			"matches empty tuple",
+			Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "a"},
+					},
+					Type: cty.Tuple([]cty.Type{
+						cty.String,
+						cty.Bool,
+					}),
+				},
+			},
+			LocalOrigin{
+				Addr: lang.Address{
+					lang.RootStep{Name: "local"},
+					lang.AttrStep{Name: "a"},
+				},
+				Constraints: OriginConstraints{{
+					OfType: cty.EmptyTuple,
+				}},
+			},
+			Targets{
+				Target{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "a"},
+					},
+					Type: cty.Tuple([]cty.Type{
+						cty.String,
+						cty.Bool,
+					}),
+				},
+			},
+			true,
+		},
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {


### PR DESCRIPTION
This PR adds a special case when matching references for empty tuple constraints. By default, an empty tuple does not match a tuple with elements. So go-cty's `convert.Convert` doesn't work for tuples.

We now short-circuit the convertible check and always mark empty tuples as matching.