### PR TITLE
Added: TargetableFromCurrentBlock in BodySchema (#476)

### DIFF
--- a/decoder/reference_targets.go
+++ b/decoder/reference_targets.go
@@ -143,6 +143,14 @@ func (d *PathDecoder) decodeReferenceTargetsForBody(body hcl.Body, parentBlock *
 		mergedSchema, _ := schemahelper.MergeBlockBodySchemas(blk.Block, bSchema)
 
 		iRefs := d.decodeReferenceTargetsForBody(blk.Body, blk, mergedSchema)
+
+		// If TargetableFromCurrentBlock is set on the block's body schema,
+		// transform targets to be block-scoped: swap Addr/LocalAddr
+		// and set TargetableFromRangePtr to the parent block's range.
+		if mergedSchema.TargetableFromCurrentBlock && parentBlock != nil {
+			applyBlockScopedTargets(iRefs, parentBlock.Range.Ptr())
+		}
+
 		refs = append(refs, iRefs...)
 
 		addr, ok := resolveBlockAddress(blk.Block, bSchema)
@@ -278,6 +286,27 @@ func decodeTargetableBody(body hcl.Body, parentBlock *ast.BlockContent, tt *sche
 	}
 
 	return target
+}
+
+// applyBlockScopedTargets transforms reference targets to be block-scoped by
+// swapping Addr to LocalAddr and setting TargetableFromRangePtr to the parent
+// block's range. This is applied recursively to all nested targets.
+func applyBlockScopedTargets(targets reference.Targets, parentBlockRange *hcl.Range) {
+	for i := range targets {
+		target := &targets[i]
+		target.BlockScoped = true
+		if target.Addr != nil {
+			target.LocalAddr = target.Addr.Copy()
+			target.Addr = nil
+		}
+		if target.TargetableFromRangePtr == nil {
+			target.TargetableFromRangePtr = parentBlockRange
+		}
+		// Recursively modify nested targets
+		if len(target.NestedTargets) > 0 {
+			applyBlockScopedTargets(target.NestedTargets, parentBlockRange)
+		}
+	}
 }
 
 func (d *PathDecoder) decodeReferenceTargetsForAttribute(attr *hcl.Attribute, attrSchema *schema.AttributeSchema) reference.Targets {

--- a/decoder/reference_targets_collect_hcl_test.go
+++ b/decoder/reference_targets_collect_hcl_test.go
@@ -5036,6 +5036,338 @@ module "different" {
 				},
 			},
 		},
+		{
+			"TargetableFromCurrentBlock - single attribute in nested block",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource_policy": {
+						Labels: []*schema.LabelSchema{
+							{Name: "name"},
+						},
+						Body: &schema.BodySchema{
+							Blocks: map[string]*schema.BlockSchema{
+								"locals": {
+									Body: &schema.BodySchema{
+										AnyAttribute: &schema.AttributeSchema{
+											Address: &schema.AttributeAddrSchema{
+												Steps: []schema.AddrStep{
+													schema.StaticStep{Name: "local"},
+													schema.AttrNameStep{},
+												},
+												ScopeId:    lang.ScopeId("local"),
+												AsExprType: true,
+											},
+											Constraint: schema.AnyExpression{OfType: cty.DynamicPseudoType},
+										},
+										TargetableFromCurrentBlock: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			`resource_policy "mypolicy" {
+  locals {
+    key1 = "value1"
+  }
+}
+`,
+			reference.Targets{
+				{
+					LocalAddr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "key1"},
+					},
+					ScopeId:     lang.ScopeId("local"),
+					BlockScoped: true,
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 3, Column: 5, Byte: 44},
+						End:      hcl.Pos{Line: 3, Column: 20, Byte: 59},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 3, Column: 5, Byte: 44},
+						End:      hcl.Pos{Line: 3, Column: 9, Byte: 48},
+					},
+					Type: cty.String,
+					TargetableFromRangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 5, Column: 2, Byte: 65},
+					},
+				},
+			},
+		},
+		{
+			"TargetableFromCurrentBlock - multiple attributes in nested block",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource_policy": {
+						Labels: []*schema.LabelSchema{
+							{Name: "name"},
+						},
+						Body: &schema.BodySchema{
+							Blocks: map[string]*schema.BlockSchema{
+								"locals": {
+									Body: &schema.BodySchema{
+										AnyAttribute: &schema.AttributeSchema{
+											Address: &schema.AttributeAddrSchema{
+												Steps: []schema.AddrStep{
+													schema.StaticStep{Name: "local"},
+													schema.AttrNameStep{},
+												},
+												ScopeId:    lang.ScopeId("local"),
+												AsExprType: true,
+											},
+											Constraint: schema.AnyExpression{OfType: cty.DynamicPseudoType},
+										},
+										TargetableFromCurrentBlock: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			`resource_policy "mypolicy" {
+  locals {
+    key1 = "value1"
+    key2 = true
+  }
+}
+`,
+			reference.Targets{
+				{
+					LocalAddr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "key1"},
+					},
+					ScopeId:     lang.ScopeId("local"),
+					BlockScoped: true,
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 3, Column: 5, Byte: 44},
+						End:      hcl.Pos{Line: 3, Column: 20, Byte: 59},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 3, Column: 5, Byte: 44},
+						End:      hcl.Pos{Line: 3, Column: 9, Byte: 48},
+					},
+					Type: cty.String,
+					TargetableFromRangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 6, Column: 2, Byte: 81},
+					},
+				},
+				{
+					LocalAddr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "key2"},
+					},
+					ScopeId:     lang.ScopeId("local"),
+					BlockScoped: true,
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 4, Column: 5, Byte: 64},
+						End:      hcl.Pos{Line: 4, Column: 16, Byte: 75},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 4, Column: 5, Byte: 64},
+						End:      hcl.Pos{Line: 4, Column: 9, Byte: 68},
+					},
+					Type: cty.Bool,
+					TargetableFromRangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 6, Column: 2, Byte: 81},
+					},
+				},
+			},
+		},
+		{
+			"TargetableFromCurrentBlock false - targets retain Addr",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource_policy": {
+						Labels: []*schema.LabelSchema{
+							{Name: "name"},
+						},
+						Body: &schema.BodySchema{
+							Blocks: map[string]*schema.BlockSchema{
+								"locals": {
+									Body: &schema.BodySchema{
+										AnyAttribute: &schema.AttributeSchema{
+											Address: &schema.AttributeAddrSchema{
+												Steps: []schema.AddrStep{
+													schema.StaticStep{Name: "local"},
+													schema.AttrNameStep{},
+												},
+												ScopeId:    lang.ScopeId("local"),
+												AsExprType: true,
+											},
+											Constraint: schema.AnyExpression{OfType: cty.DynamicPseudoType},
+										},
+										// TargetableFromCurrentBlock is false (default)
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			`resource_policy "mypolicy" {
+  locals {
+    key1 = "value1"
+  }
+}
+`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "key1"},
+					},
+					ScopeId: lang.ScopeId("local"),
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 3, Column: 5, Byte: 44},
+						End:      hcl.Pos{Line: 3, Column: 20, Byte: 59},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 3, Column: 5, Byte: 44},
+						End:      hcl.Pos{Line: 3, Column: 9, Byte: 48},
+					},
+					Type: cty.String,
+				},
+			},
+		},
+		{
+			"TargetableFromCurrentBlock - no parent block (root level) does not apply",
+			&schema.BodySchema{
+				// TargetableFromCurrentBlock on root body has no parent block,
+				// so it should NOT apply the block-scoped transformation
+				Attributes: map[string]*schema.AttributeSchema{
+					"attr": {
+						Constraint: schema.AnyExpression{OfType: cty.DynamicPseudoType},
+						IsOptional: true,
+						Address: &schema.AttributeAddrSchema{
+							Steps: schema.Address{
+								schema.StaticStep{Name: "local"},
+								schema.AttrNameStep{},
+							},
+							ScopeId:    lang.ScopeId("local"),
+							AsExprType: true,
+						},
+					},
+				},
+				TargetableFromCurrentBlock: true,
+			},
+			`attr = "value"
+`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "attr"},
+					},
+					ScopeId: lang.ScopeId("local"),
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 15, Byte: 14},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+					},
+					Type: cty.String,
+				},
+			},
+		},
+		{
+			"TargetableFromCurrentBlock - sibling blocks in parent",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource_policy": {
+						Labels: []*schema.LabelSchema{
+							{Name: "name"},
+						},
+						Body: &schema.BodySchema{
+							Blocks: map[string]*schema.BlockSchema{
+								"locals": {
+									Body: &schema.BodySchema{
+										AnyAttribute: &schema.AttributeSchema{
+											Address: &schema.AttributeAddrSchema{
+												Steps: []schema.AddrStep{
+													schema.StaticStep{Name: "local"},
+													schema.AttrNameStep{},
+												},
+												ScopeId:    lang.ScopeId("local"),
+												AsExprType: true,
+											},
+											Constraint: schema.AnyExpression{OfType: cty.DynamicPseudoType},
+										},
+										TargetableFromCurrentBlock: true,
+									},
+								},
+								"enforce": {
+									Body: &schema.BodySchema{
+										Attributes: map[string]*schema.AttributeSchema{
+											"condition": {
+												Constraint: schema.AnyExpression{OfType: cty.Bool},
+												IsOptional: true,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			`resource_policy "mypolicy" {
+  locals {
+    key1 = "value1"
+  }
+  enforce {
+    condition = true
+  }
+}
+`,
+			reference.Targets{
+				{
+					LocalAddr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "key1"},
+					},
+					ScopeId:     lang.ScopeId("local"),
+					BlockScoped: true,
+					RangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 3, Column: 5, Byte: 44},
+						End:      hcl.Pos{Line: 3, Column: 20, Byte: 59},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 3, Column: 5, Byte: 44},
+						End:      hcl.Pos{Line: 3, Column: 9, Byte: 48},
+					},
+					Type: cty.String,
+					TargetableFromRangePtr: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 8, Column: 2, Byte: 102},
+					},
+				},
+			},
+		},
 	}
 
 	for i, tc := range testCases {

--- a/decoder/reference_targets_collect_json_test.go
+++ b/decoder/reference_targets_collect_json_test.go
@@ -4426,6 +4426,135 @@ func TestCollectReferenceTargets_json(t *testing.T) {
 `,
 			reference.Targets{},
 		},
+		{
+			"TargetableFromCurrentBlock - single attribute in nested block",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource_policy": {
+						Labels: []*schema.LabelSchema{
+							{Name: "name"},
+						},
+						Body: &schema.BodySchema{
+							Blocks: map[string]*schema.BlockSchema{
+								"locals": {
+									Body: &schema.BodySchema{
+										AnyAttribute: &schema.AttributeSchema{
+											Address: &schema.AttributeAddrSchema{
+												Steps: []schema.AddrStep{
+													schema.StaticStep{Name: "local"},
+													schema.AttrNameStep{},
+												},
+												ScopeId:    lang.ScopeId("local"),
+												AsExprType: true,
+											},
+											Constraint: schema.AnyExpression{OfType: cty.DynamicPseudoType},
+										},
+										TargetableFromCurrentBlock: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			`{
+  "resource_policy": {
+    "mypolicy": {
+      "locals": {
+        "key1": "value1"
+      }
+    }
+  }
+}
+`,
+			reference.Targets{
+				{
+					LocalAddr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "key1"},
+					},
+					ScopeId:     lang.ScopeId("local"),
+					BlockScoped: true,
+					RangePtr: &hcl.Range{
+						Filename: "test.tf.json",
+						Start:    hcl.Pos{Line: 5, Column: 9, Byte: 69},
+						End:      hcl.Pos{Line: 5, Column: 25, Byte: 85},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.tf.json",
+						Start:    hcl.Pos{Line: 5, Column: 9, Byte: 69},
+						End:      hcl.Pos{Line: 5, Column: 15, Byte: 75},
+					},
+					Type: cty.String,
+					TargetableFromRangePtr: &hcl.Range{
+						Filename: "test.tf.json",
+						Start:    hcl.Pos{Line: 3, Column: 17, Byte: 41},
+						End:      hcl.Pos{Line: 7, Column: 6, Byte: 99},
+					},
+				},
+			},
+		},
+		{
+			"TargetableFromCurrentBlock false - targets retain Addr",
+			&schema.BodySchema{
+				Blocks: map[string]*schema.BlockSchema{
+					"resource_policy": {
+						Labels: []*schema.LabelSchema{
+							{Name: "name"},
+						},
+						Body: &schema.BodySchema{
+							Blocks: map[string]*schema.BlockSchema{
+								"locals": {
+									Body: &schema.BodySchema{
+										AnyAttribute: &schema.AttributeSchema{
+											Address: &schema.AttributeAddrSchema{
+												Steps: []schema.AddrStep{
+													schema.StaticStep{Name: "local"},
+													schema.AttrNameStep{},
+												},
+												ScopeId:    lang.ScopeId("local"),
+												AsExprType: true,
+											},
+											Constraint: schema.AnyExpression{OfType: cty.DynamicPseudoType},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			`{
+  "resource_policy": {
+    "mypolicy": {
+      "locals": {
+        "key1": "value1"
+      }
+    }
+  }
+}
+`,
+			reference.Targets{
+				{
+					Addr: lang.Address{
+						lang.RootStep{Name: "local"},
+						lang.AttrStep{Name: "key1"},
+					},
+					ScopeId: lang.ScopeId("local"),
+					RangePtr: &hcl.Range{
+						Filename: "test.tf.json",
+						Start:    hcl.Pos{Line: 5, Column: 9, Byte: 69},
+						End:      hcl.Pos{Line: 5, Column: 25, Byte: 85},
+					},
+					DefRangePtr: &hcl.Range{
+						Filename: "test.tf.json",
+						Start:    hcl.Pos{Line: 5, Column: 9, Byte: 69},
+						End:      hcl.Pos{Line: 5, Column: 15, Byte: 75},
+					},
+					Type: cty.String,
+				},
+			},
+		},
 	}
 
 	for i, tc := range testCases {

--- a/reference/target.go
+++ b/reference/target.go
@@ -29,6 +29,21 @@ type Target struct {
 	// where count is declared (and extension enabled)
 	TargetableFromRangePtr *hcl.Range
 
+	// BlockScoped indicates this target is scoped to a specific block and should
+	// not be suggested for references defined in the same nested block where the
+	// target is defined. It is set when the body schema has TargetableFromCurrentBlock
+	// enabled.
+	//
+	// When true, reference matching will reject targets defined within the same
+	// innermost nested block as the origin, but still allow references from parent
+	// or sibling blocks within the TargetableFromRangePtr.
+	//
+	// e.g. in resource_policy { locals { foo = "bar" } }, local.foo defined in the
+	// nested locals block should not be suggested while still typing within that
+	// same locals block, but should be available in the enforce block.
+
+	BlockScoped bool
+
 	// ScopeId provides scope for matching/filtering
 	// (in addition to Type & Addr/LocalAddr).
 	//
@@ -83,6 +98,7 @@ func (ref Target) Copy() Target {
 		Addr:                   ref.Addr,
 		LocalAddr:              ref.LocalAddr,
 		TargetableFromRangePtr: copyHclRangePtr(ref.TargetableFromRangePtr),
+		BlockScoped:            ref.BlockScoped,
 		ScopeId:                ref.ScopeId,
 		RangePtr:               copyHclRangePtr(ref.RangePtr),
 		DefRangePtr:            copyHclRangePtr(ref.DefRangePtr),

--- a/reference/targets.go
+++ b/reference/targets.go
@@ -76,26 +76,26 @@ func (w refTargetDeepWalker) walk(refTargets Targets) {
 	}
 }
 
-func (targets Targets) MatchWalk(ctx context.Context, ref schema.Reference, prefix string, outermostBodyRng, originRng hcl.Range, f TargetWalkFunc) {
+func (targets Targets) MatchWalk(ctx context.Context, ref schema.Reference, prefix string, outermostBodyRng, originRng, innermostBlockRng hcl.Range, f TargetWalkFunc) {
 	for _, target := range targets {
-		if localTargetMatches(ctx, target, ref, prefix, outermostBodyRng, originRng) ||
-			absTargetMatches(ctx, target, ref, prefix, outermostBodyRng, originRng) {
+		if localTargetMatches(ctx, target, ref, prefix, outermostBodyRng, originRng, innermostBlockRng) ||
+			absTargetMatches(ctx, target, ref, prefix, outermostBodyRng, originRng, innermostBlockRng) {
 			f(target)
 			continue
 		}
 
-		target.NestedTargets.MatchWalk(ctx, ref, prefix, outermostBodyRng, originRng, f)
+		target.NestedTargets.MatchWalk(ctx, ref, prefix, outermostBodyRng, originRng, innermostBlockRng, f)
 	}
 }
 
-func localTargetMatches(ctx context.Context, target Target, ref schema.Reference, prefix string, outermostBodyRng, originRng hcl.Range) bool {
+func localTargetMatches(ctx context.Context, target Target, ref schema.Reference, prefix string, outermostBodyRng, originRng, innermostBlockRng hcl.Range) bool {
 	if len(target.LocalAddr) > 0 && strings.HasPrefix(target.LocalAddr.String(), prefix) {
 		// reject self references if not enabled
 		if !schema.ActiveSelfRefsFromContext(ctx) && target.LocalAddr[0].String() == "self" {
 			return false
 		}
 
-		hasNestedMatches := target.NestedTargets.containsMatch(ctx, ref, prefix, outermostBodyRng, originRng)
+		hasNestedMatches := target.NestedTargets.containsMatch(ctx, ref, prefix, outermostBodyRng, originRng, innermostBlockRng)
 
 		// Avoid suggesting cyclical reference to the same attribute
 		// unless it has nested matches - i.e. still consider reference
@@ -108,6 +108,21 @@ func localTargetMatches(ctx context.Context, target Target, ref schema.Reference
 			if rangeOverlaps(*target.RangePtr, originRng) {
 				return false
 			}
+
+			// For block-scoped targets (e.g., locals in nested policy blocks),
+			// reject if the target is defined in the same innermost block as the origin.
+			// This prevents suggesting references to attributes defined in the same
+			// nested block scope where you're currently typing.
+			//
+			// Example: in resource_policy { locals { foo = ... } }, don't suggest
+			// local.foo while still typing within that same locals block.
+			if target.BlockScoped {
+				// if target is in the same block as it's immediate parent, we don't want any suggestions
+				if innermostBlockRng.Filename == target.RangePtr.Filename && innermostBlockRng.ContainsPos(target.RangePtr.Start) {
+					return false
+				}
+			}
+
 			// We compare line in case the (incomplete) attribute
 			// ends w/ whitespace which wouldn't be included in the range
 			if target.RangePtr.Filename == originRng.Filename &&
@@ -129,31 +144,31 @@ func localTargetMatches(ctx context.Context, target Target, ref schema.Reference
 	return false
 }
 
-func absTargetMatches(ctx context.Context, target Target, ref schema.Reference, prefix string, outermostBodyRng, originRng hcl.Range) bool {
+func absTargetMatches(ctx context.Context, target Target, ref schema.Reference, prefix string, outermostBodyRng, originRng, innermostBlockRng hcl.Range) bool {
 	if len(target.Addr) > 0 && strings.HasPrefix(target.Addr.String(), prefix) {
 		// Reject references to block's own fields from within the body
 		if referenceTargetIsInRange(target, outermostBodyRng) {
 			return false
 		}
 
-		if target.MatchesConstraint(ref) || target.NestedTargets.containsMatch(ctx, ref, prefix, outermostBodyRng, originRng) {
+		if target.MatchesConstraint(ref) || target.NestedTargets.containsMatch(ctx, ref, prefix, outermostBodyRng, originRng, innermostBlockRng) {
 			return true
 		}
 	}
 	return false
 }
 
-func (targets Targets) containsMatch(ctx context.Context, ref schema.Reference, prefix string, outermostBodyRng, originRng hcl.Range) bool {
+func (targets Targets) containsMatch(ctx context.Context, ref schema.Reference, prefix string, outermostBodyRng, originRng, innermostBlockRng hcl.Range) bool {
 	for _, target := range targets {
-		if localTargetMatches(ctx, target, ref, prefix, outermostBodyRng, originRng) {
+		if localTargetMatches(ctx, target, ref, prefix, outermostBodyRng, originRng, innermostBlockRng) {
 			return true
 		}
-		if absTargetMatches(ctx, target, ref, prefix, outermostBodyRng, originRng) {
+		if absTargetMatches(ctx, target, ref, prefix, outermostBodyRng, originRng, innermostBlockRng) {
 			return true
 		}
 
 		if len(target.NestedTargets) > 0 {
-			if match := target.NestedTargets.containsMatch(ctx, ref, prefix, outermostBodyRng, originRng); match {
+			if match := target.NestedTargets.containsMatch(ctx, ref, prefix, outermostBodyRng, originRng, innermostBlockRng); match {
 				return true
 			}
 		}

--- a/schema/body_schema.go
+++ b/schema/body_schema.go
@@ -51,6 +51,18 @@ type BodySchema struct {
 
 	// Extensions represents any HCL extensions supported in this body
 	Extensions *BodyExtensions
+
+	// TargetableFromCurrentBlock indicates that reference targets defined in this body
+	// are only accessible from origins within the parent block's range. This is used
+	// for block-scoped constructs like nested locals blocks in policy files.
+	//
+	// When true, reference matching will ensure that:
+	// 1. TargetableFromRangePtr is set to the parent block's range, restricting where they can be referenced from.
+	// 2. The targets Addr is swapped to LocalAddr (Addr is set to nil)
+	//
+	// Example: A locals block nested within a resource_policy block where local.foo
+	// defined in the nested locals is only accessible within that resource_policy block.
+	TargetableFromCurrentBlock bool
 }
 
 type BodyExtensions struct {
@@ -195,14 +207,15 @@ func (bs *BodySchema) Copy() *BodySchema {
 	}
 
 	newBs := &BodySchema{
-		IsDeprecated: bs.IsDeprecated,
-		Detail:       bs.Detail,
-		Description:  bs.Description,
-		AnyAttribute: bs.AnyAttribute.Copy(),
-		HoverURL:     bs.HoverURL,
-		DocsLink:     bs.DocsLink.Copy(),
-		Targets:      bs.Targets.Copy(),
-		Extensions:   bs.Extensions.Copy(),
+		IsDeprecated:               bs.IsDeprecated,
+		Detail:                     bs.Detail,
+		Description:                bs.Description,
+		AnyAttribute:               bs.AnyAttribute.Copy(),
+		HoverURL:                   bs.HoverURL,
+		DocsLink:                   bs.DocsLink.Copy(),
+		Targets:                    bs.Targets.Copy(),
+		Extensions:                 bs.Extensions.Copy(),
+		TargetableFromCurrentBlock: bs.TargetableFromCurrentBlock,
 	}
 
 	if bs.TargetableAs != nil {


### PR DESCRIPTION
* feat(tfpolicy): TF-33301 TF-33802: Modified: Prevents suggesting references to attributes in the same nested block scope

* feat(tfpolicy): TF-33301 TF-33802: Added: TargetableFromCurrentBlock

* feat(tfpolicy): TF-33301 TF-33802: Modified: simplified conditions

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
