### PR TITLE
Propagate AnyAttribute when merging dependent block body schemas

### DIFF
--- a/decoder/internal/schemahelper/block_schema.go
+++ b/decoder/internal/schemahelper/block_schema.go
@@ -31,6 +31,12 @@ func MergeBlockBodySchemas(block *hcl.Block, blockSchema *schema.BlockSchema) (*
 		for name, attr := range depSchema.Attributes {
 			mergedSchema.Attributes[name] = attr
 		}
+		// A dependent body may allow arbitrary attributes (e.g. a module
+		// block whose inputs are not known yet). Propagate AnyAttribute so
+		// that expressions within such attributes are still decoded.
+		if depSchema.AnyAttribute != nil {
+			mergedSchema.AnyAttribute = depSchema.AnyAttribute
+		}
 		for bType, block := range depSchema.Blocks {
 			copiedBlock := block.Copy()
 			// propagate DynamicBlocks extension to any nested blocks

--- a/decoder/internal/schemahelper/block_schema_test.go
+++ b/decoder/internal/schemahelper/block_schema_test.go
@@ -1,0 +1,66 @@
+// Copyright IBM Corp. 2020, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package schemahelper
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestMergeBlockBodySchemas_propagatesAnyAttributeFromDependentBody(t *testing.T) {
+	cfg := `module "app" {
+  source = "git::https://example.com/module.git"
+}
+`
+	f, diags := hclsyntax.ParseConfig([]byte(cfg), "main.tf", hcl.InitialPos)
+	if len(diags) > 0 {
+		t.Fatal(diags)
+	}
+	body := f.Body.(*hclsyntax.Body)
+	block := body.Blocks[0].AsHCLBlock()
+
+	anyAttr := &schema.AttributeSchema{
+		Constraint: schema.AnyExpression{OfType: cty.DynamicPseudoType},
+	}
+
+	blockSchema := &schema.BlockSchema{
+		Labels: []*schema.LabelSchema{{Name: "name"}},
+		Body: &schema.BodySchema{
+			Attributes: map[string]*schema.AttributeSchema{
+				"source": {
+					Constraint: schema.LiteralType{Type: cty.String},
+					IsRequired: true,
+					IsDepKey:   true,
+				},
+			},
+		},
+		DependentBody: map[schema.SchemaKey]*schema.BodySchema{
+			schema.NewSchemaKey(schema.DependencyKeys{
+				Attributes: []schema.AttributeDependent{
+					{
+						Name: "source",
+						Expr: schema.ExpressionValue{
+							Static: cty.StringVal("git::https://example.com/module.git"),
+						},
+					},
+				},
+			}): {
+				AnyAttribute: anyAttr,
+			},
+		},
+	}
+
+	merged, result := MergeBlockBodySchemas(block, blockSchema)
+	if result != LookupSuccessful {
+		t.Fatalf("expected successful dependent body lookup, got %v", result)
+	}
+
+	if merged.AnyAttribute == nil {
+		t.Fatal("expected AnyAttribute to be propagated from dependent body, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

- Propagate `AnyAttribute` from dependent body schemas when merging block body schemas in `MergeBlockBodySchemas`
- Add test coverage for the merge behavior

## Motivation

`MergeBlockBodySchemas` copies named `Attributes`, `Blocks`, `TargetableAs`, and other fields from a matched dependent body schema, but previously did not copy `AnyAttribute`.

This matters when a dependent body schema intentionally uses `AnyAttribute` to allow decoding of arbitrary attributes whose names are not known ahead of time. Without propagating `AnyAttribute`, expressions inside those attributes are not decoded and reference origins (e.g. `var.*`) are not collected.

A concrete use case is in `terraform-schema`, where uninstalled remote module blocks need a permissive dependent body schema so that local symbols used as module arguments can still be navigated before `terraform init` downloads child module metadata. That schema relies on `AnyAttribute`, but the merge step was dropping it.

## Test plan

- [x] `go test ./decoder/internal/schemahelper/ -run TestMergeBlockBodySchemas_propagatesAnyAttributeFromDependentBody`
- [x] `go test ./decoder/internal/schemahelper/` (no regressions)

Made with [Cursor](https://cursor.com)