### PR TITLE
Fix target collection from for-expressions

### DIFF
--- a/decoder/expr_object_ref_targets_test.go
+++ b/decoder/expr_object_ref_targets_test.go
@@ -620,6 +620,51 @@ func TestCollectRefTargets_exprObject_hcl(t *testing.T) {
 				},
 			},
 		},
+		{
+			"object from for-expression",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Object{
+						Attributes: schema.ObjectAttributes{
+							"foo": {
+								Constraint: schema.LiteralType{
+									Type: cty.String,
+								},
+								IsOptional: true,
+							},
+						},
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						ScopeId:    lang.ScopeId("test"),
+						AsExprType: true,
+					},
+				},
+			},
+			`attr = { for s in ["a", "b"] : s => "s${s}" }`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					ScopeId: lang.ScopeId("test"),
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 46, Byte: 45},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+					Type: cty.DynamicPseudoType,
+				},
+			},
+		},
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {

--- a/decoder/expr_tuple_ref_targets_test.go
+++ b/decoder/expr_tuple_ref_targets_test.go
@@ -452,6 +452,48 @@ func TestCollectRefTargets_exprTuple_hcl(t *testing.T) {
 				},
 			},
 		},
+		{
+			"tuple from for-expression",
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.Tuple{
+						Elems: []schema.Constraint{
+							schema.LiteralType{
+								Type: cty.String,
+							},
+						},
+					},
+					IsOptional: true,
+					Address: &schema.AttributeAddrSchema{
+						Steps: schema.Address{
+							schema.AttrNameStep{},
+						},
+						ScopeId:    lang.ScopeId("test"),
+						AsExprType: true,
+					},
+				},
+			},
+			`attr = [for sa in ["one", "two"]: sa]`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "attr"},
+					},
+					RangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 38, Byte: 37},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.hcl",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+					ScopeId: lang.ScopeId("test"),
+					Type:    cty.DynamicPseudoType,
+				},
+			},
+		},
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.testName), func(t *testing.T) {


### PR DESCRIPTION
This PR allows the collection of targets for tuple and object expressions that are created from a for-expression. Previously, we would simply not collect any targets, since a for-expression cannot be converted to a static list or map.

The new target is the same as we would collect for other dynamic types:
https://github.com/hashicorp/hcl-lang/blob/e51d98381d623a627909629610433119b0369f55/decoder/expr_any_ref_targets.go#L29-L48

_Fun side note_: If you use any function calls or variables in the for-expression, we'll hit the code path above instead, because the type refinements will fail due to the empty evaluation context:
https://github.com/hashicorp/hcl-lang/blob/e51d98381d623a627909629610433119b0369f55/decoder/expr_any_ref_targets.go#L19

While this doesn't improve completion due to the missing nested targets, it does improve the UX on hover, go-to-*, and validation.

## UX Before
![CleanShot 2024-12-05 at 12 53 54@2x](https://github.com/user-attachments/assets/35422ec5-7568-40f9-8b8a-b2aa5f4bf92a)

## UX After
![CleanShot 2024-12-05 at 12 53 30@2x](https://github.com/user-attachments/assets/548eb59d-0022-4e0a-b336-f25f0ba63d34)

Closes #427