### PR TITLE
(TFECO-7724) Support write only attributes in schema

### DIFF
--- a/decoder/attribute_candidates.go
+++ b/decoder/attribute_candidates.go
@@ -40,6 +40,10 @@ func attributeSchemaToCandidate(ctx context.Context, name string, attr *schema.A
 func detailForAttribute(attr *schema.AttributeSchema) string {
 	details := []string{}
 
+	if attr.IsWriteOnly {
+		details = append(details, "write-only")
+	}
+
 	if attr.IsRequired {
 		details = append(details, "required")
 	} else if attr.IsOptional {

--- a/schema/attribute_schema.go
+++ b/schema/attribute_schema.go
@@ -19,6 +19,10 @@ type AttributeSchema struct {
 	IsComputed   bool
 	IsSensitive  bool
 
+	// If true, this attribute is write only and its value will not be
+	// persisted in artifacts such as plan files or state.
+	IsWriteOnly bool
+
 	// Constraint represents expression constraint e.g. what types of
 	// expressions are expected for the attribute
 	//
@@ -139,6 +143,7 @@ func (as *AttributeSchema) Copy() *AttributeSchema {
 		IsDeprecated:           as.IsDeprecated,
 		IsComputed:             as.IsComputed,
 		IsSensitive:            as.IsSensitive,
+		IsWriteOnly:            as.IsWriteOnly,
 		IsDepKey:               as.IsDepKey,
 		DefaultValue:           as.DefaultValue,
 		Description:            as.Description,


### PR DESCRIPTION
This change adds support for write only attributes in schema. This is useful for attributes that are write only and should not be read back from the state file.
