### PR TITLE
Support single file context

### DIFF
--- a/lang/path.go
+++ b/lang/path.go
@@ -6,8 +6,13 @@ package lang
 type Path struct {
 	Path       string
 	LanguageID string
+	// If not empty, this is the file within the directory that the path points to
+	// This is useful for languages like Terraform Test which have a file-based scope
+	// instead of all files in a directory sharing the same scope
+	File string
 }
 
+// TODO: check whether setting File for non test files might have unintended consequences
 func (path Path) Equals(p Path) bool {
-	return path.Path == p.Path && path.LanguageID == p.LanguageID
+	return path.Path == p.Path && path.LanguageID == p.LanguageID && (path.File == "" || p.File == "" || path.File == p.File)
 }

--- a/reference/origins.go
+++ b/reference/origins.go
@@ -40,6 +40,7 @@ func (ro Origins) Match(localPath lang.Path, target Target, targetPath lang.Path
 	for _, refOrigin := range ro {
 		switch origin := refOrigin.(type) {
 		case LocalOrigin:
+			// TODO: equals might do weird things for non test files, ensure this works!
 			if localPath.Equals(targetPath) && target.Matches(origin) {
 				origins = append(origins, refOrigin)
 			}


### PR DESCRIPTION
This change allows implementations of PathContext() to return different contexts based on the current filename

This makes it possible for Terraform Test files to each have their own context that is not shared between tests in the same directory
