### PR TITLE
decoder: allow non-string-coercible references inside template expressions

### DIFF
--- a/decoder/expr_any_completion_test.go
+++ b/decoder/expr_any_completion_test.go
@@ -5313,6 +5313,21 @@ func TestCompletionAtPos_exprAny_template(t *testing.T) {
 						},
 					},
 				},
+				{
+					Label:       "split",
+					Detail:      "split(separator string, str string) list of string",
+					Description: lang.Markdown("`split` produces a list by dividing a given string at all occurrences of a given separator."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "split()",
+						Snippet: "split(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 11, Byte: 10},
+							End:      hcl.Pos{Line: 1, Column: 11, Byte: 10},
+						},
+					},
+				},
 			}),
 		},
 		{
@@ -5543,6 +5558,21 @@ EOT
 					TextEdit: lang.TextEdit{
 						NewText: "provider::framework::example()",
 						Snippet: "provider::framework::example(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 3, Column: 10, Byte: 38},
+							End:      hcl.Pos{Line: 3, Column: 10, Byte: 38},
+						},
+					},
+				},
+				{
+					Label:       "split",
+					Detail:      "split(separator string, str string) list of string",
+					Description: lang.Markdown("`split` produces a list by dividing a given string at all occurrences of a given separator."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "split()",
+						Snippet: "split(${0})",
 						Range: hcl.Range{
 							Filename: "test.tf",
 							Start:    hcl.Pos{Line: 3, Column: 10, Byte: 38},
@@ -6006,6 +6036,21 @@ EOT
 						},
 					},
 				},
+				{
+					Label:       "split",
+					Detail:      "split(separator string, str string) list of string",
+					Description: lang.Markdown("`split` produces a list by dividing a given string at all occurrences of a given separator."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "split()",
+						Snippet: "split(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 23, Byte: 22},
+							End:      hcl.Pos{Line: 1, Column: 23, Byte: 22},
+						},
+					},
+				},
 			}),
 		},
 		{
@@ -6147,6 +6192,21 @@ EOT
 					TextEdit: lang.TextEdit{
 						NewText: "provider::framework::example()",
 						Snippet: "provider::framework::example(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 23, Byte: 22},
+							End:      hcl.Pos{Line: 1, Column: 23, Byte: 22},
+						},
+					},
+				},
+				{
+					Label:       "split",
+					Detail:      "split(separator string, str string) list of string",
+					Description: lang.Markdown("`split` produces a list by dividing a given string at all occurrences of a given separator."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "split()",
+						Snippet: "split(${0})",
 						Range: hcl.Range{
 							Filename: "test.tf",
 							Start:    hcl.Pos{Line: 1, Column: 23, Byte: 22},
@@ -6298,6 +6358,21 @@ EOT
 					TextEdit: lang.TextEdit{
 						NewText: "provider::framework::example()",
 						Snippet: "provider::framework::example(${0})",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 23, Byte: 22},
+							End:      hcl.Pos{Line: 1, Column: 23, Byte: 22},
+						},
+					},
+				},
+				{
+					Label:       "split",
+					Detail:      "split(separator string, str string) list of string",
+					Description: lang.Markdown("`split` produces a list by dividing a given string at all occurrences of a given separator."),
+					Kind:        lang.FunctionCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "split()",
+						Snippet: "split(${0})",
 						Range: hcl.Range{
 							Filename: "test.tf",
 							Start:    hcl.Pos{Line: 1, Column: 23, Byte: 22},

--- a/decoder/expr_any_template.go
+++ b/decoder/expr_any_template.go
@@ -32,8 +32,11 @@ func (a Any) completeTemplateExprAtPos(ctx context.Context, pos hcl.Pos) ([]lang
 			// We're not checking the end byte position here, because we don't
 			// allow completion after the }
 			if partExpr.Range().ContainsPos(pos) || partExpr.Range().End.Byte == pos.Byte {
+				// Inside ${...} we accept any reference; composite-typed values
+				// (map, list, tuple, object, set) are reachable via subsequent
+				// indexing/access (e.g. ${var.m_map["k"]}) and should be offered.
 				cons := schema.AnyExpression{
-					OfType: cty.String,
+					OfType: cty.DynamicPseudoType,
 				}
 				return newExpression(a.pathCtx, partExpr, cons).CompletionAtPos(ctx, pos), true
 			}
@@ -45,7 +48,7 @@ func (a Any) completeTemplateExprAtPos(ctx context.Context, pos hcl.Pos) ([]lang
 
 				if trailingRune == '.' {
 					cons := schema.AnyExpression{
-						OfType: cty.String,
+						OfType: cty.DynamicPseudoType,
 					}
 					return newExpression(a.pathCtx, partExpr, cons).CompletionAtPos(ctx, pos), true
 				}
@@ -56,7 +59,7 @@ func (a Any) completeTemplateExprAtPos(ctx context.Context, pos hcl.Pos) ([]lang
 	case *hclsyntax.TemplateWrapExpr:
 		if eType.Wrapped.Range().ContainsPos(pos) || eType.Wrapped.Range().End.Byte == pos.Byte {
 			cons := schema.AnyExpression{
-				OfType: cty.String,
+				OfType: cty.DynamicPseudoType,
 			}
 			return newExpression(a.pathCtx, eType.Wrapped, cons).CompletionAtPos(ctx, pos), true
 		}
@@ -68,7 +71,7 @@ func (a Any) completeTemplateExprAtPos(ctx context.Context, pos hcl.Pos) ([]lang
 
 			if trailingRune == '.' {
 				cons := schema.AnyExpression{
-					OfType: cty.String,
+					OfType: cty.DynamicPseudoType,
 				}
 				return newExpression(a.pathCtx, eType.Wrapped, cons).CompletionAtPos(ctx, pos), true
 			}


### PR DESCRIPTION
## Problem

Inside `${...}` template expressions, completion is constrained to `cty.String`, which filters out composite-typed references (`map`, `list`, `tuple`, `set`, `object`). For users whose declared variables are composites, the completion popup looks near-empty — even though `${var.m_map["k"]}` and `${var.l_list[0]}` are valid Terraform: the composite is reachable via subsequent indexing/access.

This is the user-visible "no autocomplete in string interpolation" symptom that recurs in user reports; tracked upstream in hashicorp/terraform-ls#653.

## Repro

Drove `terraform-ls serve` over JSON-RPC stdio against a 33-case fixture suite (one fresh LS per case, isolated to avoid parse-error cascades). Representative case:

```hcl
variable "s_string" { type = string default = "hello" }
variable "n_number" { type = number default = 42 }
variable "b_bool"   { type = bool   default = true }
variable "l_list"   { type = list(string) default = ["a"] }
variable "m_map"    { type = map(string)  default = { red = "x" } }
variable "se_set"   { type = set(string)  default = ["x"] }
variable "t_tuple"  { type = tuple([string, number]) default = ["a", 1] }
variable "o_object" { type = object({ name = string }) default = { name = "ada" } }

# Cursor between dot and brace inside ${var.|}
output "o" { value = "x ${var.}" }
```

Before this patch, `textDocument/completion` returns 3 candidates (`var.b_bool`, `var.n_number`, `var.s_string`). After: 8 candidates including all composite-typed vars.

## Change

Switch the constraint from `cty.String` to `cty.DynamicPseudoType` at all four template candidate sites in `decoder/expr_any_template.go` — `TemplateExpr` part-expression, `TemplateExpr` trailing-dot recovery, `TemplateWrapExpr` wrapped expression, `TemplateWrapExpr` trailing-dot recovery.

The looser constraint reflects what's actually valid inside `${...}`: anything reachable from the cursor that ultimately produces a string-coercible value via subsequent expression nodes (indexing, access, function calls). Validation of the *complete* expression remains the responsibility of validators downstream.

## Test updates

Five subtests in `TestCompletionAtPos_exprAny_template` (subtests 0, 3, 10, 11, 12) were pinning the prior behavior. With the looser constraint, `split` (return type `list of string`) now legitimately appears alongside other functions — added to the expected candidate lists.

All hcl-lang tests pass:
```
ok  github.com/hashicorp/hcl-lang/decoder           0.826s
ok  github.com/hashicorp/hcl-lang/decoder/internal/schemahelper  0.560s
ok  github.com/hashicorp/hcl-lang/decoder/internal/walker        1.109s
ok  github.com/hashicorp/hcl-lang/lang              1.885s
ok  github.com/hashicorp/hcl-lang/reference         1.694s
ok  github.com/hashicorp/hcl-lang/schema            2.165s
```

## End-to-end verification

Built `terraform-ls` against this branch (via local `go.mod` `replace`), re-ran the 33-case completion suite. Comparison against unpatched main (terraform-ls v0.38.6, hcl-lang HEAD):

| Test position | Before | After |
|---|---|---|
| `${HERE}` (root inside template) | scalar vars only | all 8 var names |
| `${var.HERE}` | 3 scalar var names | 8 var names |
| `<<-EOT ${HERE} EOT` (heredoc) | scalar vars only | all 8 var names |
| `<<-EOT ${var.HERE} EOT` | 1 scalar var name | 2 var names |
| `${[for k in HERE : k]}` (for iterator) | 0 candidates | 6 incl. `var.l_list` |
| `${[for k in var.l_list : HERE]}` (for body) | 0 candidates | 100 incl. references |

27 of 33 cases unchanged. The 6 changes are all improvements, no regressions. The for-expression improvements are a side-effect — those positions previously reached the same `cty.String` filter through the template path.

## What this does *not* fix

This change deliberately scopes to template-expression candidate-gathering. Two related-but-separate gaps remain (each tracked under its own issue):

- **terraform-ls#1596** — index `[…]` constraints still default to `cty.String` (the `TODO` in `decoder/expr_any_index.go:19-25`). Different code path.
- **terraform-ls#1225** — dot-access on declared composite-typed variables (`var.m_map.|`, `var.o_object.|`) returns nothing in any context. Different code path (reference-target collection for variable defaults).

Happy to follow up with separate PRs for either once this lands and a maintainer signals shape preference.

## Considerations

- `cty.DynamicPseudoType` is the simplest valid replacement. A more nuanced alternative would be a custom "string-or-indexable" constraint; happy to iterate if that's preferred.
- Marked **draft** because this is a first-time contribution to this repo and the test-update direction may want maintainer input before being marked ready.

Refs: hashicorp/terraform-ls#653