### PR TITLE
fix: for_each references only shown once instead of duplicates

### DIFF
--- a/decoder/expr_one_of_completion_test.go
+++ b/decoder/expr_one_of_completion_test.go
@@ -10,15 +10,18 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/reference"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
 )
 
 func TestCompletionAtPos_exprOneOf(t *testing.T) {
 	testCases := []struct {
 		testName           string
 		attrSchema         map[string]*schema.AttributeSchema
+		refTargets         reference.Targets
 		cfg                string
 		pos                hcl.Pos
 		expectedCandidates lang.Candidates
@@ -40,8 +43,9 @@ func TestCompletionAtPos_exprOneOf(t *testing.T) {
 					},
 				},
 			},
-			`attr = 
-`,
+			nil,
+			`attr =
+		`,
 			hcl.Pos{Line: 1, Column: 8, Byte: 7},
 			lang.CompleteCandidates([]lang.Candidate{
 				{
@@ -105,8 +109,9 @@ func TestCompletionAtPos_exprOneOf(t *testing.T) {
 					},
 				},
 			},
+			nil,
 			`attr = akey
-`,
+		`,
 			hcl.Pos{Line: 1, Column: 12, Byte: 11},
 			lang.CompleteCandidates([]lang.Candidate{
 				{
@@ -142,8 +147,9 @@ func TestCompletionAtPos_exprOneOf(t *testing.T) {
 					},
 				},
 			},
+			nil,
 			`attr = key
-`,
+		`,
 			hcl.Pos{Line: 1, Column: 11, Byte: 10},
 			lang.CompleteCandidates([]lang.Candidate{
 				{
@@ -183,10 +189,51 @@ func TestCompletionAtPos_exprOneOf(t *testing.T) {
 					Constraint: schema.OneOf{},
 				},
 			},
-			`attr = 
-`,
+			nil,
+			`attr =
+		`,
 			hcl.Pos{Line: 1, Column: 8, Byte: 7},
 			lang.CompleteCandidates([]lang.Candidate{}),
+		},
+		{
+			"no duplicate references across for_each constraints",
+			// Based on attribute_extensions.go ForEachAttributeSchema
+			map[string]*schema.AttributeSchema{
+				"attr": {
+					Constraint: schema.OneOf{
+						schema.AnyExpression{OfType: cty.Map(cty.DynamicPseudoType)},
+						schema.AnyExpression{OfType: cty.Set(cty.String)},
+						schema.AnyExpression{OfType: cty.EmptyObject},
+					},
+				},
+			},
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "some_set"},
+					},
+					Type: cty.DynamicPseudoType,
+				},
+			},
+			`attr = local.some`,
+			hcl.Pos{Line: 1, Column: 18, Byte: 17},
+			lang.CompleteCandidates([]lang.Candidate{
+				{
+					Label:  "local.some_set",
+					Detail: "dynamic",
+					Kind:   lang.ReferenceCandidateKind,
+					TextEdit: lang.TextEdit{
+						NewText: "local.some_set",
+						Snippet: "local.some_set",
+						Range: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 8, Byte: 7},
+							End:      hcl.Pos{Line: 1, Column: 18, Byte: 17},
+						},
+					},
+				},
+			}),
 		},
 	}
 
@@ -202,6 +249,7 @@ func TestCompletionAtPos_exprOneOf(t *testing.T) {
 				Files: map[string]*hcl.File{
 					"test.tf": f,
 				},
+				ReferenceTargets: tc.refTargets,
 			})
 
 			ctx := context.Background()

--- a/decoder/expression_candidates.go
+++ b/decoder/expression_candidates.go
@@ -26,12 +26,19 @@ func (d *PathDecoder) attrValueCompletionAtPos(ctx context.Context, attr *hclsyn
 	}
 	count := len(candidates.List)
 
+	seen := make(map[string]struct{})
 	if uint(count) < d.maxCandidates {
 		expr := d.newExpression(attr.Expr, schema.Constraint)
 		for _, candidate := range expr.CompletionAtPos(ctx, pos) {
 			if uint(count) >= d.maxCandidates {
 				return candidates, nil
 			}
+
+			key := fmt.Sprintf("%s %s", candidate.Label, candidate.TextEdit.Range)
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
 
 			candidates.List = append(candidates.List, candidate)
 			count++


### PR DESCRIPTION
Fixes https://github.com/opentofu/tofu-ls/issues/169

https://github.com/opentofu/hcl-lang/blob/4d002ed218c29319a67edc88b011a397d3bd9647/decoder/expression_candidates.go#L19-L42

Basically, the code loops through all the expressions of the ForEach OneOf, creating one candidate per expression: 

https://github.com/opentofu/hcl-lang/blob/4d002ed218c29319a67edc88b011a397d3bd9647/decoder/internal/schemahelper/attribute_extensions.go#L21-L36

With the fix we're evaluating to ensure we're adding the candidates only once.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
